### PR TITLE
style updates

### DIFF
--- a/nph.nimble
+++ b/nph.nimble
@@ -21,14 +21,13 @@ proc build() =
 task self, "Format nph itself":
   build()
 
-  # Stage changes before doing self-formatting!
-  exec "git diff --staged --no-ext-diff --quiet --exit-code"
-  exec "git add -A"
+  # Require there are no changes before self-formatting! Can stage if needed
+  exec "git diff --no-ext-diff --quiet --exit-code"
 
   for file in listFiles("src"):
     if file.len > 4 and file[^4..^1] == ".nim":
       echo file
-      exec "./nph " & file & " --debug"
+      exec "./nph " & file
 
 task f, "Format":
   build()

--- a/src/nph.nim
+++ b/src/nph.nim
@@ -4,13 +4,11 @@
 
 import
   "."/[astcmp, phast, phastalgo, phmsgs, phlineinfos, phoptions, phparser, phrenderer]
-import
-  "$nim"/compiler/idents
+import "$nim"/compiler/idents
 
 from "$nim"/compiler/astalgo import nil
 
-import
-  std/[parseopt, strutils, os, sequtils]
+import std/[parseopt, strutils, os, sequtils]
 
 static:
   doAssert (NimMajor, NimMinor, NimPatch) == (2, 0, 0),
@@ -19,7 +17,8 @@ static:
 const
   Version = "0.1"
   Usage =
-    "nph - Nim formatter " & Version & """
+    "nph - Nim formatter " & Version &
+      """
 Usage:
   nph [options] nimfiles...
 Options:
@@ -67,7 +66,7 @@ proc prettyPrint(infile, outfile: string; debug, check, printTokens: bool): bool
         writeFile(outfile, output)
         writeFile(
           outfile & ".nph.yaml",
-          treeToYaml(nil, parse(output, outfile, printTokens, newConfigRef()))
+          treeToYaml(nil, parse(output, outfile, printTokens, newConfigRef())),
         )
     elif fileExists(outFile) and output == readFile(outFile):
       # No formatting difference - don't touch file modificuation date
@@ -82,6 +81,7 @@ proc prettyPrint(infile, outfile: string; debug, check, printTokens: bool): bool
         "stdout"
       else:
         outfile
+      ,
     )
   if eq.kind == Different:
     stderr.writeLine "--- Input ---"

--- a/src/phast.nim
+++ b/src/phast.nim
@@ -12,36 +12,31 @@
 # nph version:
 # * enhanced concrete syntax information
 
-import
-  std/[hashes, tables]
-import
-  "$nim"/compiler/[idents, options, int128, ropes]
+import std/[hashes, tables]
+import "$nim"/compiler/[idents, options, int128, ropes]
 
 from std/strutils import toLowerAscii
 
-import
-  "."/phlineinfos
+import "."/phlineinfos
 when defined(nimPreviewSlimSystem):
-  import
-    std/assertions
+  import std/assertions
 
 import phlexer
 
 export int128
 
-type
-  TCallingConvention* = enum
-    ccNimCall = "nimcall" # nimcall, also the default
-    ccStdCall = "stdcall" # procedure is stdcall
-    ccCDecl = "cdecl" # cdecl
-    ccSafeCall = "safecall" # safecall
-    ccSysCall = "syscall" # system call
-    ccInline = "inline" # proc should be inlined
-    ccNoInline = "noinline" # proc should not be inlined
-    ccFastCall = "fastcall" # fastcall (pass parameters in registers)
-    ccThisCall = "thiscall" # thiscall (parameters are pushed right-to-left)
-    ccClosure = "closure" # proc has a closure
-    ccNoConvention = "noconv" # needed for generating proper C procs sometimes
+type TCallingConvention* = enum
+  ccNimCall = "nimcall" # nimcall, also the default
+  ccStdCall = "stdcall" # procedure is stdcall
+  ccCDecl = "cdecl" # cdecl
+  ccSafeCall = "safecall" # safecall
+  ccSysCall = "syscall" # system call
+  ccInline = "inline" # proc should be inlined
+  ccNoInline = "noinline" # proc should not be inlined
+  ccFastCall = "fastcall" # fastcall (pass parameters in registers)
+  ccThisCall = "thiscall" # thiscall (parameters are pushed right-to-left)
+  ccClosure = "closure" # proc has a closure
+  ccNoConvention = "noconv" # needed for generating proper C procs sometimes
 
 type
   TNodeKind* = enum
@@ -389,108 +384,107 @@ const
   effectListLen* = 6 # list of effects list
   nkLastBlockStmts* = {nkRaiseStmt, nkReturnStmt, nkBreakStmt, nkContinueStmt} # these must be last statements in a block
 
-type
-  TTypeKind* = enum
-    # order is important!
-    # Don't forget to change hti.nim if you make a change here
-    # XXX put this into an include file to avoid this issue!
-    # several types are no longer used (guess which), but a
-    # spot in the sequence is kept for backwards compatibility
-    # (apparently something with bootstrapping)
-    # if you need to add a type, they can apparently be reused
-    tyNone
-    tyBool
-    tyChar
-    tyEmpty
-    tyAlias
-    tyNil
-    tyUntyped
-    tyTyped
-    tyTypeDesc
-    tyGenericInvocation # ``T[a, b]`` for types to invoke
-    tyGenericBody # ``T[a, b, body]`` last parameter is the body
-    tyGenericInst
-      # ``T[a, b, realInstance]`` instantiated generic type
-      # realInstance will be a concrete type like tyObject
-      # unless this is an instance of a generic alias type.
-      # then realInstance will be the tyGenericInst of the
-      # completely (recursively) resolved alias.
-    tyGenericParam # ``a`` in the above patterns
-    tyDistinct
-    tyEnum
-    tyOrdinal # integer types (including enums and boolean)
-    tyArray
-    tyObject
-    tyTuple
-    tySet
-    tyRange
-    tyPtr
-    tyRef
-    tyVar
-    tySequence
-    tyProc
-    tyPointer
-    tyOpenArray
-    tyString
-    tyCstring
-    tyForward
-    tyInt
-    tyInt8
-    tyInt16
-    tyInt32
-    tyInt64 # signed integers
-    tyFloat
-    tyFloat32
-    tyFloat64
-    tyFloat128
-    tyUInt
-    tyUInt8
-    tyUInt16
-    tyUInt32
-    tyUInt64
-    tyOwned
-    tySink
-    tyLent
-    tyVarargs
-    tyUncheckedArray # An array with boundaries [0,+∞]
-    tyProxy # used as errornous type (for idetools)
-    tyBuiltInTypeClass # Type such as the catch-all object, tuple, seq, etc
-    tyUserTypeClass # the body of a user-defined type class
-    tyUserTypeClassInst
-      # Instance of a parametric user-defined type class.
-      # Structured similarly to tyGenericInst.
-      # tyGenericInst represents concrete types, while
-      # this is still a "generic param" that will bind types
-      # and resolves them during sigmatch and instantiation.
-    tyCompositeTypeClass
-      # Type such as seq[Number]
-      # The notes for tyUserTypeClassInst apply here as well
-      # sons[0]: the original expression used by the user.
-      # sons[1]: fully expanded and instantiated meta type
-      # (potentially following aliases)
-    tyInferred
-      # In the initial state `base` stores a type class constraining
-      # the types that can be inferred. After a candidate type is
-      # selected, it's stored in `lastSon`. Between `base` and `lastSon`
-      # there may be 0, 2 or more types that were also considered as
-      # possible candidates in the inference process (i.e. lastSon will
-      # be updated to store a type best conforming to all candidates)
-    tyAnd
-    tyOr
-    tyNot
-      # boolean type classes such as `string|int`,`not seq`,
-      # `Sortable and Enumable`, etc
-    tyAnything # a type class matching any type
-    tyStatic # a value known at compile type (the underlying type is .base)
-    tyFromExpr
-      # This is a type representing an expression that depends
-      # on generic parameters (the expression is stored in t.n)
-      # It will be converted to a real type only during generic
-      # instantiation and prior to this it has the potential to
-      # be any type.
-    tyConcept # new style concept.
-    tyVoid # now different from tyEmpty, hurray!
-    tyIterable
+type TTypeKind* = enum
+  # order is important!
+  # Don't forget to change hti.nim if you make a change here
+  # XXX put this into an include file to avoid this issue!
+  # several types are no longer used (guess which), but a
+  # spot in the sequence is kept for backwards compatibility
+  # (apparently something with bootstrapping)
+  # if you need to add a type, they can apparently be reused
+  tyNone
+  tyBool
+  tyChar
+  tyEmpty
+  tyAlias
+  tyNil
+  tyUntyped
+  tyTyped
+  tyTypeDesc
+  tyGenericInvocation # ``T[a, b]`` for types to invoke
+  tyGenericBody # ``T[a, b, body]`` last parameter is the body
+  tyGenericInst
+    # ``T[a, b, realInstance]`` instantiated generic type
+    # realInstance will be a concrete type like tyObject
+    # unless this is an instance of a generic alias type.
+    # then realInstance will be the tyGenericInst of the
+    # completely (recursively) resolved alias.
+  tyGenericParam # ``a`` in the above patterns
+  tyDistinct
+  tyEnum
+  tyOrdinal # integer types (including enums and boolean)
+  tyArray
+  tyObject
+  tyTuple
+  tySet
+  tyRange
+  tyPtr
+  tyRef
+  tyVar
+  tySequence
+  tyProc
+  tyPointer
+  tyOpenArray
+  tyString
+  tyCstring
+  tyForward
+  tyInt
+  tyInt8
+  tyInt16
+  tyInt32
+  tyInt64 # signed integers
+  tyFloat
+  tyFloat32
+  tyFloat64
+  tyFloat128
+  tyUInt
+  tyUInt8
+  tyUInt16
+  tyUInt32
+  tyUInt64
+  tyOwned
+  tySink
+  tyLent
+  tyVarargs
+  tyUncheckedArray # An array with boundaries [0,+∞]
+  tyProxy # used as errornous type (for idetools)
+  tyBuiltInTypeClass # Type such as the catch-all object, tuple, seq, etc
+  tyUserTypeClass # the body of a user-defined type class
+  tyUserTypeClassInst
+    # Instance of a parametric user-defined type class.
+    # Structured similarly to tyGenericInst.
+    # tyGenericInst represents concrete types, while
+    # this is still a "generic param" that will bind types
+    # and resolves them during sigmatch and instantiation.
+  tyCompositeTypeClass
+    # Type such as seq[Number]
+    # The notes for tyUserTypeClassInst apply here as well
+    # sons[0]: the original expression used by the user.
+    # sons[1]: fully expanded and instantiated meta type
+    # (potentially following aliases)
+  tyInferred
+    # In the initial state `base` stores a type class constraining
+    # the types that can be inferred. After a candidate type is
+    # selected, it's stored in `lastSon`. Between `base` and `lastSon`
+    # there may be 0, 2 or more types that were also considered as
+    # possible candidates in the inference process (i.e. lastSon will
+    # be updated to store a type best conforming to all candidates)
+  tyAnd
+  tyOr
+  tyNot
+    # boolean type classes such as `string|int`,`not seq`,
+    # `Sortable and Enumable`, etc
+  tyAnything # a type class matching any type
+  tyStatic # a value known at compile type (the underlying type is .base)
+  tyFromExpr
+    # This is a type representing an expression that depends
+    # on generic parameters (the expression is stored in t.n)
+    # It will be converted to a real type only during generic
+    # instantiation and prior to this it has the potential to
+    # be any type.
+  tyConcept # new style concept.
+  tyVoid # now different from tyEmpty, hurray!
+  tyIterable
 
 static:
   # remind us when TTypeKind stops to fit in a single 64-bit word
@@ -699,288 +693,287 @@ var eqTypeFlags* =
   ## This is now a variable because for emulation of version:1.0 we
   ## might exclude {tfGcSafe, tfNoSideEffect}.
 
-type
-  TMagic* = enum # symbols that require compiler magic:
-    mNone
-    mDefined
-    mDeclared
-    mDeclaredInScope
-    mCompiles
-    mArrGet
-    mArrPut
-    mAsgn
-    mLow
-    mHigh
-    mSizeOf
-    mAlignOf
-    mOffsetOf
-    mTypeTrait
-    mIs
-    mOf
-    mAddr
-    mType
-    mTypeOf
-    mPlugin
-    mEcho
-    mShallowCopy
-    mSlurp
-    mStaticExec
-    mStatic
-    mParseExprToAst
-    mParseStmtToAst
-    mExpandToAst
-    mQuoteAst
-    mInc
-    mDec
-    mOrd
-    mNew
-    mNewFinalize
-    mNewSeq
-    mNewSeqOfCap
-    mLengthOpenArray
-    mLengthStr
-    mLengthArray
-    mLengthSeq
-    mIncl
-    mExcl
-    mCard
-    mChr
-    mGCref
-    mGCunref
-    mAddI
-    mSubI
-    mMulI
-    mDivI
-    mModI
-    mSucc
-    mPred
-    mAddF64
-    mSubF64
-    mMulF64
-    mDivF64
-    mShrI
-    mShlI
-    mAshrI
-    mBitandI
-    mBitorI
-    mBitxorI
-    mMinI
-    mMaxI
-    mAddU
-    mSubU
-    mMulU
-    mDivU
-    mModU
-    mEqI
-    mLeI
-    mLtI
-    mEqF64
-    mLeF64
-    mLtF64
-    mLeU
-    mLtU
-    mEqEnum
-    mLeEnum
-    mLtEnum
-    mEqCh
-    mLeCh
-    mLtCh
-    mEqB
-    mLeB
-    mLtB
-    mEqRef
-    mLePtr
-    mLtPtr
-    mXor
-    mEqCString
-    mEqProc
-    mUnaryMinusI
-    mUnaryMinusI64
-    mAbsI
-    mNot
-    mUnaryPlusI
-    mBitnotI
-    mUnaryPlusF64
-    mUnaryMinusF64
-    mCharToStr
-    mBoolToStr
-    mIntToStr
-    mInt64ToStr
-    mFloatToStr # for compiling nimStdlibVersion < 1.5.1 (not bootstrapping)
-    mCStrToStr
-    mStrToStr
-    mEnumToStr
-    mAnd
-    mOr
-    mImplies
-    mIff
-    mExists
-    mForall
-    mOld
-    mEqStr
-    mLeStr
-    mLtStr
-    mEqSet
-    mLeSet
-    mLtSet
-    mMulSet
-    mPlusSet
-    mMinusSet
-    mConStrStr
-    mSlice
-    mDotDot # this one is only necessary to give nice compile time warnings
-    mFields
-    mFieldPairs
-    mOmpParFor
-    mAppendStrCh
-    mAppendStrStr
-    mAppendSeqElem
-    mInSet
-    mRepr
-    mExit
-    mSetLengthStr
-    mSetLengthSeq
-    mIsPartOf
-    mAstToStr
-    mParallel
-    mSwap
-    mIsNil
-    mArrToSeq
-    mOpenArrayToSeq
-    mNewString
-    mNewStringOfCap
-    mParseBiggestFloat
-    mMove
-    mEnsureMove
-    mWasMoved
-    mDup
-    mDestroy
-    mTrace
-    mDefault
-    mUnown
-    mFinished
-    mIsolate
-    mAccessEnv
-    mAccessTypeField
-    mReset
-    mArray
-    mOpenArray
-    mRange
-    mSet
-    mSeq
-    mVarargs
-    mRef
-    mPtr
-    mVar
-    mDistinct
-    mVoid
-    mTuple
-    mOrdinal
-    mIterableType
-    mInt
-    mInt8
-    mInt16
-    mInt32
-    mInt64
-    mUInt
-    mUInt8
-    mUInt16
-    mUInt32
-    mUInt64
-    mFloat
-    mFloat32
-    mFloat64
-    mFloat128
-    mBool
-    mChar
-    mString
-    mCstring
-    mPointer
-    mNil
-    mExpr
-    mStmt
-    mTypeDesc
-    mVoidType
-    mPNimrodNode
-    mSpawn
-    mDeepCopy
-    mIsMainModule
-    mCompileDate
-    mCompileTime
-    mProcCall
-    mCpuEndian
-    mHostOS
-    mHostCPU
-    mBuildOS
-    mBuildCPU
-    mAppType
-    mCompileOption
-    mCompileOptionArg
-    mNLen
-    mNChild
-    mNSetChild
-    mNAdd
-    mNAddMultiple
-    mNDel
-    mNKind
-    mNSymKind
-    mNccValue
-    mNccInc
-    mNcsAdd
-    mNcsIncl
-    mNcsLen
-    mNcsAt
-    mNctPut
-    mNctLen
-    mNctGet
-    mNctHasNext
-    mNctNext
-    mNIntVal
-    mNFloatVal
-    mNSymbol
-    mNIdent
-    mNGetType
-    mNStrVal
-    mNSetIntVal
-    mNSetFloatVal
-    mNSetSymbol
-    mNSetIdent
-    mNSetStrVal
-    mNLineInfo
-    mNNewNimNode
-    mNCopyNimNode
-    mNCopyNimTree
-    mStrToIdent
-    mNSigHash
-    mNSizeOf
-    mNBindSym
-    mNCallSite
-    mEqIdent
-    mEqNimrodNode
-    mSameNodeType
-    mGetImpl
-    mNGenSym
-    mNHint
-    mNWarning
-    mNError
-    mInstantiationInfo
-    mGetTypeInfo
-    mGetTypeInfoV2
-    mNimvm
-    mIntDefine
-    mStrDefine
-    mBoolDefine
-    mGenericDefine
-    mRunnableExamples
-    mException
-    mBuiltinType
-    mSymOwner
-    mUncheckedArray
-    mGetImplTransf
-    mSymIsInstantiationOf
-    mNodeId
-    mPrivateAccess
-    mZeroDefault
+type TMagic* = enum # symbols that require compiler magic:
+  mNone
+  mDefined
+  mDeclared
+  mDeclaredInScope
+  mCompiles
+  mArrGet
+  mArrPut
+  mAsgn
+  mLow
+  mHigh
+  mSizeOf
+  mAlignOf
+  mOffsetOf
+  mTypeTrait
+  mIs
+  mOf
+  mAddr
+  mType
+  mTypeOf
+  mPlugin
+  mEcho
+  mShallowCopy
+  mSlurp
+  mStaticExec
+  mStatic
+  mParseExprToAst
+  mParseStmtToAst
+  mExpandToAst
+  mQuoteAst
+  mInc
+  mDec
+  mOrd
+  mNew
+  mNewFinalize
+  mNewSeq
+  mNewSeqOfCap
+  mLengthOpenArray
+  mLengthStr
+  mLengthArray
+  mLengthSeq
+  mIncl
+  mExcl
+  mCard
+  mChr
+  mGCref
+  mGCunref
+  mAddI
+  mSubI
+  mMulI
+  mDivI
+  mModI
+  mSucc
+  mPred
+  mAddF64
+  mSubF64
+  mMulF64
+  mDivF64
+  mShrI
+  mShlI
+  mAshrI
+  mBitandI
+  mBitorI
+  mBitxorI
+  mMinI
+  mMaxI
+  mAddU
+  mSubU
+  mMulU
+  mDivU
+  mModU
+  mEqI
+  mLeI
+  mLtI
+  mEqF64
+  mLeF64
+  mLtF64
+  mLeU
+  mLtU
+  mEqEnum
+  mLeEnum
+  mLtEnum
+  mEqCh
+  mLeCh
+  mLtCh
+  mEqB
+  mLeB
+  mLtB
+  mEqRef
+  mLePtr
+  mLtPtr
+  mXor
+  mEqCString
+  mEqProc
+  mUnaryMinusI
+  mUnaryMinusI64
+  mAbsI
+  mNot
+  mUnaryPlusI
+  mBitnotI
+  mUnaryPlusF64
+  mUnaryMinusF64
+  mCharToStr
+  mBoolToStr
+  mIntToStr
+  mInt64ToStr
+  mFloatToStr # for compiling nimStdlibVersion < 1.5.1 (not bootstrapping)
+  mCStrToStr
+  mStrToStr
+  mEnumToStr
+  mAnd
+  mOr
+  mImplies
+  mIff
+  mExists
+  mForall
+  mOld
+  mEqStr
+  mLeStr
+  mLtStr
+  mEqSet
+  mLeSet
+  mLtSet
+  mMulSet
+  mPlusSet
+  mMinusSet
+  mConStrStr
+  mSlice
+  mDotDot # this one is only necessary to give nice compile time warnings
+  mFields
+  mFieldPairs
+  mOmpParFor
+  mAppendStrCh
+  mAppendStrStr
+  mAppendSeqElem
+  mInSet
+  mRepr
+  mExit
+  mSetLengthStr
+  mSetLengthSeq
+  mIsPartOf
+  mAstToStr
+  mParallel
+  mSwap
+  mIsNil
+  mArrToSeq
+  mOpenArrayToSeq
+  mNewString
+  mNewStringOfCap
+  mParseBiggestFloat
+  mMove
+  mEnsureMove
+  mWasMoved
+  mDup
+  mDestroy
+  mTrace
+  mDefault
+  mUnown
+  mFinished
+  mIsolate
+  mAccessEnv
+  mAccessTypeField
+  mReset
+  mArray
+  mOpenArray
+  mRange
+  mSet
+  mSeq
+  mVarargs
+  mRef
+  mPtr
+  mVar
+  mDistinct
+  mVoid
+  mTuple
+  mOrdinal
+  mIterableType
+  mInt
+  mInt8
+  mInt16
+  mInt32
+  mInt64
+  mUInt
+  mUInt8
+  mUInt16
+  mUInt32
+  mUInt64
+  mFloat
+  mFloat32
+  mFloat64
+  mFloat128
+  mBool
+  mChar
+  mString
+  mCstring
+  mPointer
+  mNil
+  mExpr
+  mStmt
+  mTypeDesc
+  mVoidType
+  mPNimrodNode
+  mSpawn
+  mDeepCopy
+  mIsMainModule
+  mCompileDate
+  mCompileTime
+  mProcCall
+  mCpuEndian
+  mHostOS
+  mHostCPU
+  mBuildOS
+  mBuildCPU
+  mAppType
+  mCompileOption
+  mCompileOptionArg
+  mNLen
+  mNChild
+  mNSetChild
+  mNAdd
+  mNAddMultiple
+  mNDel
+  mNKind
+  mNSymKind
+  mNccValue
+  mNccInc
+  mNcsAdd
+  mNcsIncl
+  mNcsLen
+  mNcsAt
+  mNctPut
+  mNctLen
+  mNctGet
+  mNctHasNext
+  mNctNext
+  mNIntVal
+  mNFloatVal
+  mNSymbol
+  mNIdent
+  mNGetType
+  mNStrVal
+  mNSetIntVal
+  mNSetFloatVal
+  mNSetSymbol
+  mNSetIdent
+  mNSetStrVal
+  mNLineInfo
+  mNNewNimNode
+  mNCopyNimNode
+  mNCopyNimTree
+  mStrToIdent
+  mNSigHash
+  mNSizeOf
+  mNBindSym
+  mNCallSite
+  mEqIdent
+  mEqNimrodNode
+  mSameNodeType
+  mGetImpl
+  mNGenSym
+  mNHint
+  mNWarning
+  mNError
+  mInstantiationInfo
+  mGetTypeInfo
+  mGetTypeInfoV2
+  mNimvm
+  mIntDefine
+  mStrDefine
+  mBoolDefine
+  mGenericDefine
+  mRunnableExamples
+  mException
+  mBuiltinType
+  mSymOwner
+  mUncheckedArray
+  mGetImplTransf
+  mSymIsInstantiationOf
+  mNodeId
+  mPrivateAccess
+  mZeroDefault
 
 const
   # things that we can evaluate safely at compile time, even if not asked for it:
@@ -1000,10 +993,9 @@ const
     }
   generatedMagics* = {mNone, mIsolate, mFinished, mOpenArrayToSeq} ## magics that are generated as normal procs in the backend
 
-type
-  ItemId* = object
-    module*: int32
-    item*: int32
+type ItemId* = object
+  module*: int32
+  item*: int32
 
 proc `$`*(x: ItemId): string =
   "(module: " & $x.module & ", item: " & $x.item & ")"
@@ -1028,25 +1020,25 @@ type
   PSym* = ref TSym
   TNode* {.final, acyclic.} = object # on a 32bit machine, this takes 32 bytes
     when defined(useNodeIds):
-        id*: int
+      id*: int
     typ*: PType
     info*: TLineInfo
     flags*: TNodeFlags
     case kind*: TNodeKind
     of nkCharLit .. nkUInt64Lit:
-        intVal*: BiggestInt
+      intVal*: BiggestInt
     of nkFloatLit .. nkFloat128Lit:
-        floatVal*: BiggestFloat
+      floatVal*: BiggestFloat
     of nkStrLit .. nkTripleStrLit:
-        strVal*: string
+      strVal*: string
     of nkSym:
-        sym*: PSym
+      sym*: PSym
     of nkIdent:
-        ident*: PIdent
+      ident*: PIdent
     else:
-        sons*: TNodeSeq
+      sons*: TNodeSeq
     when defined(nimsuggest):
-        endInfo*: TLineInfo
+      endInfo*: TLineInfo
     prefix*: seq[Token] # comments leading up to this node
     mid*: seq[Token] # comments in the middle of the node
     postfix*: seq[Token] # comments after the node
@@ -1136,12 +1128,12 @@ type
     of routineKinds:
       #procInstCache*: seq[PInstantiation]
       #procInstCache*: seq[PInstantiation]
-        gcUnsafetyReason*: PSym # for better error messages regarding gcsafe
-        transformedBody*: PNode # cached body after transf pass
+      gcUnsafetyReason*: PSym # for better error messages regarding gcsafe
+      transformedBody*: PNode # cached body after transf pass
     of skLet, skVar, skField, skForVar:
-        guard*: PSym
-        bitsize*: int
-        alignment*: int # for alignment
+      guard*: PSym
+      bitsize*: int
+      alignment*: int # for alignment
     else:
       nil
     magic*: TMagic
@@ -1149,7 +1141,7 @@ type
     name*: PIdent
     info*: TLineInfo
     when defined(nimsuggest):
-        endInfo*: TLineInfo
+      endInfo*: TLineInfo
     owner*: PSym
     flags*: TSymFlags
     ast*: PNode
@@ -1182,9 +1174,9 @@ type
       # additional fields (seldom used, so we use a
       # reference to another object to save space)
     when hasFFI:
-        cname*: string
-          # resolved C declaration name in importc decl, e.g.:
-          # proc fun() {.importc: "$1aux".} => cname = funaux
+      cname*: string
+        # resolved C declaration name in importc decl, e.g.:
+        # proc fun() {.importc: "$1aux".} => cname = funaux
     constraint*: PNode
       # additional constraints like 'lit|result'; also
       # misused for the codegenDecl and virtual pragmas in the hope
@@ -1192,7 +1184,7 @@ type
       # for skModule the string literal to output for
       # deprecated modules.
     when defined(nimsuggest):
-        allUsages*: seq[TLineInfo]
+      allUsages*: seq[TLineInfo]
 
   TTypeSeq* = seq[PType]
   TTypeAttachedOp* = enum ## as usual, order is important here
@@ -1288,12 +1280,11 @@ type
 template nodeId(n: PNode): int =
   cast[int](n)
 
-type
-  Gconfig = object
-    # we put comments in a side channel to avoid increasing `sizeof(TNode)`, which
-    # reduces memory usage given that `PNode` is the most allocated type by far.
-    comments: Table[int, string] # nodeId => comment
-    useIc*: bool
+type Gconfig = object
+  # we put comments in a side channel to avoid increasing `sizeof(TNode)`, which
+  # reduces memory usage given that `PNode` is the most allocated type by far.
+  comments: Table[int, string] # nodeId => comment
+  useIc*: bool
 
 var gconfig {.threadvar.}: Gconfig
 
@@ -1361,8 +1352,8 @@ const
       tyFloat .. tyFloat128,
       tyUInt .. tyUInt64
     }
-      # types of the expr that may occur in::
-      # var x = expr
+    # types of the expr that may occur in::
+    # var x = expr
   IntegralTypes* =
     {
       tyBool,
@@ -1423,28 +1414,25 @@ proc getPIdent*(a: PNode): PIdent {.inline.} =
   else:
     nil
 
-const
-  moduleShift =
-    when defined(cpu32):
-      20
-    else:
-      24
+const moduleShift =
+  when defined(cpu32):
+    20
+  else:
+    24
 
 template id*(a: PIdObj): int =
   let x = a
 
   (x.itemId.module.int shl moduleShift) + x.itemId.item.int
 
-type
-  IdGenerator* = ref object # unfortunately, we really need the 'shared mutable' aspect here.
-    module*: int32
-    symId*: int32
-    typeId*: int32
-    sealed*: bool
-    disambTable*: CountTable[PIdent]
+type IdGenerator* = ref object # unfortunately, we really need the 'shared mutable' aspect here.
+  module*: int32
+  symId*: int32
+  typeId*: int32
+  sealed*: bool
+  disambTable*: CountTable[PIdent]
 
-const
-  PackageModuleId* = -3'i32
+const PackageModuleId* = -3'i32
 
 proc idGeneratorFromModule*(m: PSym): IdGenerator =
   assert m.kind == skModule
@@ -1454,7 +1442,7 @@ proc idGeneratorFromModule*(m: PSym): IdGenerator =
       module: m.itemId.module,
       symId: m.itemId.item,
       typeId: 0,
-      disambTable: initCountTable[PIdent]()
+      disambTable: initCountTable[PIdent](),
     )
 
 proc idGeneratorForPackage*(nextIdWillBe: int32): IdGenerator =
@@ -1463,7 +1451,7 @@ proc idGeneratorForPackage*(nextIdWillBe: int32): IdGenerator =
       module: PackageModuleId,
       symId: nextIdWillBe - 1'i32,
       typeId: 0,
-      disambTable: initCountTable[PIdent]()
+      disambTable: initCountTable[PIdent](),
     )
 
 proc nextSymId*(x: IdGenerator): ItemId {.inline.} =
@@ -1503,8 +1491,7 @@ proc isCallExpr*(n: PNode): bool =
 
 proc discardSons*(father: PNode)
 
-type
-  Indexable = PNode | PType
+type Indexable = PNode | PType
 
 proc len*(n: Indexable): int {.inline.} =
   result = n.sons.len
@@ -1606,8 +1593,7 @@ proc setInfoRecursive*(n: PNode; info: TLineInfo) =
     n.info = info
 
 when defined(useNodeIds):
-  const
-    nodeIdToDebug* = -1 # 2322968
+  const nodeIdToDebug* = -1 # 2322968
 
   var gNodeId: int
 
@@ -1700,7 +1686,7 @@ proc newSym*(
     idgen: IdGenerator;
     owner: PSym;
     info: TLineInfo;
-    options: TOptions = {}
+    options: TOptions = {};
 ): PSym =
   # generates a symbol and initializes the hash field too
   assert not name.isNil
@@ -1717,7 +1703,7 @@ proc newSym*(
       options: options,
       owner: owner,
       offset: defaultOffset,
-      disamb: getOrDefault(idgen.disambTable, name).int32
+      disamb: getOrDefault(idgen.disambTable, name).int32,
     )
 
   idgen.disambTable.inc name
@@ -1737,7 +1723,8 @@ proc astdef*(s: PSym): PNode =
     s.ast
 
 proc isMetaType*(t: PType): bool =
-  return t.kind in tyMetaTypes or (t.kind == tyStatic and t.n == nil) or tfHasMeta in t.flags
+  return t.kind in tyMetaTypes or (t.kind == tyStatic and t.n == nil) or
+      tfHasMeta in t.flags
 
 proc isUnresolvedStatic*(t: PType): bool =
   return t.kind == tyStatic and t.n == nil
@@ -1898,14 +1885,13 @@ proc newProcNode*(
     kind: TNodeKind;
     info: TLineInfo;
     body: PNode;
-    params, name, pattern, genericParams, pragmas, exceptions: PNode
+    params, name, pattern, genericParams, pragmas, exceptions: PNode;
 ): PNode =
   result = newNodeI(kind, info)
   result.sons = @[name, pattern, genericParams, params, pragmas, exceptions, body]
 
-const
-  AttachedOpToStr*: array[TTypeAttachedOp, string] =
-    ["=wasMoved", "=destroy", "=copy", "=dup", "=sink", "=trace", "=deepcopy"]
+const AttachedOpToStr*: array[TTypeAttachedOp, string] =
+  ["=wasMoved", "=destroy", "=copy", "=dup", "=sink", "=trace", "=deepcopy"]
 
 proc `$`*(s: PSym): string =
   if s != nil:
@@ -1921,7 +1907,7 @@ proc newType*(kind: TTypeKind; id: ItemId; owner: PSym): PType =
       size: defaultSize,
       align: defaultAlignment,
       itemId: id,
-      uniqueId: id
+      uniqueId: id,
     )
   when false:
     if result.itemId.module == 55 and result.itemId.item == 2:
@@ -2065,7 +2051,8 @@ proc skipTypesOrNil*(t: PType; kinds: TTypeKinds): PType =
 
 proc isGCedMem*(t: PType): bool {.inline.} =
   result =
-    t.kind in {tyString, tyRef, tySequence} or t.kind == tyProc and t.callConv == ccClosure
+    t.kind in {tyString, tyRef, tySequence} or
+      t.kind == tyProc and t.callConv == ccClosure
 
 proc propagateToOwner*(owner, elem: PType; propagateHasAsgn = true) =
   owner.flags.incl elem.flags * {tfHasMeta, tfTriggersCompileTime}
@@ -2147,7 +2134,7 @@ template transitionNodeKindCommon(k: TNodeKind) =
       flags: obj.flags,
       prefix: obj.prefix,
       mid: obj.mid,
-      postfix: obj.postfix
+      postfix: obj.postfix,
     )
   # n.comment = obj.comment # shouldn't be needed, the address doesnt' change
   when defined(useNodeIds):
@@ -2190,7 +2177,7 @@ template transitionSymKindCommon*(k: TSymKind) =
       offset: obj.offset,
       loc: obj.loc,
       annex: obj.annex,
-      constraint: obj.constraint
+      constraint: obj.constraint,
     )
   when hasFFI:
     s.cname = obj.cname
@@ -2485,7 +2472,6 @@ proc toObjectFromRefPtrGeneric*(typ: PType): PType =
       result = result.lastSon
     of tyRef, tyPtr, tyGenericInst, tyGenericInvocation, tyAlias:
       result = result[0]
-    # automatic dereferencing is deep, refs #18298.
     else:
       break
 
@@ -2574,9 +2560,8 @@ proc addParam*(procType: PType; param: PSym) =
 
   rawAddSon(procType, param.typ)
 
-const
-  magicsThatCanRaise =
-    {mNone, mSlurp, mStaticExec, mParseExprToAst, mParseStmtToAst, mEcho}
+const magicsThatCanRaise =
+  {mNone, mSlurp, mStaticExec, mParseExprToAst, mParseStmtToAst, mEcho}
 
 proc canRaiseConservative*(fn: PNode): bool =
   if fn.kind == nkSym and fn.sym.magic notin magicsThatCanRaise:
@@ -2585,11 +2570,12 @@ proc canRaiseConservative*(fn: PNode): bool =
     result = true
 
 proc canRaise*(fn: PNode): bool =
-  if fn.kind == nkSym and (
-      fn.sym.magic notin magicsThatCanRaise or {sfImportc, sfInfixCall} * fn.sym.flags == {
-            sfImportc
-          } or sfGeneratedOp in fn.sym.flags
-    ):
+  if fn.kind == nkSym and
+      (
+        fn.sym.magic notin magicsThatCanRaise or
+        {sfImportc, sfInfixCall} * fn.sym.flags == {sfImportc} or
+        sfGeneratedOp in fn.sym.flags
+      ):
     result = false
   elif fn.kind == nkSym and fn.sym.magic == mEcho:
     result = true
@@ -2599,10 +2585,13 @@ proc canRaise*(fn: PNode): bool =
       result = false
     else:
       result =
-        fn.typ != nil and fn.typ.n != nil and (
-            (fn.typ.n[0].len < effectListLen) or (
-                fn.typ.n[0][exceptionEffects] != nil and fn.typ.n[0][exceptionEffects].safeLen > 0
-              )
+        fn.typ != nil and fn.typ.n != nil and
+          (
+            (fn.typ.n[0].len < effectListLen) or
+            (
+              fn.typ.n[0][exceptionEffects] != nil and
+              fn.typ.n[0][exceptionEffects].safeLen > 0
+            )
           )
 
 proc toHumanStrImpl[T](kind: T; num: static int): string =
@@ -2621,7 +2610,8 @@ proc toHumanStr*(kind: TTypeKind): string =
 proc skipAddr*(n: PNode): PNode {.inline.} =
   if n.kind == nkHiddenAddr:
     n[0]
-  else: n
+  else:
+    n
 
 proc isNewStyleConcept*(n: PNode): bool {.inline.} =
   assert n.kind == nkTypeClassTy
@@ -2631,30 +2621,29 @@ proc isNewStyleConcept*(n: PNode): bool {.inline.} =
 proc isOutParam*(t: PType): bool {.inline.} =
   tfIsOutParam in t.flags
 
-const
-  nodesToIgnoreSet* =
-    {
-      nkNone .. pred(nkSym),
-      succ(nkSym) .. nkNilLit,
-      nkTypeSection,
-      nkProcDef,
-      nkConverterDef,
-      nkMethodDef,
-      nkIteratorDef,
-      nkMacroDef,
-      nkTemplateDef,
-      nkLambda,
-      nkDo,
-      nkFuncDef,
-      nkConstSection,
-      nkConstDef,
-      nkIncludeStmt,
-      nkImportStmt,
-      nkExportStmt,
-      nkPragma,
-      nkCommentStmt,
-      nkBreakState,
-      nkTypeOfExpr,
-      nkMixinStmt,
-      nkBindStmt
-    }
+const nodesToIgnoreSet* =
+  {
+    nkNone .. pred(nkSym),
+    succ(nkSym) .. nkNilLit,
+    nkTypeSection,
+    nkProcDef,
+    nkConverterDef,
+    nkMethodDef,
+    nkIteratorDef,
+    nkMacroDef,
+    nkTemplateDef,
+    nkLambda,
+    nkDo,
+    nkFuncDef,
+    nkConstSection,
+    nkConstDef,
+    nkIncludeStmt,
+    nkImportStmt,
+    nkExportStmt,
+    nkPragma,
+    nkCommentStmt,
+    nkBreakState,
+    nkTypeOfExpr,
+    nkMixinStmt,
+    nkBindStmt
+  }

--- a/src/phastalgo.nim
+++ b/src/phastalgo.nim
@@ -21,20 +21,19 @@ import
 
 import strutils except addf
 when defined(nimPreviewSlimSystem):
-  import
-    std/assertions
+  import std/assertions
 
 proc hashNode*(p: RootRef): Hash
 
 proc treeToYaml*(
-    conf: ConfigRef; n: PNode; indent: int = 0; maxRecDepth: int = -1
+  conf: ConfigRef; n: PNode; indent: int = 0; maxRecDepth: int = -1
 ): Rope
 
   # Convert a tree into its YAML representation; this is used by the
   # YAML code generator and it is invaluable for debugging purposes.
   # If maxRecDepht <> -1 then it won't print the whole graph.
 proc typeToYaml*(
-    conf: ConfigRef; n: PType; indent: int = 0; maxRecDepth: int = -1
+  conf: ConfigRef; n: PType; indent: int = 0; maxRecDepth: int = -1
 ): Rope
 
 proc symToYaml*(conf: ConfigRef; n: PSym; indent: int = 0; maxRecDepth: int = -1): Rope
@@ -115,8 +114,7 @@ proc mustRehash*(length, counter: int): bool
 
 proc nextTry*(h, maxHash: Hash): Hash {.inline.} # ------------- table[int, int] ---------------------------------------------
 
-const
-  InvalidKey* = low(int)
+const InvalidKey* = low(int)
 
 type
   TIIPair* {.final.} = object
@@ -321,8 +319,7 @@ proc makeYamlString*(s: string): Rope =
   # We have to split long strings into many ropes. Otherwise
   # this could trigger InternalError(111). See the ropes module for
   # further information.
-  const
-    MaxLineLength = 64000
+  const MaxLineLength = 64000
 
   result = ""
 
@@ -355,22 +352,23 @@ proc flagsToStr[T](flags: set[T]): Rope =
 
 proc lineInfoToStr(conf: ConfigRef; info: TLineInfo): Rope =
   result =
-    "[$1, $2, $3]" % [
+    "[$1, $2, $3]" %
+      [
         makeYamlString(toFilename(conf, info)),
         rope(toLinenumber(info)),
         rope(toColumn(info))
       ]
 
 proc treeToYamlAux(
-    conf: ConfigRef; n: PNode; marker: var IntSet; indent, maxRecDepth: int
+  conf: ConfigRef; n: PNode; marker: var IntSet; indent, maxRecDepth: int
 ): Rope
 
 proc symToYamlAux(
-    conf: ConfigRef; n: PSym; marker: var IntSet; indent, maxRecDepth: int
+  conf: ConfigRef; n: PSym; marker: var IntSet; indent, maxRecDepth: int
 ): Rope
 
 proc typeToYamlAux(
-    conf: ConfigRef; n: PType; marker: var IntSet; indent, maxRecDepth: int
+  conf: ConfigRef; n: PType; marker: var IntSet; indent, maxRecDepth: int
 ): Rope
 
 proc symToYamlAux(
@@ -394,7 +392,7 @@ proc symToYamlAux(
     if n.typ != nil:
       result.addf(
         "$N$1\"typ\": $2",
-        [istr, typeToYamlAux(conf, n.typ, marker, indent + 2, maxRecDepth - 1)]
+        [istr, typeToYamlAux(conf, n.typ, marker, indent + 2, maxRecDepth - 1)],
       )
     if conf != nil:
       # if we don't pass the config, we probably don't care about the line info
@@ -414,7 +412,7 @@ proc symToYamlAux(
     result.addf("$N$1\"r\": $2", [istr, n.loc.r])
     result.addf(
       "$N$1\"lode\": $2",
-      [istr, treeToYamlAux(conf, n.loc.lode, marker, indent + 2, maxRecDepth - 1)]
+      [istr, treeToYamlAux(conf, n.loc.lode, marker, indent + 2, maxRecDepth - 1)],
     )
     result.addf("$N$1}", [rspaces(indent)])
 
@@ -439,7 +437,7 @@ proc typeToYamlAux(
           [
             rspaces(indent + 4),
             typeToYamlAux(conf, n[i], marker, indent + 4, maxRecDepth - 1)
-          ]
+          ],
         )
 
       sonsRope.addf("$N$1]", [rspaces(indent + 2)])
@@ -453,11 +451,11 @@ proc typeToYamlAux(
     result.addf("$N$1\"kind\": $2", [istr, makeYamlString($n.kind)])
     result.addf(
       "$N$1\"sym\": $2",
-      [istr, symToYamlAux(conf, n.sym, marker, indent + 2, maxRecDepth - 1)]
+      [istr, symToYamlAux(conf, n.sym, marker, indent + 2, maxRecDepth - 1)],
     )
     result.addf(
       "$N$1\"n\": $2",
-      [istr, treeToYamlAux(conf, n.n, marker, indent + 2, maxRecDepth - 1)]
+      [istr, treeToYamlAux(conf, n.n, marker, indent + 2, maxRecDepth - 1)],
     )
     if card(n.flags) > 0:
       result.addf("$N$1\"flags\": $2", [istr, flagsToStr(n.flags)])
@@ -507,7 +505,7 @@ proc treeToYamlAux(
       of nkSym:
         result.addf(
           ",$N$1\"sym\": $2",
-          [istr, symToYamlAux(conf, n.sym, marker, indent + 2, maxRecDepth)]
+          [istr, symToYamlAux(conf, n.sym, marker, indent + 2, maxRecDepth)],
         )
       of nkIdent:
         if n.ident != nil:
@@ -528,14 +526,14 @@ proc treeToYamlAux(
               [
                 rspaces(indent + 4),
                 treeToYamlAux(conf, n[i], marker, indent + 4, maxRecDepth - 1)
-              ]
+              ],
             )
 
           result.addf("$N$1]", [istr])
       if n.typ != nil:
         result.addf(
           ",$N$1\"typ\": $2",
-          [istr, typeToYamlAux(conf, n.typ, marker, indent + 2, maxRecDepth)]
+          [istr, typeToYamlAux(conf, n.typ, marker, indent + 2, maxRecDepth)],
         )
       if n.postfix.len > 0:
         result.addf(",$N$1\"postfix\": [", [istr])
@@ -549,16 +547,12 @@ proc treeToYamlAux(
 
     result.addf("$N$1}", [rspaces(indent)])
 
-proc treeToYaml(
-    conf: ConfigRef; n: PNode; indent: int = 0; maxRecDepth: int = -1
-): Rope =
+proc treeToYaml(conf: ConfigRef; n: PNode; indent: int = 0; maxRecDepth: int = -1): Rope =
   var marker = initIntSet()
 
   result = treeToYamlAux(conf, n, marker, indent, maxRecDepth)
 
-proc typeToYaml(
-    conf: ConfigRef; n: PType; indent: int = 0; maxRecDepth: int = -1
-): Rope =
+proc typeToYaml(conf: ConfigRef; n: PType; indent: int = 0; maxRecDepth: int = -1): Rope =
   var marker = initIntSet()
 
   result = typeToYamlAux(conf, n, marker, indent, maxRecDepth)
@@ -570,27 +564,21 @@ proc symToYaml(conf: ConfigRef; n: PSym; indent: int = 0; maxRecDepth: int = -1)
 
 import tables
 
-const
-  backrefStyle = "\e[90m"
-const
-  enumStyle = "\e[34m"
-const
-  numberStyle = "\e[33m"
-const
-  stringStyle = "\e[32m"
-const
-  resetStyle = "\e[0m"
+const backrefStyle = "\e[90m"
+const enumStyle = "\e[34m"
+const numberStyle = "\e[33m"
+const stringStyle = "\e[32m"
+const resetStyle = "\e[0m"
 
-type
-  DebugPrinter = object
-    conf: ConfigRef
-    visited: Table[pointer, int]
-    renderSymType: bool
-    indent: int
-    currentLine: int
-    firstItem: bool
-    useColor: bool
-    res: string
+type DebugPrinter = object
+  conf: ConfigRef
+  visited: Table[pointer, int]
+  renderSymType: bool
+  indent: int
+  currentLine: int
+  firstItem: bool
+  useColor: bool
+  res: string
 
 proc indentMore(this: var DebugPrinter) =
   this.indent += 2
@@ -1043,10 +1031,9 @@ proc strTableGet*(t: TStrTable; name: PIdent): PSym =
 
     h = nextTry(h, high(t.data))
 
-type
-  TIdentIter* = object # iterator over all syms with same identifier
-    h*: Hash # current hash
-    name*: PIdent
+type TIdentIter* = object # iterator over all syms with same identifier
+  h*: Hash # current hash
+  name*: PIdent
 
 proc nextIdentIter*(ti: var TIdentIter; tab: TStrTable): PSym =
   # hot spots
@@ -1110,9 +1097,8 @@ proc firstIdentExcluding*(
   else:
     result = nextIdentExcluding(ti, tab, excluding)
 
-type
-  TTabIter* = object
-    h: Hash
+type TTabIter* = object
+  h: Hash
 
 proc nextIter*(ti: var TTabIter; tab: TStrTable): PSym =
   # usage:

--- a/src/phlexer.nim
+++ b/src/phlexer.nim
@@ -30,8 +30,7 @@ import
   "."/[phoptions, phmsgs, phlineinfos],
   std/[hashes, strutils, parseutils]
 when defined(nimPreviewSlimSystem):
-  import
-    std/[assertions, formatfloat]
+  import std/[assertions, formatfloat]
 
 const
   numChars*: set[char] = {'0' .. '9', 'a' .. 'z', 'A' .. 'Z'}
@@ -39,25 +38,8 @@ const
   SymStartChars*: set[char] = {'a' .. 'z', 'A' .. 'Z', '\x80' .. '\xFF'}
   OpChars*: set[char] =
     {
-      '+',
-      '-',
-      '*',
-      '/',
-      '\\',
-      '<',
-      '>',
-      '!',
-      '?',
-      '^',
-      '.',
-      '|',
-      '=',
-      '%',
-      '&',
-      '$',
-      '@',
-      '~',
-      ':'
+      '+', '-', '*', '/', '\\', '<', '>', '!', '?', '^', '.', '|', '=', '%', '&', '$',
+      '@', '~', ':'
     }
   UnaryMinusWhitelist = {' ', '\t', '\n', '\r', ',', ';', '(', '[', '{'}
 
@@ -249,7 +231,6 @@ template ones(n): untyped =
   ((1 shl n) - 1)
 
 # for utf-8 conversion
-
 proc isNimIdentifier*(s: string): bool =
   let sLen = s.len
   if sLen > 0 and s[0] in SymStartChars:
@@ -292,7 +273,8 @@ proc printTok*(conf: ConfigRef; tok: Token) =
   # xxx factor with toLocation
   msgWriteln(
     conf,
-    $tok.line & ":" & $tok.col & "\t" & $tok.indent & "\t" & $tok.tokType & " " & $tok & " " & $tok.offsetA & ":" & $tok.offsetB
+    $tok.line & ":" & $tok.col & "\t" & $tok.indent & "\t" & $tok.tokType & " " & $tok &
+      " " & $tok.offsetA & ":" & $tok.offsetB,
   )
 
 proc openLexer*(
@@ -301,7 +283,7 @@ proc openLexer*(
     inputstream: PLLStream;
     cache: IdentCache;
     config: ConfigRef;
-    printTokens: bool
+    printTokens: bool;
 ) =
   openBaseLexer(lex, inputstream)
 
@@ -321,7 +303,7 @@ proc openLexer*(
     inputstream: PLLStream;
     cache: IdentCache;
     config: ConfigRef;
-    printTokens: bool
+    printTokens: bool;
 ) =
   openLexer(lex, fileInfoIdx(config, filename), inputstream, cache, config, printTokens)
 
@@ -393,7 +375,8 @@ proc getNumber(L: var Lexer; result: var Token) =
           lexMessage(
             L,
             errGenerated,
-            "only single underscores may occur in a token and token may not " & "end with an underscore: e.g. '1__1' and '1_' are invalid"
+            "only single underscores may occur in a token and token may not " &
+              "end with an underscore: e.g. '1__1' and '1_' are invalid",
           )
 
           break
@@ -415,8 +398,7 @@ proc getNumber(L: var Lexer; result: var Token) =
       L: var Lexer; msg: string; startpos: int; msgKind = errGenerated
   ) =
     # Used to get slightly human friendlier err messages.
-    const
-      literalishChars = {'A' .. 'Z', 'a' .. 'z', '0' .. '9', '_', '.', '\''}
+    const literalishChars = {'A' .. 'Z', 'a' .. 'z', '0' .. '9', '_', '.', '\''}
 
     var msgPos = L.bufpos
     var t: Token
@@ -481,9 +463,10 @@ proc getNumber(L: var Lexer; result: var Token) =
     of 'c', 'C':
       lexMessageLitNum(
         L,
-        "$1 will soon be invalid for oct literals; Use '0o' " & "for octals. 'c', 'C' prefix",
+        "$1 will soon be invalid for oct literals; Use '0o' " &
+          "for octals. 'c', 'C' prefix",
         startpos,
-        warnDeprecated
+        warnDeprecated,
       )
       eatChar(L, result, 'c')
 
@@ -492,7 +475,7 @@ proc getNumber(L: var Lexer; result: var Token) =
       lexMessageLitNum(
         L,
         "$1 is an invalid int literal; For octal literals " & "use the '0o' prefix.",
-        startpos
+        startpos,
       )
     of 'x', 'X':
       eatChar(L, result, 'x')
@@ -530,8 +513,7 @@ proc getNumber(L: var Lexer; result: var Token) =
   let endpos = L.bufpos
 
   # Second stage, find out if there's a datatype suffix and handle it
-  var
-    postPos = endpos
+  var postPos = endpos
   if L.buf[postPos] in {'\'', 'f', 'F', 'd', 'D', 'i', 'I', 'u', 'U'}:
     let errPos = postPos
 
@@ -588,9 +570,8 @@ proc getNumber(L: var Lexer; result: var Token) =
     else:
       lexMessageLitNum(L, "invalid number suffix: '$1'", errPos)
   # Is there still a literalish char awaiting? Then it's an error!
-  if L.buf[postPos] in literalishChars or (
-      L.buf[postPos] == '.' and L.buf[postPos + 1] in {'0' .. '9'}
-    ):
+  if L.buf[postPos] in literalishChars or
+      (L.buf[postPos] == '.' and L.buf[postPos + 1] in {'0' .. '9'}):
     lexMessageLitNum(L, "invalid number: '$1'", startpos)
   if result.tokType != tkCustomLit:
     # Third stage, extract actual number
@@ -741,7 +722,7 @@ proc handleHexChar(L: var Lexer; xi: var int; position: range[0 .. 4]) =
     lexMessage(
       L,
       errGenerated,
-      "expected a hex digit, but found: " & L.buf[L.bufpos] & "; maybe prepend with 0"
+      "expected a hex digit, but found: " & L.buf[L.bufpos] & "; maybe prepend with 0",
     )
 
   case L.buf[L.bufpos]
@@ -777,8 +758,7 @@ proc handleDecChars(L: var Lexer; xi: var int) =
 proc addUnicodeCodePoint(s: var string; i: int) =
   let i = cast[uint](i)
   # inlined toUTF-8 to avoid unicode and strutils dependencies.
-  let
-    pos = s.len
+  let pos = s.len
   if i <= 127:
     s.setLen(pos + 1)
 
@@ -892,7 +872,7 @@ proc getEscapedChar(L: var Lexer; tok: var Token) =
         lexMessage(
           L,
           errGenerated,
-          "Unicode codepoint must be lower than 0x10FFFF, but was: " & hex
+          "Unicode codepoint must be lower than 0x10FFFF, but was: " & hex,
         )
     else:
       handleHexChar(L, xi, 1)
@@ -924,11 +904,10 @@ proc handleCRLF(L: var Lexer; pos: int): int =
   else:
     result = pos
 
-type
-  StringMode = enum
-    normal
-    raw
-    generalized
+type StringMode = enum
+  normal
+  raw
+  generalized
 
 proc getString(L: var Lexer; tok: var Token; mode: StringMode) =
   var pos = L.bufpos
@@ -979,7 +958,7 @@ proc getString(L: var Lexer; tok: var Token; mode: StringMode) =
           L,
           errGenerated,
           L.lineStart,
-          "closing \"\"\" expected, but end of file reached"
+          "closing \"\"\" expected, but end of file reached",
         )
 
         L.lineNumber = line2
@@ -1054,15 +1033,14 @@ proc getCharacter(L: var Lexer; tok: var Token) =
 
     tokenEndIgnore(tok, L.bufpos - 1)
 
-const
-  UnicodeOperatorStartChars = {'\226', '\194', '\195'}
-    # the allowed unicode characters ("∙ ∘ × ★ ⊗ ⊘ ⊙ ⊛ ⊠ ⊡ ∩ ∧ ⊓ ± ⊕ ⊖ ⊞ ⊟ ∪ ∨ ⊔")
-    # all start with one of these.
+const UnicodeOperatorStartChars = {'\226', '\194', '\195'}
 
-type
-  UnicodeOprPred = enum
-    Mul
-    Add
+# the allowed unicode characters ("∙ ∘ × ★ ⊗ ⊘ ⊙ ⊛ ⊠ ⊡ ∩ ∧ ⊓ ± ⊕ ⊖ ⊞ ⊟ ∪ ∨ ⊔")
+# all start with one of these.
+
+type UnicodeOprPred = enum
+  Mul
+  Add
 
 proc unicodeOprLen(buf: cstring; pos: int): (int8, UnicodeOprPred) =
   template m(len): untyped =
@@ -1167,9 +1145,8 @@ proc getSymbol(L: var Lexer; tok: var Token) =
 
   h = !$h
   tok.ident = L.cache.getIdent(cast[cstring](addr(L.buf[L.bufpos])), pos - L.bufpos, h)
-  if (tok.ident.id < ord(tokKeywordLow) - ord(tkSymbol)) or (
-      tok.ident.id > ord(tokKeywordHigh) - ord(tkSymbol)
-    ):
+  if (tok.ident.id < ord(tokKeywordLow) - ord(tkSymbol)) or
+      (tok.ident.id > ord(tokKeywordHigh) - ord(tkSymbol)):
     tok.tokType = tkSymbol
   else:
     tok.tokType = TokType(tok.ident.id + ord(tkSymbol))
@@ -1238,9 +1215,8 @@ proc getPrecedence*(tok: Token): int =
   of tkOpr:
     let relevantChar = tok.ident.s[0]
     # arrow like?
-    if tok.ident.s.len > 1 and tok.ident.s[^1] == '>' and tok.ident.s[^2] in {
-          '-', '~', '='
-        }:
+    if tok.ident.s.len > 1 and tok.ident.s[^1] == '>' and
+        tok.ident.s[^2] in {'-', '~', '='}:
       return 0
 
     template considerAsgn(value: untyped) =
@@ -1563,14 +1539,12 @@ proc rawGetTok*(L: var Lexer; tok: var Token) =
           discard
         else:
           lexMessage(
-            L,
-            errGenerated,
+            L, errGenerated,
             "invalid token: no whitespace between number and identifier"
           )
     of '-':
-      if L.buf[L.bufpos + 1] in {'0' .. '9'} and (
-          L.bufpos - 1 == 0 or L.buf[L.bufpos - 1] in UnaryMinusWhitelist
-        ):
+      if L.buf[L.bufpos + 1] in {'0' .. '9'} and
+          (L.bufpos - 1 == 0 or L.buf[L.bufpos - 1] in UnaryMinusWhitelist):
         # x)-23 # binary minus
         # ,-23  # unary minus
         # \n-78 # unary minus? Yes.
@@ -1583,8 +1557,7 @@ proc rawGetTok*(L: var Lexer; tok: var Token) =
             discard
           else:
             lexMessage(
-              L,
-              errGenerated,
+              L, errGenerated,
               "invalid token: no whitespace between number and identifier"
             )
       else:
@@ -1619,9 +1592,8 @@ proc getIndentWidth*(
   var prevToken = tkEof
   while tok.tokType != tkEof:
     rawGetTok(lex, tok)
-    if tok.indent > 0 and prevToken in {
-          tkColon, tkEquals, tkType, tkConst, tkLet, tkVar, tkUsing
-        }:
+    if tok.indent > 0 and
+        prevToken in {tkColon, tkEquals, tkType, tkConst, tkLet, tkVar, tkUsing}:
       result = tok.indent
       if result > 0:
         break
@@ -1634,9 +1606,8 @@ proc getPrecedence*(ident: PIdent): int =
   ## assumes ident is binary operator already
   let
     tokType =
-      if ident.id in ord(tokKeywordLow) - ord(tkSymbol) .. ord(tokKeywordHigh) - ord(
-              tkSymbol
-            ):
+      if ident.id in
+        ord(tokKeywordLow) - ord(tkSymbol) .. ord(tokKeywordHigh) - ord(tkSymbol):
         TokType(ident.id + ord(tkSymbol))
       else:
         tkOpr

--- a/src/phlineinfos.nim
+++ b/src/phlineinfos.nim
@@ -11,13 +11,12 @@
 ## This module contains the ``TMsgKind`` enum as well as the
 ## ``TLineInfo`` object.
 
-import
-  "$nim"/compiler/[ropes, pathutils], std/[hashes, tables]
+import "$nim"/compiler/[ropes, pathutils], std/[hashes, tables]
 
-const
-  explanationsBaseUrl* = "https://nim-lang.github.io/Nim"
-    # was: "https://nim-lang.org/docs" but we're now usually showing devel docs
-    # instead of latest release docs.
+const explanationsBaseUrl* = "https://nim-lang.github.io/Nim"
+
+# was: "https://nim-lang.org/docs" but we're now usually showing devel docs
+# instead of latest release docs.
 
 proc createDocLink*(urlSuffix: string): string =
   # os.`/` is not appropriate for urls.
@@ -27,260 +26,260 @@ proc createDocLink*(urlSuffix: string): string =
   else:
     result.add "/" & urlSuffix
 
-type
-  TMsgKind* = enum
-    # fatal errors
-    errUnknown
-    errFatal
-    errInternal # non-fatal errors
-    errIllFormedAstX
-    errCannotOpenFile
-    errXExpected
-    errRstMissingClosing
-    errRstGridTableNotImplemented
-    errRstMarkdownIllformedTable
-    errRstIllformedTable
-    errRstNewSectionExpected
-    errRstGeneralParseError
-    errRstInvalidDirectiveX
-    errRstInvalidField
-    errRstFootnoteMismatch
-    errRstSandboxedDirective
-    errProveInit # deadcode
-    errGenerated
-    errFailedMove
-    errUser # warnings
-    warnCannotOpenFile = "CannotOpenFile"
-    warnOctalEscape = "OctalEscape"
-    warnXIsNeverRead = "XIsNeverRead"
-    warnXmightNotBeenInit = "XmightNotBeenInit"
-    warnDeprecated = "Deprecated"
-    warnConfigDeprecated = "ConfigDeprecated"
-    warnDotLikeOps = "DotLikeOps"
-    warnSmallLshouldNotBeUsed = "SmallLshouldNotBeUsed"
-    warnUnknownMagic = "UnknownMagic"
-    warnRstRedefinitionOfLabel = "RedefinitionOfLabel"
-    warnRstUnknownSubstitutionX = "UnknownSubstitutionX"
-    warnRstAmbiguousLink = "AmbiguousLink"
-    warnRstBrokenLink = "BrokenLink"
-    warnRstLanguageXNotSupported = "LanguageXNotSupported"
-    warnRstFieldXNotSupported = "FieldXNotSupported"
-    warnRstUnusedImportdoc = "UnusedImportdoc"
-    warnRstStyle = "warnRstStyle"
-    warnCommentXIgnored = "CommentXIgnored"
-    warnTypelessParam = "TypelessParam"
-    warnUseBase = "UseBase"
-    warnWriteToForeignHeap = "WriteToForeignHeap"
-    warnUnsafeCode = "UnsafeCode"
-    warnUnusedImportX = "UnusedImport"
-    warnInheritFromException = "InheritFromException"
-    warnEachIdentIsTuple = "EachIdentIsTuple"
-    warnUnsafeSetLen = "UnsafeSetLen"
-    warnUnsafeDefault = "UnsafeDefault"
-    warnProveInit = "ProveInit"
-    warnProveField = "ProveField"
-    warnProveIndex = "ProveIndex"
-    warnUnreachableElse = "UnreachableElse"
-    warnUnreachableCode = "UnreachableCode"
-    warnStaticIndexCheck = "IndexCheck"
-    warnGcUnsafe = "GcUnsafe"
-    warnGcUnsafe2 = "GcUnsafe2"
-    warnUninit = "Uninit"
-    warnGcMem = "GcMem"
-    warnDestructor = "Destructor"
-    warnLockLevel = "LockLevel" # deadcode
-    warnResultShadowed = "ResultShadowed"
-    warnInconsistentSpacing = "Spacing"
-    warnCaseTransition = "CaseTransition"
-    warnCycleCreated = "CycleCreated"
-    warnObservableStores = "ObservableStores"
-    warnStrictNotNil = "StrictNotNil"
-    warnResultUsed = "ResultUsed"
-    warnCannotOpen = "CannotOpen"
-    warnFileChanged = "FileChanged"
-    warnSuspiciousEnumConv = "EnumConv"
-    warnAnyEnumConv = "AnyEnumConv"
-    warnHoleEnumConv = "HoleEnumConv"
-    warnCstringConv = "CStringConv"
-    warnPtrToCstringConv = "PtrToCstringConv"
-    warnEffect = "Effect"
-    warnCastSizes = "CastSizes" # deadcode
-    warnAboveMaxSizeSet = "AboveMaxSizeSet"
-    warnImplicitTemplateRedefinition = "ImplicitTemplateRedefinition"
-    warnUnnamedBreak = "UnnamedBreak"
-    warnStmtListLambda = "StmtListLambda"
-    warnBareExcept = "BareExcept"
-    warnImplicitDefaultValue = "ImplicitDefaultValue"
-    warnUser = "User" # hints
-    hintSuccess = "Success"
-    hintSuccessX = "SuccessX"
-    hintCC = "CC"
-    hintXDeclaredButNotUsed = "XDeclaredButNotUsed"
-    hintDuplicateModuleImport = "DuplicateModuleImport"
-    hintXCannotRaiseY = "XCannotRaiseY"
-    hintConvToBaseNotNeeded = "ConvToBaseNotNeeded"
-    hintConvFromXtoItselfNotNeeded = "ConvFromXtoItselfNotNeeded"
-    hintExprAlwaysX = "ExprAlwaysX"
-    hintQuitCalled = "QuitCalled"
-    hintProcessing = "Processing"
-    hintProcessingStmt = "ProcessingStmt"
-    hintCodeBegin = "CodeBegin"
-    hintCodeEnd = "CodeEnd"
-    hintConf = "Conf"
-    hintPath = "Path"
-    hintConditionAlwaysTrue = "CondTrue"
-    hintConditionAlwaysFalse = "CondFalse"
-    hintName = "Name"
-    hintPattern = "Pattern"
-    hintExecuting = "Exec"
-    hintLinking = "Link"
-    hintDependency = "Dependency"
-    hintSource = "Source"
-    hintPerformance = "Performance"
-    hintStackTrace = "StackTrace"
-    hintGCStats = "GCStats"
-    hintGlobalVar = "GlobalVar"
-    hintExpandMacro = "ExpandMacro"
-    hintAmbiguousEnum = "AmbiguousEnum"
-    hintUser = "User"
-    hintUserRaw = "UserRaw"
-    hintExtendedContext = "ExtendedContext"
-    hintMsgOrigin = "MsgOrigin" # since 1.3.5
-    hintDeclaredLoc = "DeclaredLoc" # since 1.5.1
+type TMsgKind* = enum
+  # fatal errors
+  errUnknown
+  errFatal
+  errInternal # non-fatal errors
+  errIllFormedAstX
+  errCannotOpenFile
+  errXExpected
+  errRstMissingClosing
+  errRstGridTableNotImplemented
+  errRstMarkdownIllformedTable
+  errRstIllformedTable
+  errRstNewSectionExpected
+  errRstGeneralParseError
+  errRstInvalidDirectiveX
+  errRstInvalidField
+  errRstFootnoteMismatch
+  errRstSandboxedDirective
+  errProveInit # deadcode
+  errGenerated
+  errFailedMove
+  errUser # warnings
+  warnCannotOpenFile = "CannotOpenFile"
+  warnOctalEscape = "OctalEscape"
+  warnXIsNeverRead = "XIsNeverRead"
+  warnXmightNotBeenInit = "XmightNotBeenInit"
+  warnDeprecated = "Deprecated"
+  warnConfigDeprecated = "ConfigDeprecated"
+  warnDotLikeOps = "DotLikeOps"
+  warnSmallLshouldNotBeUsed = "SmallLshouldNotBeUsed"
+  warnUnknownMagic = "UnknownMagic"
+  warnRstRedefinitionOfLabel = "RedefinitionOfLabel"
+  warnRstUnknownSubstitutionX = "UnknownSubstitutionX"
+  warnRstAmbiguousLink = "AmbiguousLink"
+  warnRstBrokenLink = "BrokenLink"
+  warnRstLanguageXNotSupported = "LanguageXNotSupported"
+  warnRstFieldXNotSupported = "FieldXNotSupported"
+  warnRstUnusedImportdoc = "UnusedImportdoc"
+  warnRstStyle = "warnRstStyle"
+  warnCommentXIgnored = "CommentXIgnored"
+  warnTypelessParam = "TypelessParam"
+  warnUseBase = "UseBase"
+  warnWriteToForeignHeap = "WriteToForeignHeap"
+  warnUnsafeCode = "UnsafeCode"
+  warnUnusedImportX = "UnusedImport"
+  warnInheritFromException = "InheritFromException"
+  warnEachIdentIsTuple = "EachIdentIsTuple"
+  warnUnsafeSetLen = "UnsafeSetLen"
+  warnUnsafeDefault = "UnsafeDefault"
+  warnProveInit = "ProveInit"
+  warnProveField = "ProveField"
+  warnProveIndex = "ProveIndex"
+  warnUnreachableElse = "UnreachableElse"
+  warnUnreachableCode = "UnreachableCode"
+  warnStaticIndexCheck = "IndexCheck"
+  warnGcUnsafe = "GcUnsafe"
+  warnGcUnsafe2 = "GcUnsafe2"
+  warnUninit = "Uninit"
+  warnGcMem = "GcMem"
+  warnDestructor = "Destructor"
+  warnLockLevel = "LockLevel" # deadcode
+  warnResultShadowed = "ResultShadowed"
+  warnInconsistentSpacing = "Spacing"
+  warnCaseTransition = "CaseTransition"
+  warnCycleCreated = "CycleCreated"
+  warnObservableStores = "ObservableStores"
+  warnStrictNotNil = "StrictNotNil"
+  warnResultUsed = "ResultUsed"
+  warnCannotOpen = "CannotOpen"
+  warnFileChanged = "FileChanged"
+  warnSuspiciousEnumConv = "EnumConv"
+  warnAnyEnumConv = "AnyEnumConv"
+  warnHoleEnumConv = "HoleEnumConv"
+  warnCstringConv = "CStringConv"
+  warnPtrToCstringConv = "PtrToCstringConv"
+  warnEffect = "Effect"
+  warnCastSizes = "CastSizes" # deadcode
+  warnAboveMaxSizeSet = "AboveMaxSizeSet"
+  warnImplicitTemplateRedefinition = "ImplicitTemplateRedefinition"
+  warnUnnamedBreak = "UnnamedBreak"
+  warnStmtListLambda = "StmtListLambda"
+  warnBareExcept = "BareExcept"
+  warnImplicitDefaultValue = "ImplicitDefaultValue"
+  warnUser = "User" # hints
+  hintSuccess = "Success"
+  hintSuccessX = "SuccessX"
+  hintCC = "CC"
+  hintXDeclaredButNotUsed = "XDeclaredButNotUsed"
+  hintDuplicateModuleImport = "DuplicateModuleImport"
+  hintXCannotRaiseY = "XCannotRaiseY"
+  hintConvToBaseNotNeeded = "ConvToBaseNotNeeded"
+  hintConvFromXtoItselfNotNeeded = "ConvFromXtoItselfNotNeeded"
+  hintExprAlwaysX = "ExprAlwaysX"
+  hintQuitCalled = "QuitCalled"
+  hintProcessing = "Processing"
+  hintProcessingStmt = "ProcessingStmt"
+  hintCodeBegin = "CodeBegin"
+  hintCodeEnd = "CodeEnd"
+  hintConf = "Conf"
+  hintPath = "Path"
+  hintConditionAlwaysTrue = "CondTrue"
+  hintConditionAlwaysFalse = "CondFalse"
+  hintName = "Name"
+  hintPattern = "Pattern"
+  hintExecuting = "Exec"
+  hintLinking = "Link"
+  hintDependency = "Dependency"
+  hintSource = "Source"
+  hintPerformance = "Performance"
+  hintStackTrace = "StackTrace"
+  hintGCStats = "GCStats"
+  hintGlobalVar = "GlobalVar"
+  hintExpandMacro = "ExpandMacro"
+  hintAmbiguousEnum = "AmbiguousEnum"
+  hintUser = "User"
+  hintUserRaw = "UserRaw"
+  hintExtendedContext = "ExtendedContext"
+  hintMsgOrigin = "MsgOrigin" # since 1.3.5
+  hintDeclaredLoc = "DeclaredLoc" # since 1.5.1
 
-const
-  MsgKindToStr*: array[TMsgKind, string] =
-    [
-      errUnknown: "unknown error",
-      errFatal: "fatal error: $1",
-      errInternal: "internal error: $1",
-      errIllFormedAstX: "illformed AST: $1",
-      errCannotOpenFile: "cannot open '$1'",
-      errXExpected: "'$1' expected",
-      errRstMissingClosing: "$1",
-      errRstGridTableNotImplemented: "grid table is not implemented",
-      errRstMarkdownIllformedTable: "illformed delimiter row of a markdown table",
-      errRstIllformedTable: "Illformed table: $1",
-      errRstNewSectionExpected: "new section expected $1",
-      errRstGeneralParseError: "general parse error",
-      errRstInvalidDirectiveX: "invalid directive: '$1'",
-      errRstInvalidField: "invalid field: $1",
-      errRstFootnoteMismatch: "number of footnotes and their references don't match: $1",
-      errRstSandboxedDirective: "disabled directive: '$1'",
-      errProveInit: "Cannot prove that '$1' is initialized.", # deadcode
-      errGenerated: "$1",
-      errFailedMove: "$1",
-      errUser: "$1",
-      warnCannotOpenFile: "cannot open '$1'",
-      warnOctalEscape: "octal escape sequences do not exist; leading zero is ignored",
-      warnXIsNeverRead: "'$1' is never read",
-      warnXmightNotBeenInit: "'$1' might not have been initialized",
-      warnDeprecated: "$1",
-      warnConfigDeprecated: "config file '$1' is deprecated",
-      warnDotLikeOps: "$1",
-      warnSmallLshouldNotBeUsed:
-        "'l' should not be used as an identifier; may look like '1' (one)",
-      warnUnknownMagic: "unknown magic '$1' might crash the compiler",
-      warnRstRedefinitionOfLabel: "redefinition of label '$1'",
-      warnRstUnknownSubstitutionX: "unknown substitution '$1'",
-      warnRstAmbiguousLink: "ambiguous doc link $1",
-      warnRstBrokenLink: "broken link '$1'",
-      warnRstLanguageXNotSupported: "language '$1' not supported",
-      warnRstFieldXNotSupported: "field '$1' not supported",
-      warnRstUnusedImportdoc: "importdoc for '$1' is not used",
-      warnRstStyle: "RST style: $1",
-      warnCommentXIgnored: "comment '$1' ignored",
-      warnTypelessParam: "", # deadcode
-      warnUseBase: "use {.base.} for base methods; baseless methods are deprecated",
-      warnWriteToForeignHeap: "write to foreign heap",
-      warnUnsafeCode: "unsafe code: '$1'",
-      warnUnusedImportX: "imported and not used: '$1'",
-      warnInheritFromException:
-        "inherit from a more precise exception type like ValueError, " & "IOError or OSError. If these don't suit, inherit from CatchableError or Defect.",
-      warnEachIdentIsTuple: "each identifier is a tuple",
-      warnUnsafeSetLen:
-        "setLen can potentially expand the sequence, " & "but the element type '$1' doesn't have a valid default value",
-      warnUnsafeDefault: "The '$1' type doesn't have a valid default value",
-      warnProveInit:
-        "Cannot prove that '$1' is initialized. This will become a compile time error in the future.",
-      warnProveField: "cannot prove that field '$1' is accessible",
-      warnProveIndex: "cannot prove index '$1' is valid",
-      warnUnreachableElse: "unreachable else, all cases are already covered",
-      warnUnreachableCode:
-        "unreachable code after 'return' statement or '{.noReturn.}' proc",
-      warnStaticIndexCheck: "$1",
-      warnGcUnsafe: "not GC-safe: '$1'",
-      warnGcUnsafe2: "$1",
-      warnUninit: "use explicit initialization of '$1' for clarity",
-      warnGcMem: "'$1' uses GC'ed memory",
-      warnDestructor:
-        "usage of a type with a destructor in a non destructible context. This will become a compile time error in the future.",
-      warnLockLevel: "$1", # deadcode
-      warnResultShadowed: "Special variable 'result' is shadowed.",
-      warnInconsistentSpacing: "Number of spaces around '$#' is not consistent",
-      warnCaseTransition:
-        "Potential object case transition, instantiate new object instead",
-      warnCycleCreated: "$1",
-      warnObservableStores: "observable stores to '$1'",
-      warnStrictNotNil: "$1",
-      warnResultUsed: "used 'result' variable",
-      warnCannotOpen: "cannot open: $1",
-      warnFileChanged: "file changed: $1",
-      warnSuspiciousEnumConv: "$1",
-      warnAnyEnumConv: "$1",
-      warnHoleEnumConv: "$1",
-      warnCstringConv: "$1",
-      warnPtrToCstringConv:
-        "unsafe conversion to 'cstring' from '$1'; this will become a compile time error in the future",
-      warnEffect: "$1",
-      warnCastSizes: "$1", # deadcode
-      warnAboveMaxSizeSet: "$1",
-      warnImplicitTemplateRedefinition:
-        "template '$1' is implicitly redefined; this is deprecated, add an explicit .redefine pragma",
-      warnUnnamedBreak:
-        "Using an unnamed break in a block is deprecated; Use a named block with a named break instead",
-      warnStmtListLambda:
-        "statement list expression assumed to be anonymous proc; this is deprecated, use `do (): ...` or `proc () = ...` instead",
-      warnBareExcept: "$1",
-      warnImplicitDefaultValue: "$1",
-      warnUser: "$1",
-      hintSuccess: "operation successful: $#",
-      # keep in sync with `testament.isSuccess`
-      hintSuccessX: "$build\n$loc lines; ${sec}s; $mem; proj: $project; out: $output",
-      hintCC: "CC: $1",
-      hintXDeclaredButNotUsed: "'$1' is declared but not used",
-      hintDuplicateModuleImport: "$1",
-      hintXCannotRaiseY: "$1",
-      hintConvToBaseNotNeeded: "conversion to base object is not needed",
-      hintConvFromXtoItselfNotNeeded: "conversion from $1 to itself is pointless",
-      hintExprAlwaysX: "expression evaluates always to '$1'",
-      hintQuitCalled: "quit() called",
-      hintProcessing: "$1",
-      hintProcessingStmt: "$1",
-      hintCodeBegin: "generated code listing:",
-      hintCodeEnd: "end of listing",
-      hintConf: "used config file '$1'",
-      hintPath: "added path: '$1'",
-      hintConditionAlwaysTrue: "condition is always true: '$1'",
-      hintConditionAlwaysFalse: "condition is always false: '$1'",
-      hintName: "$1",
-      hintPattern: "$1",
-      hintExecuting: "$1",
-      hintLinking: "$1",
-      hintDependency: "$1",
-      hintSource: "$1",
-      hintPerformance: "$1",
-      hintStackTrace: "$1",
-      hintGCStats: "$1",
-      hintGlobalVar: "global variable declared here",
-      hintExpandMacro: "expanded macro: $1",
-      hintAmbiguousEnum: "$1",
-      hintUser: "$1",
-      hintUserRaw: "$1",
-      hintExtendedContext: "$1",
-      hintMsgOrigin: "$1",
-      hintDeclaredLoc: "$1"
-    ]
+const MsgKindToStr*: array[TMsgKind, string] =
+  [
+    errUnknown: "unknown error",
+    errFatal: "fatal error: $1",
+    errInternal: "internal error: $1",
+    errIllFormedAstX: "illformed AST: $1",
+    errCannotOpenFile: "cannot open '$1'",
+    errXExpected: "'$1' expected",
+    errRstMissingClosing: "$1",
+    errRstGridTableNotImplemented: "grid table is not implemented",
+    errRstMarkdownIllformedTable: "illformed delimiter row of a markdown table",
+    errRstIllformedTable: "Illformed table: $1",
+    errRstNewSectionExpected: "new section expected $1",
+    errRstGeneralParseError: "general parse error",
+    errRstInvalidDirectiveX: "invalid directive: '$1'",
+    errRstInvalidField: "invalid field: $1",
+    errRstFootnoteMismatch: "number of footnotes and their references don't match: $1",
+    errRstSandboxedDirective: "disabled directive: '$1'",
+    errProveInit: "Cannot prove that '$1' is initialized.", # deadcode
+    errGenerated: "$1",
+    errFailedMove: "$1",
+    errUser: "$1",
+    warnCannotOpenFile: "cannot open '$1'",
+    warnOctalEscape: "octal escape sequences do not exist; leading zero is ignored",
+    warnXIsNeverRead: "'$1' is never read",
+    warnXmightNotBeenInit: "'$1' might not have been initialized",
+    warnDeprecated: "$1",
+    warnConfigDeprecated: "config file '$1' is deprecated",
+    warnDotLikeOps: "$1",
+    warnSmallLshouldNotBeUsed:
+      "'l' should not be used as an identifier; may look like '1' (one)",
+    warnUnknownMagic: "unknown magic '$1' might crash the compiler",
+    warnRstRedefinitionOfLabel: "redefinition of label '$1'",
+    warnRstUnknownSubstitutionX: "unknown substitution '$1'",
+    warnRstAmbiguousLink: "ambiguous doc link $1",
+    warnRstBrokenLink: "broken link '$1'",
+    warnRstLanguageXNotSupported: "language '$1' not supported",
+    warnRstFieldXNotSupported: "field '$1' not supported",
+    warnRstUnusedImportdoc: "importdoc for '$1' is not used",
+    warnRstStyle: "RST style: $1",
+    warnCommentXIgnored: "comment '$1' ignored",
+    warnTypelessParam: "", # deadcode
+    warnUseBase: "use {.base.} for base methods; baseless methods are deprecated",
+    warnWriteToForeignHeap: "write to foreign heap",
+    warnUnsafeCode: "unsafe code: '$1'",
+    warnUnusedImportX: "imported and not used: '$1'",
+    warnInheritFromException:
+      "inherit from a more precise exception type like ValueError, " &
+        "IOError or OSError. If these don't suit, inherit from CatchableError or Defect.",
+    warnEachIdentIsTuple: "each identifier is a tuple",
+    warnUnsafeSetLen:
+      "setLen can potentially expand the sequence, " &
+        "but the element type '$1' doesn't have a valid default value",
+    warnUnsafeDefault: "The '$1' type doesn't have a valid default value",
+    warnProveInit:
+      "Cannot prove that '$1' is initialized. This will become a compile time error in the future.",
+    warnProveField: "cannot prove that field '$1' is accessible",
+    warnProveIndex: "cannot prove index '$1' is valid",
+    warnUnreachableElse: "unreachable else, all cases are already covered",
+    warnUnreachableCode:
+      "unreachable code after 'return' statement or '{.noReturn.}' proc",
+    warnStaticIndexCheck: "$1",
+    warnGcUnsafe: "not GC-safe: '$1'",
+    warnGcUnsafe2: "$1",
+    warnUninit: "use explicit initialization of '$1' for clarity",
+    warnGcMem: "'$1' uses GC'ed memory",
+    warnDestructor:
+      "usage of a type with a destructor in a non destructible context. This will become a compile time error in the future.",
+    warnLockLevel: "$1", # deadcode
+    warnResultShadowed: "Special variable 'result' is shadowed.",
+    warnInconsistentSpacing: "Number of spaces around '$#' is not consistent",
+    warnCaseTransition:
+      "Potential object case transition, instantiate new object instead",
+    warnCycleCreated: "$1",
+    warnObservableStores: "observable stores to '$1'",
+    warnStrictNotNil: "$1",
+    warnResultUsed: "used 'result' variable",
+    warnCannotOpen: "cannot open: $1",
+    warnFileChanged: "file changed: $1",
+    warnSuspiciousEnumConv: "$1",
+    warnAnyEnumConv: "$1",
+    warnHoleEnumConv: "$1",
+    warnCstringConv: "$1",
+    warnPtrToCstringConv:
+      "unsafe conversion to 'cstring' from '$1'; this will become a compile time error in the future",
+    warnEffect: "$1",
+    warnCastSizes: "$1", # deadcode
+    warnAboveMaxSizeSet: "$1",
+    warnImplicitTemplateRedefinition:
+      "template '$1' is implicitly redefined; this is deprecated, add an explicit .redefine pragma",
+    warnUnnamedBreak:
+      "Using an unnamed break in a block is deprecated; Use a named block with a named break instead",
+    warnStmtListLambda:
+      "statement list expression assumed to be anonymous proc; this is deprecated, use `do (): ...` or `proc () = ...` instead",
+    warnBareExcept: "$1",
+    warnImplicitDefaultValue: "$1",
+    warnUser: "$1",
+    hintSuccess: "operation successful: $#",
+    # keep in sync with `testament.isSuccess`
+    hintSuccessX: "$build\n$loc lines; ${sec}s; $mem; proj: $project; out: $output",
+    hintCC: "CC: $1",
+    hintXDeclaredButNotUsed: "'$1' is declared but not used",
+    hintDuplicateModuleImport: "$1",
+    hintXCannotRaiseY: "$1",
+    hintConvToBaseNotNeeded: "conversion to base object is not needed",
+    hintConvFromXtoItselfNotNeeded: "conversion from $1 to itself is pointless",
+    hintExprAlwaysX: "expression evaluates always to '$1'",
+    hintQuitCalled: "quit() called",
+    hintProcessing: "$1",
+    hintProcessingStmt: "$1",
+    hintCodeBegin: "generated code listing:",
+    hintCodeEnd: "end of listing",
+    hintConf: "used config file '$1'",
+    hintPath: "added path: '$1'",
+    hintConditionAlwaysTrue: "condition is always true: '$1'",
+    hintConditionAlwaysFalse: "condition is always false: '$1'",
+    hintName: "$1",
+    hintPattern: "$1",
+    hintExecuting: "$1",
+    hintLinking: "$1",
+    hintDependency: "$1",
+    hintSource: "$1",
+    hintPerformance: "$1",
+    hintStackTrace: "$1",
+    hintGCStats: "$1",
+    hintGlobalVar: "global variable declared here",
+    hintExpandMacro: "expanded macro: $1",
+    hintAmbiguousEnum: "$1",
+    hintUser: "$1",
+    hintUserRaw: "$1",
+    hintExtendedContext: "$1",
+    hintMsgOrigin: "$1",
+    hintDeclaredLoc: "$1"
+  ]
 const
   fatalMsgs* = {errUnknown .. errInternal}
   errMin* = errUnknown
@@ -297,21 +296,21 @@ type
 
 proc computeNotesVerbosity(): array[0 .. 3, TNoteKinds] =
   result[3] =
-    {low(TNoteKind) .. high(TNoteKind)} - {
-        warnObservableStores, warnResultUsed, warnAnyEnumConv, warnBareExcept
-      }
+    {low(TNoteKind) .. high(TNoteKind)} -
+      {warnObservableStores, warnResultUsed, warnAnyEnumConv, warnBareExcept}
   result[2] =
-    result[3] - {
-        hintStackTrace, hintExtendedContext, hintDeclaredLoc, hintProcessingStmt
-      }
+    result[3] -
+      {hintStackTrace, hintExtendedContext, hintDeclaredLoc, hintProcessingStmt}
   result[1] =
-    result[2] - {
+    result[2] -
+      {
         warnProveField, warnProveIndex, warnGcUnsafe, hintPath, hintDependency,
         hintCodeBegin, hintCodeEnd, hintSource, hintGlobalVar, hintGCStats,
         hintMsgOrigin, hintPerformance
       }
   result[0] =
-    result[1] - {
+    result[1] -
+      {
         hintSuccessX, hintSuccess, hintConf, hintProcessing, hintPattern, hintExecuting,
         hintLinking, hintCC
       }
@@ -380,11 +379,10 @@ const
   InvalidFileIdx* = FileIndex(-1)
   unknownLineInfo* = TLineInfo(line: 0, col: -1, fileIndex: InvalidFileIdx)
 
-type
-  Severity* {.pure.} = enum ## VS Code only supports these three
-    Hint
-    Warning
-    Error
+type Severity* {.pure.} = enum ## VS Code only supports these three
+  Hint
+  Warning
+  Error
 
 const
   trackPosInvalidFileIdx* = FileIndex(-2)
@@ -392,18 +390,17 @@ const
       # are produced within comments and string literals
   commandLineIdx* = FileIndex(-3)
 
-type
-  MsgConfig* = object ## does not need to be stored in the incremental cache
-    trackPos*: TLineInfo
-    trackPosAttached*: bool
-      ## whether the tracking position was attached to
-      ## some close token.
-    errorOutputs*: TErrorOutputs
-    msgContext*: seq[tuple[info: TLineInfo, detail: string]]
-    lastError*: TLineInfo
-    filenameToIndexTbl*: Table[string, FileIndex]
-    fileInfos*: seq[TFileInfo]
-    systemFileIdx*: FileIndex
+type MsgConfig* = object ## does not need to be stored in the incremental cache
+  trackPos*: TLineInfo
+  trackPosAttached*: bool
+    ## whether the tracking position was attached to
+    ## some close token.
+  errorOutputs*: TErrorOutputs
+  msgContext*: seq[tuple[info: TLineInfo, detail: string]]
+  lastError*: TLineInfo
+  filenameToIndexTbl*: Table[string, FileIndex]
+  fileInfos*: seq[TFileInfo]
+  systemFileIdx*: FileIndex
 
 proc initMsgConfig*(): MsgConfig =
   result.msgContext = @[]

--- a/src/phoptions.nim
+++ b/src/phoptions.nim
@@ -12,15 +12,13 @@
 import
   std/[os, strutils, strtabs, sets, tables],
   "$nim"/compiler/[platform, prefixmatches, pathutils, nimpaths]
-import
-  ./phlineinfos
+import ./phlineinfos
 
 from std/terminal import isatty
 from std/times import utc, fromUnix, local, getTime, format, DateTime
 from std/private/globs import nativeToUnixPath
 when defined(nimPreviewSlimSystem):
-  import
-    std/[syncio, assertions]
+  import std/[syncio, assertions]
 
 const
   hasTinyCBackend* = defined(tinyc)
@@ -466,7 +464,7 @@ type
     lastLineInfo*: TLineInfo
     writelnHook*: proc(output: string) {.closure, gcsafe.}
     structuredErrorHook*: proc(
-        config: ConfigRef; info: TLineInfo; msg: string; severity: Severity
+      config: ConfigRef; info: TLineInfo; msg: string; severity: Severity
     ) {.closure, gcsafe.}
     cppCustomNamespace*: string
     nimMainPrefix*: string
@@ -542,8 +540,7 @@ when false:
     fn(globalOptions)
     fn(selectedGC)
 
-const
-  oldExperimentalFeatures* = {dotOperators, callOperator, parallel}
+const oldExperimentalFeatures* = {dotOperators, callOperator, parallel}
 const
   ChecksOptions* =
     {
@@ -581,17 +578,14 @@ template newPackageCache*(): untyped =
       modeCaseInsensitive
     else:
       modeCaseSensitive
+    ,
   )
 
 proc newProfileData(): ProfileData =
   ProfileData(data: newTable[TLineInfo, ProfileInfo]())
 
-const
-  foreignPackageNotesDefault* =
-    {
-      hintProcessing, warnUnknownMagic, hintQuitCalled, hintExecuting, hintUser,
-      warnUser
-    }
+const foreignPackageNotesDefault* =
+  {hintProcessing, warnUnknownMagic, hintQuitCalled, hintExecuting, hintUser, warnUser}
 
 proc isDefined*(conf: ConfigRef; symbol: string): bool
 
@@ -664,7 +658,7 @@ proc newConfigRef*(): ConfigRef =
       suggestMaxResults: 10_000,
       maxLoopIterationsVM: 10_000_000,
       vmProfileData: newProfileData(),
-      spellSuggestMax: spellSuggestSecretSauce
+      spellSuggestMax: spellSuggestSecretSauce,
     )
 
   initConfigRefCommon(result)
@@ -712,7 +706,8 @@ proc isDefined*(conf: ConfigRef; symbol: string): bool =
       result = conf.target.targetCPU == cpuAmd64
     of "posix", "unix":
       result =
-        conf.target.targetOS in {
+        conf.target.targetOS in
+          {
             osLinux, osMorphos, osSkyos, osIrix, osPalmos, osQnx, osAtari, osAix,
             osHaiku, osVxWorks, osSolaris, osNetbsd, osFreebsd, osOpenbsd, osDragonfly,
             osMacosx, osIos, osAndroid, osNintendoSwitch, osFreeRTOS, osCrossos,
@@ -759,9 +754,8 @@ proc isDefined*(conf: ConfigRef; symbol: string): bool =
       result = CPU[conf.target.targetCPU].bit == 64
     of "nimrawsetjmp":
       result =
-        conf.target.targetOS in {
-            osSolaris, osNetbsd, osFreebsd, osOpenbsd, osDragonfly, osMacosx
-          }
+        conf.target.targetOS in
+          {osSolaris, osNetbsd, osFreebsd, osOpenbsd, osDragonfly, osMacosx}
     else:
       discard
 
@@ -858,14 +852,11 @@ proc setDefaultLibpath*(conf: ConfigRef) =
 
     # Special rule to support other tools (nimble) which import the compiler
     # modules and make use of them.
-    let
-      realNimPath = findExe("nim")
+    let realNimPath = findExe("nim")
     # Find out if $nim/../../lib/system.nim exists.
-    let
-      parentNimLibPath = realNimPath.parentDir.parentDir / "lib"
-    if not fileExists(conf.libpath.string / "system.nim") and fileExists(
-        parentNimLibPath / "system.nim"
-      ):
+    let parentNimLibPath = realNimPath.parentDir.parentDir / "lib"
+    if not fileExists(conf.libpath.string / "system.nim") and
+        fileExists(parentNimLibPath / "system.nim"):
       conf.libpath = AbsoluteDir parentNimLibPath
 
 proc canonicalizePath*(conf: ConfigRef; path: AbsoluteFile): AbsoluteFile =
@@ -903,8 +894,7 @@ proc clearNimblePath*(conf: ConfigRef) =
   conf.lazyPaths.setLen(0)
   conf.nimblePaths.setLen(0)
 
-include
-  "$nim"/compiler/packagehandling
+include "$nim"/compiler/packagehandling
 
 proc getOsCacheDir(): string =
   when defined(posix):
@@ -940,7 +930,8 @@ proc pathSubs*(conf: ConfigRef; p, config: string): string =
 
   result =
     unixToNativePath(
-      p % [
+      p %
+        [
           "nim",
           getPrefixDir(conf).string,
           "lib",
@@ -957,7 +948,7 @@ proc pathSubs*(conf: ConfigRef; p, config: string): string =
           conf.projectPath.string,
           "nimcache",
           getNimcacheDir(conf).string
-        ]
+        ],
     ).expandTilde
 
 iterator nimbleSubs*(conf: ConfigRef; p: string): string =
@@ -1020,23 +1011,12 @@ template patchModule(conf: ConfigRef) {.dirty.} =
       if ov.len > 0:
         result = AbsoluteFile(ov)
 
-const
-  stdlibDirs* =
-    [
-      "pure",
-      "core",
-      "arch",
-      "pure/collections",
-      "pure/concurrency",
-      "pure/unidecode",
-      "impure",
-      "wrappers",
-      "wrappers/linenoise",
-      "windows",
-      "posix",
-      "js",
-      "deprecated/pure"
-    ]
+const stdlibDirs* =
+  [
+    "pure", "core", "arch", "pure/collections", "pure/concurrency", "pure/unidecode",
+    "impure", "wrappers", "wrappers/linenoise", "windows", "posix", "js",
+    "deprecated/pure"
+  ]
 const
   pkgPrefix = "pkg/"
   stdPrefix = "std/"
@@ -1106,8 +1086,7 @@ proc findModule*(conf: ConfigRef; modulename, currentModule: string): AbsoluteFi
   patchModule(conf)
 
 proc findProjectNimFile*(conf: ConfigRef; pkg: string): string =
-  const
-    extensions = [".nims", ".cfg", ".nimcfg", ".nimble"]
+  const extensions = [".nims", ".cfg", ".nimcfg", ".nimble"]
 
   var
     candidates: seq[string] = @[]
@@ -1196,9 +1175,8 @@ proc inclDynlibOverride*(conf: ConfigRef; lib: string) =
 
 proc isDynlibOverride*(conf: ConfigRef; lib: string): bool =
   result =
-    optDynlibOverrideAll in conf.globalOptions or conf.dllOverrides.hasKey(
-        lib.canonDynlibName
-      )
+    optDynlibOverrideAll in conf.globalOptions or
+      conf.dllOverrides.hasKey(lib.canonDynlibName)
 
 proc showNonExportedFields*(conf: ConfigRef) =
   incl(conf.globalOptions, optShowNonExportedFields)

--- a/src/phparser.nim
+++ b/src/phparser.nim
@@ -32,13 +32,10 @@
 # that the lexer is trying to do comment layout / reflow / analysis in the
 # middle of lexing..
 
-import
-  "$nim"/compiler/[llstream, idents, pathutils], std/[strutils]
-import
-  "."/[phast, phlexer, phlineinfos, phmsgs, phoptions]
+import "$nim"/compiler/[llstream, idents, pathutils], std/[strutils]
+import "."/[phast, phlexer, phlineinfos, phmsgs, phoptions]
 when defined(nimPreviewSlimSystem):
-  import
-    std/assertions
+  import std/assertions
 
 type
   Parser* = object
@@ -106,7 +103,7 @@ proc optPar*(p: var Parser)
 proc optInd*(p: var Parser; n: PNode; commentLoc = clPostfix)
 
 proc indAndComment*(
-    p: var Parser; n: PNode; commentLoc = clPostfix; maybeMissEquals = false
+  p: var Parser; n: PNode; commentLoc = clPostfix; maybeMissEquals = false
 )
 
 proc setBaseFlags*(n: PNode; base: NumericalBase)
@@ -151,7 +148,7 @@ proc openParser*(
     inputStream: PLLStream;
     cache: IdentCache;
     config: ConfigRef;
-    printTokens: bool
+    printTokens: bool;
 ) =
   ## Open a parser, using the given arguments to set up its internal state.
   ##
@@ -168,7 +165,7 @@ proc openParser*(
     inputStream: PLLStream;
     cache: IdentCache;
     config: ConfigRef;
-    printTokens: bool
+    printTokens: bool;
 ) =
   openParser(p, fileInfoIdx(config, filename), inputStream, cache, config, printTokens)
 
@@ -225,9 +222,8 @@ proc addComment(node: PNode; tok: Token; commentLoc: CommentLoc) =
 proc rawSkipComment(
     p: var Parser; node: PNode; commentLoc = clPostfix; ind = 0; maxInd = int.high
 ) =
-  while p.tok.tokType == tkComment and (
-      p.tok.indent == -1 or (p.tok.indent >= ind and p.tok.indent < maxInd)
-    ):
+  while p.tok.tokType == tkComment and
+      (p.tok.indent == -1 or (p.tok.indent >= ind and p.tok.indent < maxInd)):
     # debugEcho "rsk ", p.tok.indent, " ", ind, " ", maxInd, " ", $p.tok
     if node != nil:
       addComment(node, p.tok, commentLoc)
@@ -292,7 +288,7 @@ proc eat(p: var Parser; tokType: TokType) =
     lexMessage(
       p.lex,
       errGenerated,
-      "expected: '" & $tokType & "', but got: '" & prettyTok(p.tok) & "'"
+      "expected: '" & $tokType & "', but got: '" & prettyTok(p.tok) & "'",
     )
 
 proc parLineInfo(p: Parser): TLineInfo =
@@ -411,7 +407,8 @@ proc isOperator(tok: Token): bool =
   #| operatorB = OP0 | OP1 | OP2 | OP3 | OP4 | OP5 | OP6 | OP7 | OP8 | OP9 |
   #|             'div' | 'mod' | 'shl' | 'shr' | 'in' | 'notin' |
   #|             'is' | 'isnot' | 'not' | 'of' | 'as' | 'from' | '..' | 'and' | 'or' | 'xor'
-  tok.tokType in {
+  tok.tokType in
+    {
       tkOpr, tkDiv, tkMod, tkShl, tkShr, tkIn, tkNotin, tkIs, tkIsnot, tkNot, tkOf,
       tkAs, tkFrom, tkDotDot, tkAnd, tkOr, tkXor
     }
@@ -431,8 +428,7 @@ proc parseColComStmt(p: var Parser; n: PNode; commentLoc = clPostfix): PNode =
   eat(p, tkColon)
   parseComStmt(p, n, commentLoc)
 
-const
-  tkBuiltInMagics = {tkType, tkStatic, tkAddr}
+const tkBuiltInMagics = {tkType, tkStatic, tkAddr}
 
 template setEndInfo() =
   # TODO nimsuggest leftover
@@ -562,8 +558,7 @@ proc exprList(p: var Parser; endTok: TokType; result: PNode) =
   skipInd(p)
 
   # progress guaranteed
-  var
-    a = parseExpr(p)
+  var a = parseExpr(p)
 
   result.add(a)
   while (p.tok.tokType != endTok) and (p.tok.tokType != tkEof):
@@ -826,10 +821,11 @@ proc parsePar(p: var Parser): PNode =
   p.skipped = commentLookahead(p)
 
   skipInd(p)
-  if p.tok.tokType in {
-      tkDiscard, tkInclude, tkIf, tkWhile, tkCase, tkTry, tkDefer, tkFinally, tkExcept,
-      tkBlock, tkConst, tkLet, tkWhen, tkVar, tkFor, tkMixin
-    }:
+  if p.tok.tokType in
+      {
+        tkDiscard, tkInclude, tkIf, tkWhile, tkCase, tkTry, tkDefer, tkFinally,
+        tkExcept, tkBlock, tkConst, tkLet, tkWhen, tkVar, tkFor, tkMixin
+      }:
     # XXX 'bind' used to be an expression, so we exclude it here;
     # tests/reject/tbind2 fails otherwise.
     semiStmtList(p, result)
@@ -1077,8 +1073,8 @@ proc commandExpr(p: var Parser; r: PNode; mode: PrimaryMode): PNode =
 
 proc isDotLike(tok: Token): bool =
   result =
-    tok.tokType == tkOpr and tok.ident.s.len > 1 and tok.ident.s[0] == '.' and tok.ident.s[
-        1] != '.'
+    tok.tokType == tkOpr and tok.ident.s.len > 1 and tok.ident.s[0] == '.' and
+      tok.ident.s[1] != '.'
 
 proc primarySuffix(p: var Parser; r: PNode; baseIndent: int; mode: PrimaryMode): PNode =
   #| primarySuffix = '(' (exprColonEqExpr comma?)* ')'
@@ -1125,21 +1121,22 @@ proc primarySuffix(p: var Parser; r: PNode; baseIndent: int; mode: PrimaryMode):
         break
 
       result = namedParams(p, result, nkCurlyExpr, tkCurlyRi)
-    of tkSymbol,
-      tkAccent,
-      tkIntLit .. tkCustomLit,
-      tkNil,
-      tkCast,
-      tkOpr,
-      tkDotDot,
-      tkVar,
-      tkOut,
-      tkStatic,
-      tkType,
-      tkEnum,
-      tkTuple,
-      tkObject,
-      tkProc:
+    of
+        tkSymbol,
+        tkAccent,
+        tkIntLit .. tkCustomLit,
+        tkNil,
+        tkCast,
+        tkOpr,
+        tkDotDot,
+        tkVar,
+        tkOut,
+        tkStatic,
+        tkType,
+        tkEnum,
+        tkTuple,
+        tkObject,
+        tkProc:
       # XXX: In type sections we allow the free application of the
       # command syntax, with the exception of expressions such as
       # `foo ref` or `foo ptr`. Unfortunately, these two are also
@@ -1153,8 +1150,7 @@ proc primarySuffix(p: var Parser; r: PNode; baseIndent: int; mode: PrimaryMode):
       else:
         if isDotLike2:
           parMessage(
-            p,
-            warnDotLikeOps,
+            p, warnDotLikeOps,
             "dot-like operators will be parsed differently with `-d:nimPreviewDotLikeOps`"
           )
         if p.inPragma == 0 and (isUnary(p.tok) or p.tok.tokType notin {tkOpr, tkDotDot}):
@@ -1172,8 +1168,7 @@ proc parseOperators(
   result = headNode
 
   # expand while operators have priorities higher than 'limit'
-  var
-    opPrec = getPrecedence(p.tok)
+  var opPrec = getPrecedence(p.tok)
 
   let modeB =
     if mode == pmTypeDef:
@@ -1195,8 +1190,7 @@ proc parseOperators(
     optPar(p)
 
     # read sub-expression with higher priority:
-    var
-      b = simpleExprAux(p, opPrec + leftAssoc, modeB)
+    var b = simpleExprAux(p, opPrec + leftAssoc, modeB)
 
     a.add(opNode)
     a.add(result)
@@ -1213,7 +1207,8 @@ proc simpleExprAux(p: var Parser; limit: int; mode: PrimaryMode): PNode =
   result = primary(p, mode)
   if mode == pmTrySimple:
     mode = pmNormal
-  if p.tok.tokType == tkCurlyDotLe and (p.tok.indent < 0 or realInd(p)) and mode == pmNormal:
+  if p.tok.tokType == tkCurlyDotLe and (p.tok.indent < 0 or realInd(p)) and
+      mode == pmNormal:
     var pragmaExp = newNodeP(nkPragmaExpr, p)
 
     pragmaExp.add result
@@ -1488,7 +1483,7 @@ proc parseDoBlock(p: var Parser; info: TLineInfo): PNode =
       pattern = p.emptyNode,
       genericParams = p.emptyNode,
       pragmas = pragmas,
-      exceptions = p.emptyNode
+      exceptions = p.emptyNode,
     )
 
   let body = parseColComStmt(p, result, clMid)
@@ -1531,7 +1526,7 @@ proc parseProcExpr(p: var Parser; isExpr: bool; kind: TNodeKind): PNode =
         pattern = p.emptyNode,
         genericParams = p.emptyNode,
         pragmas = pragmas,
-        exceptions = p.emptyNode
+        exceptions = p.emptyNode,
       )
     result[bodyPos] = parseComStmt(p, result, clMid)
   else:
@@ -1542,7 +1537,7 @@ proc parseProcExpr(p: var Parser; isExpr: bool; kind: TNodeKind): PNode =
         else:
           nkProcTy
         ,
-        info
+        info,
       )
     if hasSignature or pragmas.kind != nkEmpty:
       if hasSignature:
@@ -1561,34 +1556,35 @@ proc parseProcExpr(p: var Parser; isExpr: bool; kind: TNodeKind): PNode =
 
 proc isExprStart(p: Parser): bool =
   case p.tok.tokType
-  of tkSymbol,
-    tkAccent,
-    tkOpr,
-    tkNot,
-    tkNil,
-    tkCast,
-    tkIf,
-    tkFor,
-    tkProc,
-    tkFunc,
-    tkIterator,
-    tkBind,
-    tkBuiltInMagics,
-    tkParLe,
-    tkBracketLe,
-    tkCurlyLe,
-    tkIntLit .. tkCustomLit,
-    tkVar,
-    tkRef,
-    tkPtr,
-    tkEnum,
-    tkTuple,
-    tkObject,
-    tkWhen,
-    tkCase,
-    tkOut,
-    tkTry,
-    tkBlock:
+  of
+      tkSymbol,
+      tkAccent,
+      tkOpr,
+      tkNot,
+      tkNil,
+      tkCast,
+      tkIf,
+      tkFor,
+      tkProc,
+      tkFunc,
+      tkIterator,
+      tkBind,
+      tkBuiltInMagics,
+      tkParLe,
+      tkBracketLe,
+      tkCurlyLe,
+      tkIntLit .. tkCustomLit,
+      tkVar,
+      tkRef,
+      tkPtr,
+      tkEnum,
+      tkTuple,
+      tkObject,
+      tkWhen,
+      tkCase,
+      tkOut,
+      tkTry,
+      tkBlock:
     result = true
   else:
     result = false
@@ -1746,19 +1742,19 @@ proc primary(p: var Parser; mode: PrimaryMode): PNode =
     getTok(p)
     splitLookahead(p, a, clPostfix)
 
-    const
-      identOrLiteralKinds =
-        tkBuiltInMagics + {
-            tkSymbol,
-            tkAccent,
-            tkNil,
-            tkIntLit .. tkCustomLit,
-            tkCast,
-            tkOut,
-            tkParLe,
-            tkBracketLe,
-            tkCurlyLe
-          }
+    const identOrLiteralKinds =
+      tkBuiltInMagics +
+        {
+          tkSymbol,
+          tkAccent,
+          tkNil,
+          tkIntLit .. tkCustomLit,
+          tkCast,
+          tkOut,
+          tkParLe,
+          tkBracketLe,
+          tkCurlyLe
+        }
     if isSigil and p.tok.tokType in identOrLiteralKinds:
       let baseInd = p.lex.currLineIndent
 
@@ -1958,7 +1954,7 @@ proc postExprBlocks(p: var Parser; x: PNode): PNode =
             pattern = p.emptyNode,
             genericParams = p.emptyNode,
             pragmas = openingPragmas,
-            exceptions = p.emptyNode
+            exceptions = p.emptyNode,
           )
 
         result[^1].mid = move(result.mid)
@@ -2440,6 +2436,7 @@ proc parseGenericParam(p: var Parser): PNode =
             "in"
           else:
             "out"
+          ,
         )
 
       a = newNodeP(nkPrefix, p)
@@ -2522,9 +2519,8 @@ proc parseRoutine(p: var Parser; kind: TNodeKind): PNode =
 
   getTok(p)
   splitLookahead(p, result, clMid)
-  if kind in {nkProcDef, nkLambda, nkIteratorDef, nkFuncDef} and p.tok.tokType notin {
-        tkSymbol, tokKeywordLow .. tokKeywordHigh, tkAccent
-      }:
+  if kind in {nkProcDef, nkLambda, nkIteratorDef, nkFuncDef} and
+      p.tok.tokType notin {tkSymbol, tokKeywordLow .. tokKeywordHigh, tkAccent}:
     # no name; lambda or proc type
     # in every context that we can parse a routine, we can also parse these
     result =
@@ -2535,6 +2531,7 @@ proc parseRoutine(p: var Parser; kind: TNodeKind): PNode =
           nkLambda
         else:
           kind
+        ,
       )
 
     return
@@ -2571,7 +2568,8 @@ proc parseRoutine(p: var Parser; kind: TNodeKind): PNode =
   indAndComment(p, result, maybeMissEquals = maybeMissEquals)
 
   let body = result[^1]
-  if body.kind == nkStmtList and body.len > 0 and body[0].comment.len > 0 and body[0].kind != nkCommentStmt:
+  if body.kind == nkStmtList and body.len > 0 and body[0].comment.len > 0 and
+      body[0].kind != nkCommentStmt:
     if result.comment.len == 0:
       # proc fn*(a: int): int = a ## foo
       # => moves comment `foo` to `fn`
@@ -2918,7 +2916,7 @@ proc parseTypeClass(p: var Parser): PNode =
       parMessage(
         p,
         "routine expected, but found '$1' (empty new-styled concepts are not allowed)",
-        p.tok
+        p.tok,
       )
 
     result.add(p.emptyNode)
@@ -3230,7 +3228,8 @@ proc parseStmt(p: var Parser): PNode =
     withInd(p):
       splitLookahead(p, result, clPrefix)
       while true:
-        if p.tok.indent == p.currInd or p.tok.indent > p.currInd and p.tok.tokType == tkComment:
+        if p.tok.indent == p.currInd or
+            p.tok.indent > p.currInd and p.tok.tokType == tkComment:
           discard
         elif p.tok.tokType == tkSemiColon:
           getTok(p)
@@ -3258,8 +3257,7 @@ proc parseStmt(p: var Parser): PNode =
           break
 
         # Allow this too, see tests/parser/tifexprs
-        let
-          a = complexOrSimpleStmt(p)
+        let a = complexOrSimpleStmt(p)
         if a.kind == nkEmpty and not p.hasProgress:
           debugEcho 3
 
@@ -3278,7 +3276,7 @@ proc parseStmt(p: var Parser): PNode =
     # the case statement is only needed for better error messages:
     case p.tok.tokType
     of tkIf, tkWhile, tkCase, tkTry, tkFor, tkBlock, tkAsm, tkProc, tkFunc, tkIterator,
-      tkMacro, tkType, tkConst, tkWhen, tkVar:
+        tkMacro, tkType, tkConst, tkWhen, tkVar:
       parMessage(p, "nestable statement requires indentation")
 
       result = p.emptyNode
@@ -3352,7 +3350,7 @@ proc parseString*(
     filename: string = "";
     line: int = 0;
     errorHandler: ErrorHandler = nil;
-    printTokens = false
+    printTokens = false;
 ): PNode =
   ## Parses a string into an AST, returning the top node.
   ## `filename` and `line`, although optional, provide info so that the

--- a/tests/after/comments.nim
+++ b/tests/after/comments.nim
@@ -66,7 +66,7 @@ type
   CaseObject = object # caseobj eol
     case k: bool # casetype eol
     of true, false: # of eol
-        v: string # case field eol
+      v: string # case field eol
 
   SomeAlias* = int
       ## alias eol
@@ -82,7 +82,7 @@ type
   ## Some comment before whenobj
   WhenObject = object # whenobject object line
     when false: # when object false line
-        discard
+      discard
 
   NoField0* = object of RootObj
     ## comment eol
@@ -213,14 +213,14 @@ proc ffff() =
 ## Doc comment after indented statement
 ## needs to be double
 abc and # dedented comment in infix
-  def
+def
 abc and # indented comment in infix
-  def
+def
 if abc and # dedented comment in infix
-  def:
+def:
   discard
 if abc and # indented comment in infix
-  def:
+def:
   discard
 
 a(b = c # comment after keyword parameter
@@ -229,10 +229,10 @@ a(b = c)
 
 # dedented comment after keyword parameter
 {.pragma # comment here
-    .}
+  .}
 
 proc a(v #[block]#
-    : int; abc: int)
+  : int; abc: int)
 
 let
   # let first line indented
@@ -251,3 +251,23 @@ block:
   # also after call
   # comment between the dots
   f.x.z().d()
+
+proc f(): bool =
+  ## Comment here
+  ## another
+  (true or false)
+
+proc f(): bool =
+  ## Comment here
+  ## another
+  if true:
+    false
+  else:
+    ## comment
+    ## comment 2
+    if true:
+      ## comment
+      ## comment 2
+      (true or false)
+    else:
+      false

--- a/tests/after/comments.nim.nph.yaml
+++ b/tests/after/comments.nim.nph.yaml
@@ -510,7 +510,7 @@
                                     }
                                   ],
                                   "postfix": [
-                                    "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# case field eol\", line: 69, col: 18, offsetA: 1224, offsetB: 1240)"
+                                    "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# case field eol\", line: 69, col: 16, offsetA: 1222, offsetB: 1238)"
                                   ]
                                 }
                               ]
@@ -548,8 +548,8 @@
               "kind": "nkIdent",
               "ident": "int",
               "postfix": [
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 6, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## alias eol\", line: 72, col: 6, offsetA: 1267, offsetB: 1279)",
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 6, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## alias next\", line: 73, col: 6, offsetA: 1286, offsetB: 1299)"
+                "(tokType: tkComment, base: base10, spacing: {}, indent: 6, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## alias eol\", line: 72, col: 6, offsetA: 1265, offsetB: 1277)",
+                "(tokType: tkComment, base: base10, spacing: {}, indent: 6, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## alias next\", line: 73, col: 6, offsetA: 1284, offsetB: 1297)"
               ]
             }
           ]
@@ -581,11 +581,11 @@
             {
               "kind": "nkIdent",
               "prefix": [
-                "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# after pragma\", line: 74, col: 26, offsetA: 1326, offsetB: 1340)"
+                "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# after pragma\", line: 74, col: 26, offsetA: 1324, offsetB: 1338)"
               ],
               "ident": "int",
               "postfix": [
-                "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## alias2 eol\", line: 75, col: 8, offsetA: 1349, offsetB: 1362)"
+                "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## alias2 eol\", line: 75, col: 8, offsetA: 1347, offsetB: 1360)"
               ]
             }
           ]
@@ -597,7 +597,7 @@
               "kind": "nkIdent",
               "ident": "SomeAlias3",
               "postfix": [
-                "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# alias after symbol\", line: 76, col: 13, offsetA: 1376, offsetB: 1396)"
+                "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# alias after symbol\", line: 76, col: 13, offsetA: 1374, offsetB: 1394)"
               ]
             },
             {
@@ -623,11 +623,11 @@
             {
               "kind": "nkIdent",
               "prefix": [
-                "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# alias after equals\", line: 77, col: 10, offsetA: 1407, offsetB: 1427)"
+                "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# alias after equals\", line: 77, col: 10, offsetA: 1405, offsetB: 1425)"
               ],
               "ident": "int",
               "postfix": [
-                "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# alias after type\", line: 78, col: 10, offsetA: 1438, offsetB: 1456)"
+                "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# alias after type\", line: 78, col: 10, offsetA: 1436, offsetB: 1454)"
               ]
             }
           ]
@@ -655,8 +655,8 @@
                 }
               ],
               "postfix": [
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 6, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## after alias4\", line: 80, col: 6, offsetA: 1494, offsetB: 1509)",
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 6, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## more after alias4\", line: 81, col: 6, offsetA: 1516, offsetB: 1536)"
+                "(tokType: tkComment, base: base10, spacing: {}, indent: 6, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## after alias4\", line: 80, col: 6, offsetA: 1492, offsetB: 1507)",
+                "(tokType: tkComment, base: base10, spacing: {}, indent: 6, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## more after alias4\", line: 81, col: 6, offsetA: 1514, offsetB: 1534)"
               ]
             }
           ]
@@ -664,7 +664,7 @@
         {
           "kind": "nkTypeDef",
           "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## Some comment before whenobj\", line: 82, col: 2, offsetA: 1539, offsetB: 1569)"
+            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## Some comment before whenobj\", line: 82, col: 2, offsetA: 1537, offsetB: 1567)"
           ],
           "sons": [
             {
@@ -677,7 +677,7 @@
             {
               "kind": "nkObjectTy",
               "mid": [
-                "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# whenobject object line\", line: 83, col: 22, offsetA: 1592, offsetB: 1616)"
+                "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# whenobject object line\", line: 83, col: 22, offsetA: 1590, offsetB: 1614)"
               ],
               "sons": [
                 {
@@ -695,7 +695,7 @@
                         {
                           "kind": "nkElifBranch",
                           "mid": [
-                            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# when object false line\", line: 84, col: 16, offsetA: 1633, offsetB: 1657)"
+                            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# when object false line\", line: 84, col: 16, offsetA: 1631, offsetB: 1655)"
                           ],
                           "sons": [
                             {
@@ -742,8 +742,8 @@
             {
               "kind": "nkObjectTy",
               "mid": [
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 4, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## comment eol\", line: 88, col: 4, offsetA: 1711, offsetB: 1725)",
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 4, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## comment nl\", line: 89, col: 4, offsetA: 1730, offsetB: 1743)"
+                "(tokType: tkComment, base: base10, spacing: {}, indent: 4, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## comment eol\", line: 88, col: 4, offsetA: 1707, offsetB: 1721)",
+                "(tokType: tkComment, base: base10, spacing: {}, indent: 4, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## comment nl\", line: 89, col: 4, offsetA: 1726, offsetB: 1739)"
               ],
               "sons": [
                 {
@@ -787,8 +787,8 @@
             {
               "kind": "nkObjectTy",
               "mid": [
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 4, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## comment nofield1 eol\", line: 92, col: 4, offsetA: 1781, offsetB: 1804)",
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 4, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## comment nl\", line: 93, col: 4, offsetA: 1809, offsetB: 1822)"
+                "(tokType: tkComment, base: base10, spacing: {}, indent: 4, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## comment nofield1 eol\", line: 92, col: 4, offsetA: 1777, offsetB: 1800)",
+                "(tokType: tkComment, base: base10, spacing: {}, indent: 4, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## comment nl\", line: 93, col: 4, offsetA: 1805, offsetB: 1818)"
               ],
               "sons": [
                 {
@@ -818,7 +818,7 @@
         {
           "kind": "nkElifBranch",
           "mid": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# when colon line\", line: 95, col: 24, offsetA: 1848, offsetB: 1865)"
+            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# when colon line\", line: 95, col: 24, offsetA: 1844, offsetB: 1861)"
           ],
           "sons": [
             {
@@ -837,7 +837,7 @@
             {
               "kind": "nkStmtList",
               "prefix": [
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# when first line\", line: 96, col: 2, offsetA: 1868, offsetB: 1885)"
+                "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# when first line\", line: 96, col: 2, offsetA: 1864, offsetB: 1881)"
               ],
               "sons": [
                 {
@@ -855,16 +855,16 @@
         {
           "kind": "nkElse",
           "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# comment\", line: 98, col: 0, offsetA: 1896, offsetB: 1905)"
+            "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# comment\", line: 98, col: 0, offsetA: 1892, offsetB: 1901)"
           ],
           "mid": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# else colon line\", line: 99, col: 6, offsetA: 1912, offsetB: 1929)"
+            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# else colon line\", line: 99, col: 6, offsetA: 1908, offsetB: 1925)"
           ],
           "sons": [
             {
               "kind": "nkStmtList",
               "prefix": [
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# else first line\", line: 100, col: 2, offsetA: 1932, offsetB: 1949)"
+                "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# else first line\", line: 100, col: 2, offsetA: 1928, offsetB: 1945)"
               ],
               "sons": [
                 {
@@ -894,7 +894,7 @@
             {
               "kind": "nkStmtList",
               "prefix": [
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# if next line\", line: 103, col: 2, offsetA: 1971, offsetB: 1985)"
+                "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# if next line\", line: 103, col: 2, offsetA: 1967, offsetB: 1981)"
               ],
               "sons": [
                 {
@@ -915,7 +915,7 @@
             {
               "kind": "nkStmtList",
               "prefix": [
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# else next line\", line: 106, col: 2, offsetA: 2004, offsetB: 2020)"
+                "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# else next line\", line: 106, col: 2, offsetA: 2000, offsetB: 2016)"
               ],
               "sons": [
                 {
@@ -938,7 +938,7 @@
         {
           "kind": "nkElifBranch",
           "mid": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# if colon line\", line: 108, col: 9, offsetA: 2040, offsetB: 2055)"
+            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# if colon line\", line: 108, col: 9, offsetA: 2036, offsetB: 2051)"
           ],
           "sons": [
             {
@@ -963,7 +963,7 @@
         {
           "kind": "nkElse",
           "mid": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# else colon line\", line: 110, col: 6, offsetA: 2072, offsetB: 2089)"
+            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# else colon line\", line: 110, col: 6, offsetA: 2068, offsetB: 2085)"
           ],
           "sons": [
             {
@@ -996,7 +996,7 @@
             {
               "kind": "nkStmtList",
               "prefix": [
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# if dedented colon line\", line: 113, col: 2, offsetA: 2111, offsetB: 2135)"
+                "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# if dedented colon line\", line: 113, col: 2, offsetA: 2107, offsetB: 2131)"
               ],
               "sons": [
                 {
@@ -1014,10 +1014,10 @@
         {
           "kind": "nkElse",
           "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# before else dedented\", line: 115, col: 0, offsetA: 2146, offsetB: 2168)"
+            "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# before else dedented\", line: 115, col: 0, offsetA: 2142, offsetB: 2164)"
           ],
           "mid": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# else colon line\", line: 116, col: 6, offsetA: 2175, offsetB: 2192)"
+            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# else colon line\", line: 116, col: 6, offsetA: 2171, offsetB: 2188)"
           ],
           "sons": [
             {
@@ -1040,7 +1040,7 @@
     {
       "kind": "nkProcDef",
       "mid": [
-        "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# after proc before indented name\", line: 119, col: 13, offsetA: 2217, offsetB: 2250)"
+        "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# after proc before indented name\", line: 119, col: 13, offsetA: 2213, offsetB: 2246)"
       ],
       "sons": [
         {
@@ -1085,7 +1085,7 @@
     {
       "kind": "nkProcDef",
       "mid": [
-        "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# proc eq line\", line: 122, col: 14, offsetA: 2276, offsetB: 2290)"
+        "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# proc eq line\", line: 122, col: 14, offsetA: 2272, offsetB: 2286)"
       ],
       "sons": [
         {
@@ -1115,7 +1115,7 @@
         {
           "kind": "nkStmtList",
           "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# proc first line\", line: 123, col: 2, offsetA: 2293, offsetB: 2310)"
+            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# proc first line\", line: 123, col: 2, offsetA: 2289, offsetB: 2306)"
           ],
           "sons": [
             {
@@ -1160,7 +1160,7 @@
         {
           "kind": "nkStmtList",
           "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## A proc doc comment\", line: 127, col: 2, offsetA: 2335, offsetB: 2356)"
+            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## A proc doc comment\", line: 127, col: 2, offsetA: 2331, offsetB: 2352)"
           ],
           "sons": [
             {
@@ -1193,7 +1193,7 @@
                             }
                           ],
                           "postfix": [
-                            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# handle Ctrl+Z as EOF\", line: 129, col: 27, offsetA: 2395, offsetB: 2417)"
+                            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# handle Ctrl+Z as EOF\", line: 129, col: 27, offsetA: 2391, offsetB: 2413)"
                           ]
                         },
                         {
@@ -1290,16 +1290,16 @@
     {
       "kind": "nkImportStmt",
       "prefix": [
-        "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## indented doc comment for proc\", line: 136, col: 0, offsetA: 2493, offsetB: 2525)",
-        "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## that is long\", line: 137, col: 0, offsetA: 2526, offsetB: 2541)",
-        "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# before module\", line: 138, col: 0, offsetA: 2542, offsetB: 2557)"
+        "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## indented doc comment for proc\", line: 136, col: 0, offsetA: 2489, offsetB: 2521)",
+        "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## that is long\", line: 137, col: 0, offsetA: 2522, offsetB: 2537)",
+        "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# before module\", line: 138, col: 0, offsetA: 2538, offsetB: 2553)"
       ],
       "sons": [
         {
           "kind": "nkIdent",
           "ident": "module",
           "postfix": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# with a comment\", line: 139, col: 14, offsetA: 2572, offsetB: 2588)"
+            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# with a comment\", line: 139, col: 14, offsetA: 2568, offsetB: 2584)"
           ]
         }
       ]
@@ -1311,7 +1311,7 @@
           "kind": "nkIdent",
           "ident": "module",
           "postfix": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## with a comment\", line: 140, col: 14, offsetA: 2603, offsetB: 2620)"
+            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## with a comment\", line: 140, col: 14, offsetA: 2599, offsetB: 2616)"
           ]
         }
       ]
@@ -1319,13 +1319,13 @@
     {
       "kind": "nkTryStmt",
       "mid": [
-        "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# try colon line\", line: 141, col: 5, offsetA: 2626, offsetB: 2642)"
+        "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# try colon line\", line: 141, col: 5, offsetA: 2622, offsetB: 2638)"
       ],
       "sons": [
         {
           "kind": "nkStmtList",
           "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# try first line\", line: 142, col: 2, offsetA: 2645, offsetB: 2661)"
+            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# try first line\", line: 142, col: 2, offsetA: 2641, offsetB: 2657)"
           ],
           "sons": [
             {
@@ -1341,13 +1341,13 @@
         {
           "kind": "nkExceptBranch",
           "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# try last line\", line: 144, col: 0, offsetA: 2672, offsetB: 2687)"
+            "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# try last line\", line: 144, col: 0, offsetA: 2668, offsetB: 2683)"
           ],
           "sons": [
             {
               "kind": "nkStmtList",
               "prefix": [
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# except first line\", line: 146, col: 2, offsetA: 2698, offsetB: 2717)"
+                "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# except first line\", line: 146, col: 2, offsetA: 2694, offsetB: 2713)"
               ],
               "sons": [
                 {
@@ -1365,13 +1365,13 @@
         {
           "kind": "nkFinally",
           "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# except last line\", line: 148, col: 0, offsetA: 2728, offsetB: 2746)"
+            "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# except last line\", line: 148, col: 0, offsetA: 2724, offsetB: 2742)"
           ],
           "sons": [
             {
               "kind": "nkStmtList",
               "prefix": [
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# finally first line\", line: 150, col: 2, offsetA: 2758, offsetB: 2778)"
+                "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# finally first line\", line: 150, col: 2, offsetA: 2754, offsetB: 2774)"
               ],
               "sons": [
                 {
@@ -1391,13 +1391,13 @@
     {
       "kind": "nkTryStmt",
       "prefix": [
-        "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# finally last line\", line: 152, col: 0, offsetA: 2789, offsetB: 2808)"
+        "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# finally last line\", line: 152, col: 0, offsetA: 2785, offsetB: 2804)"
       ],
       "sons": [
         {
           "kind": "nkStmtList",
           "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# try first dedent line\", line: 154, col: 2, offsetA: 2816, offsetB: 2839)"
+            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# try first dedent line\", line: 154, col: 2, offsetA: 2812, offsetB: 2835)"
           ],
           "sons": [
             {
@@ -1414,13 +1414,13 @@
         {
           "kind": "nkExceptBranch",
           "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# try last dedent line\", line: 156, col: 0, offsetA: 2846, offsetB: 2868)"
+            "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# try last dedent line\", line: 156, col: 0, offsetA: 2842, offsetB: 2864)"
           ],
           "sons": [
             {
               "kind": "nkStmtList",
               "prefix": [
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# except dedent first line\", line: 158, col: 2, offsetA: 2879, offsetB: 2905)"
+                "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# except dedent first line\", line: 158, col: 2, offsetA: 2875, offsetB: 2901)"
               ],
               "sons": [
                 {
@@ -1438,13 +1438,13 @@
         {
           "kind": "nkFinally",
           "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# except dedent last line\", line: 160, col: 0, offsetA: 2916, offsetB: 2941)"
+            "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# except dedent last line\", line: 160, col: 0, offsetA: 2912, offsetB: 2937)"
           ],
           "sons": [
             {
               "kind": "nkStmtList",
               "prefix": [
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# finally first dedent line\", line: 162, col: 2, offsetA: 2953, offsetB: 2980)"
+                "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# finally first dedent line\", line: 162, col: 2, offsetA: 2949, offsetB: 2976)"
               ],
               "sons": [
                 {
@@ -1464,10 +1464,10 @@
     {
       "kind": "nkForStmt",
       "prefix": [
-        "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# finally last dedent line\", line: 164, col: 0, offsetA: 2991, offsetB: 3017)"
+        "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# finally last dedent line\", line: 164, col: 0, offsetA: 2987, offsetB: 3013)"
       ],
       "mid": [
-        "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# for colon line\", line: 165, col: 17, offsetA: 3035, offsetB: 3051)"
+        "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# for colon line\", line: 165, col: 17, offsetA: 3031, offsetB: 3047)"
       ],
       "sons": [
         {
@@ -1494,7 +1494,7 @@
         {
           "kind": "nkStmtList",
           "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# for first line\", line: 166, col: 2, offsetA: 3054, offsetB: 3070)"
+            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# for first line\", line: 166, col: 2, offsetA: 3050, offsetB: 3066)"
           ],
           "sons": [
             {
@@ -1512,7 +1512,7 @@
     {
       "kind": "nkCaseStmt",
       "mid": [
-        "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# case line\", line: 168, col: 7, offsetA: 3088, offsetB: 3099)"
+        "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# case line\", line: 168, col: 7, offsetA: 3084, offsetB: 3095)"
       ],
       "sons": [
         {
@@ -1522,7 +1522,7 @@
         {
           "kind": "nkOfBranch",
           "mid": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# of colon line\", line: 169, col: 9, offsetA: 3109, offsetB: 3124)"
+            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# of colon line\", line: 169, col: 9, offsetA: 3105, offsetB: 3120)"
           ],
           "sons": [
             {
@@ -1532,7 +1532,7 @@
             {
               "kind": "nkStmtList",
               "prefix": [
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# of first line\", line: 170, col: 2, offsetA: 3127, offsetB: 3142)"
+                "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# of first line\", line: 170, col: 2, offsetA: 3123, offsetB: 3138)"
               ],
               "sons": [
                 {
@@ -1550,13 +1550,13 @@
         {
           "kind": "nkElse",
           "mid": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# case else colon line\", line: 172, col: 6, offsetA: 3159, offsetB: 3181)"
+            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# case else colon line\", line: 172, col: 6, offsetA: 3155, offsetB: 3177)"
           ],
           "sons": [
             {
               "kind": "nkStmtList",
               "prefix": [
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# case else first line\", line: 173, col: 2, offsetA: 3184, offsetB: 3206)"
+                "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# case else first line\", line: 173, col: 2, offsetA: 3180, offsetB: 3202)"
               ],
               "sons": [
                 {
@@ -1583,7 +1583,7 @@
         {
           "kind": "nkDo",
           "mid": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# do colon line\", line: 176, col: 13, offsetA: 3231, offsetB: 3246)"
+            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# do colon line\", line: 176, col: 13, offsetA: 3227, offsetB: 3242)"
           ],
           "sons": [
             {
@@ -1638,7 +1638,7 @@
     {
       "kind": "nkBlockStmt",
       "mid": [
-        "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# block colon line\", line: 180, col: 7, offsetA: 3275, offsetB: 3293)"
+        "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# block colon line\", line: 180, col: 7, offsetA: 3271, offsetB: 3289)"
       ],
       "sons": [
         {
@@ -1647,7 +1647,7 @@
         {
           "kind": "nkStmtList",
           "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# block first line\", line: 181, col: 2, offsetA: 3296, offsetB: 3314)"
+            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# block first line\", line: 181, col: 2, offsetA: 3292, offsetB: 3310)"
           ],
           "sons": [
             {
@@ -1686,7 +1686,7 @@
             {
               "kind": "nkLambda",
               "mid": [
-                "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# lambda eq line\", line: 186, col: 17, offsetA: 3361, offsetB: 3377)"
+                "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# lambda eq line\", line: 186, col: 17, offsetA: 3357, offsetB: 3373)"
               ],
               "sons": [
                 {
@@ -1716,7 +1716,7 @@
                 {
                   "kind": "nkStmtList",
                   "prefix": [
-                    "(tokType: tkComment, base: base10, spacing: {}, indent: 6, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# lambda first line\", line: 187, col: 6, offsetA: 3384, offsetB: 3403)"
+                    "(tokType: tkComment, base: base10, spacing: {}, indent: 6, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# lambda first line\", line: 187, col: 6, offsetA: 3380, offsetB: 3399)"
                   ],
                   "sons": [
                     {
@@ -1753,7 +1753,7 @@
         {
           "kind": "nkStmtList",
           "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# while first line\", line: 191, col: 2, offsetA: 3447, offsetB: 3465)"
+            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# while first line\", line: 191, col: 2, offsetA: 3443, offsetB: 3461)"
           ],
           "sons": [
             {
@@ -1771,13 +1771,13 @@
     {
       "kind": "nkStaticStmt",
       "mid": [
-        "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# static colon line\", line: 194, col: 8, offsetA: 3485, offsetB: 3504)"
+        "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# static colon line\", line: 194, col: 8, offsetA: 3481, offsetB: 3500)"
       ],
       "sons": [
         {
           "kind": "nkStmtList",
           "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# static first line\", line: 195, col: 2, offsetA: 3507, offsetB: 3526)"
+            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# static first line\", line: 195, col: 2, offsetA: 3503, offsetB: 3522)"
           ],
           "sons": [
             {
@@ -1808,8 +1808,8 @@
                 {
                   "kind": "nkIdent",
                   "prefix": [
-                    "(tokType: tkComment, base: base10, spacing: {}, indent: 4, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# object eol\", line: 199, col: 4, offsetA: 3558, offsetB: 3570)",
-                    "(tokType: tkComment, base: base10, spacing: {}, indent: 4, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# object first line\", line: 200, col: 4, offsetA: 3575, offsetB: 3594)"
+                    "(tokType: tkComment, base: base10, spacing: {}, indent: 4, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# object eol\", line: 199, col: 4, offsetA: 3554, offsetB: 3566)",
+                    "(tokType: tkComment, base: base10, spacing: {}, indent: 4, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# object first line\", line: 200, col: 4, offsetA: 3571, offsetB: 3590)"
                   ],
                   "ident": "field"
                 },
@@ -1819,7 +1819,7 @@
                 }
               ],
               "postfix": [
-                "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# field line\", line: 201, col: 14, offsetA: 3609, offsetB: 3621)"
+                "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# field line\", line: 201, col: 14, offsetA: 3605, offsetB: 3617)"
               ]
             },
             {
@@ -1835,7 +1835,7 @@
                 }
               ],
               "postfix": [
-                "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# field colon line\", line: 202, col: 15, offsetA: 3637, offsetB: 3655)"
+                "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# field colon line\", line: 202, col: 15, offsetA: 3633, offsetB: 3651)"
               ]
             }
           ]
@@ -1922,14 +1922,14 @@
           "kind": "nkIdent",
           "ident": "and",
           "postfix": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# dedented comment in infix\", line: 215, col: 8, offsetA: 3823, offsetB: 3850)"
+            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# dedented comment in infix\", line: 215, col: 8, offsetA: 3819, offsetB: 3846)"
           ]
         },
         {
           "kind": "nkIdent",
           "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## Doc comment after indented statement\", line: 213, col: 0, offsetA: 3753, offsetB: 3792)",
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## needs to be double\", line: 214, col: 0, offsetA: 3793, offsetB: 3814)"
+            "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## Doc comment after indented statement\", line: 213, col: 0, offsetA: 3749, offsetB: 3788)",
+            "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## needs to be double\", line: 214, col: 0, offsetA: 3789, offsetB: 3810)"
           ],
           "ident": "abc"
         },
@@ -1946,7 +1946,7 @@
           "kind": "nkIdent",
           "ident": "and",
           "postfix": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# indented comment in infix\", line: 217, col: 8, offsetA: 3865, offsetB: 3892)"
+            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# indented comment in infix\", line: 217, col: 8, offsetA: 3859, offsetB: 3886)"
           ]
         },
         {
@@ -1972,7 +1972,7 @@
                   "kind": "nkIdent",
                   "ident": "and",
                   "postfix": [
-                    "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# dedented comment in infix\", line: 219, col: 11, offsetA: 3910, offsetB: 3937)"
+                    "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# dedented comment in infix\", line: 219, col: 11, offsetA: 3902, offsetB: 3929)"
                   ]
                 },
                 {
@@ -2015,7 +2015,7 @@
                   "kind": "nkIdent",
                   "ident": "and",
                   "postfix": [
-                    "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# indented comment in infix\", line: 222, col: 11, offsetA: 3966, offsetB: 3993)"
+                    "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# indented comment in infix\", line: 222, col: 11, offsetA: 3956, offsetB: 3983)"
                   ]
                 },
                 {
@@ -2065,7 +2065,7 @@
             }
           ],
           "postfix": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# comment after keyword parameter\", line: 226, col: 8, offsetA: 4020, offsetB: 4053)"
+            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# comment after keyword parameter\", line: 226, col: 8, offsetA: 4008, offsetB: 4041)"
           ]
         }
       ]
@@ -2095,14 +2095,14 @@
     {
       "kind": "nkPragma",
       "prefix": [
-        "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# dedented comment after keyword parameter\", line: 230, col: 0, offsetA: 4068, offsetB: 4110)"
+        "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# dedented comment after keyword parameter\", line: 230, col: 0, offsetA: 4056, offsetB: 4098)"
       ],
       "sons": [
         {
           "kind": "nkIdent",
           "ident": "pragma",
           "postfix": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# comment here\", line: 231, col: 9, offsetA: 4120, offsetB: 4134)"
+            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# comment here\", line: 231, col: 9, offsetA: 4108, offsetB: 4122)"
           ]
         }
       ]
@@ -2133,7 +2133,7 @@
                   "kind": "nkIdent",
                   "ident": "v",
                   "postfix": [
-                    "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"#[block]#\", line: 234, col: 9, offsetA: 4152, offsetB: 4160)"
+                    "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"#[block]#\", line: 234, col: 9, offsetA: 4138, offsetB: 4146)"
                   ]
                 },
                 {
@@ -2180,7 +2180,7 @@
         {
           "kind": "nkIdentDefs",
           "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# let first line indented\", line: 238, col: 2, offsetA: 4190, offsetB: 4215)"
+            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# let first line indented\", line: 238, col: 2, offsetA: 4174, offsetB: 4199)"
           ],
           "sons": [
             {
@@ -2196,7 +2196,7 @@
             }
           ],
           "postfix": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# after v\", line: 239, col: 9, offsetA: 4225, offsetB: 4234)"
+            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# after v\", line: 239, col: 9, offsetA: 4209, offsetB: 4218)"
           ]
         }
       ]
@@ -2207,7 +2207,7 @@
         {
           "kind": "nkIdentDefs",
           "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# var first line indented\", line: 242, col: 2, offsetA: 4242, offsetB: 4267)"
+            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# var first line indented\", line: 242, col: 2, offsetA: 4226, offsetB: 4251)"
           ],
           "sons": [
             {
@@ -2223,7 +2223,7 @@
             }
           ],
           "postfix": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# after v\", line: 243, col: 9, offsetA: 4277, offsetB: 4286)"
+            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# after v\", line: 243, col: 9, offsetA: 4261, offsetB: 4270)"
           ]
         }
       ]
@@ -2234,12 +2234,12 @@
         {
           "kind": "nkIntLit",
           "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# discard eol\", line: 246, col: 2, offsetA: 4298, offsetB: 4311)",
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# discard first line\", line: 247, col: 2, offsetA: 4314, offsetB: 4334)"
+            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# discard eol\", line: 246, col: 2, offsetA: 4282, offsetB: 4295)",
+            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# discard first line\", line: 247, col: 2, offsetA: 4298, offsetB: 4318)"
           ],
           "intVal": 54,
           "postfix": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# discard value\", line: 248, col: 5, offsetA: 4340, offsetB: 4355)"
+            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# discard value\", line: 248, col: 5, offsetA: 4324, offsetB: 4339)"
           ]
         }
       ]
@@ -2253,8 +2253,8 @@
         {
           "kind": "nkStmtList",
           "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# also after call\", line: 251, col: 2, offsetA: 4366, offsetB: 4383)",
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# comment between the dots\", line: 252, col: 2, offsetA: 4386, offsetB: 4412)"
+            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# also after call\", line: 251, col: 2, offsetA: 4350, offsetB: 4367)",
+            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# comment between the dots\", line: 252, col: 2, offsetA: 4370, offsetB: 4396)"
           ],
           "sons": [
             {
@@ -2293,6 +2293,202 @@
                     {
                       "kind": "nkIdent",
                       "ident": "d"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "nkProcDef",
+      "sons": [
+        {
+          "kind": "nkIdent",
+          "ident": "f"
+        },
+        {
+          "kind": "nkEmpty"
+        },
+        {
+          "kind": "nkEmpty"
+        },
+        {
+          "kind": "nkFormalParams",
+          "sons": [
+            {
+              "kind": "nkIdent",
+              "ident": "bool"
+            }
+          ]
+        },
+        {
+          "kind": "nkEmpty"
+        },
+        {
+          "kind": "nkEmpty"
+        },
+        {
+          "kind": "nkStmtList",
+          "prefix": [
+            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## Comment here\", line: 256, col: 2, offsetA: 4431, offsetB: 4446)",
+            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## another\", line: 257, col: 2, offsetA: 4449, offsetB: 4459)"
+          ],
+          "sons": [
+            {
+              "kind": "nkPar",
+              "sons": [
+                {
+                  "kind": "nkInfix",
+                  "sons": [
+                    {
+                      "kind": "nkIdent",
+                      "ident": "or"
+                    },
+                    {
+                      "kind": "nkIdent",
+                      "ident": "true"
+                    },
+                    {
+                      "kind": "nkIdent",
+                      "ident": "false"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "nkProcDef",
+      "sons": [
+        {
+          "kind": "nkIdent",
+          "ident": "f"
+        },
+        {
+          "kind": "nkEmpty"
+        },
+        {
+          "kind": "nkEmpty"
+        },
+        {
+          "kind": "nkFormalParams",
+          "sons": [
+            {
+              "kind": "nkIdent",
+              "ident": "bool"
+            }
+          ]
+        },
+        {
+          "kind": "nkEmpty"
+        },
+        {
+          "kind": "nkEmpty"
+        },
+        {
+          "kind": "nkStmtList",
+          "prefix": [
+            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## Comment here\", line: 261, col: 2, offsetA: 4498, offsetB: 4513)",
+            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## another\", line: 262, col: 2, offsetA: 4516, offsetB: 4526)"
+          ],
+          "sons": [
+            {
+              "kind": "nkIfStmt",
+              "sons": [
+                {
+                  "kind": "nkElifBranch",
+                  "sons": [
+                    {
+                      "kind": "nkIdent",
+                      "ident": "true"
+                    },
+                    {
+                      "kind": "nkStmtList",
+                      "sons": [
+                        {
+                          "kind": "nkIdent",
+                          "ident": "false"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "nkElse",
+                  "sons": [
+                    {
+                      "kind": "nkStmtList",
+                      "prefix": [
+                        "(tokType: tkComment, base: base10, spacing: {}, indent: 4, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## comment\", line: 266, col: 4, offsetA: 4560, offsetB: 4570)",
+                        "(tokType: tkComment, base: base10, spacing: {}, indent: 4, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## comment 2\", line: 267, col: 4, offsetA: 4575, offsetB: 4587)"
+                      ],
+                      "sons": [
+                        {
+                          "kind": "nkIfStmt",
+                          "sons": [
+                            {
+                              "kind": "nkElifBranch",
+                              "sons": [
+                                {
+                                  "kind": "nkIdent",
+                                  "ident": "true"
+                                },
+                                {
+                                  "kind": "nkStmtList",
+                                  "prefix": [
+                                    "(tokType: tkComment, base: base10, spacing: {}, indent: 6, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## comment\", line: 269, col: 6, offsetA: 4607, offsetB: 4617)",
+                                    "(tokType: tkComment, base: base10, spacing: {}, indent: 6, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## comment 2\", line: 270, col: 6, offsetA: 4624, offsetB: 4636)"
+                                  ],
+                                  "sons": [
+                                    {
+                                      "kind": "nkPar",
+                                      "sons": [
+                                        {
+                                          "kind": "nkInfix",
+                                          "sons": [
+                                            {
+                                              "kind": "nkIdent",
+                                              "ident": "or"
+                                            },
+                                            {
+                                              "kind": "nkIdent",
+                                              "ident": "true"
+                                            },
+                                            {
+                                              "kind": "nkIdent",
+                                              "ident": "false"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "nkElse",
+                              "sons": [
+                                {
+                                  "kind": "nkStmtList",
+                                  "sons": [
+                                    {
+                                      "kind": "nkIdent",
+                                      "ident": "false"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
                     }
                   ]
                 }

--- a/tests/after/exprs.nim
+++ b/tests/after/exprs.nim
@@ -1,35 +1,16 @@
 var c3 =
-  row[p] + (if runeA != runeB:
+  row[p] +
+    (if runeA != runeB:
       1
     else:
       0
     )
 var c3 =
-  row[p] + (if runeA != runeB:
+  row[p] +
+    (if runeA != runeB:
       1
     else: 0
     )
-
-proc f(): bool =
-  ## Comment here
-  ## another
-  (true or false)
-
-proc f(): bool =
-  ## Comment here
-  ## another
-  if true:
-    false
-  else:
-    ## comment
-    ## comment 2
-    if true:
-      ## comment
-      ## comment
-      (true or false)
-    else:
-      false
-
 for a in 0 ..< 1:
   discard
 for a in 0 .. 1:
@@ -57,3 +38,40 @@ res.add fff do:
 let xxx =
   implicitdo:
     return xxx
+let shortInfix = a * b * c + d * e * f + (a + b) * g
+let longInfix =
+  (
+    a30 * a21 * a12 * a03 - a20 * a31 * a12 * a03 - a30 * a11 * a22 * a03 +
+    a10 * a31 * a22 * a03 + a20 * a11 * a32 * a03 - a10 * a21 * a32 * a03 -
+    a30 * a21 * a02 * a13 + a20 * a31 * a02 * a13 + a30 * a01 * a22 * a13 -
+    a00 * a31 * a22 * a13 - a20 * a01 * a32 * a13 + a00 * a21 * a32 * a13 +
+    a30 * a11 * a02 * a23 - a10 * a31 * a02 * a23 - a30 * a01 * a12 * a23 +
+    a00 * a31 * a12 * a23 + a10 * a01 * a32 * a23 - a00 * a11 * a32 * a23 -
+    a20 * a11 * a02 * a33 + a10 * a21 * a02 * a33 + a20 * a01 * a12 * a33 -
+    a00 * a21 * a12 * a33 - a10 * a01 * a22 * a33 + a00 * a11 * a22 * a33
+  )
+if aaaaaaaaaaaaaaaaaaaa and bbbbbbbbbbbbbbbbbbbbbbb and ccccccccccccccccccccccccc and
+    ddddddddddddddddd and fffffffffffffffff:
+  discard
+if (aaaaaaaaaaaaaaaa and bbbbbbbbbbbbbbbbbbbbbbbbbbbb) or
+    (ccccccccccccccccccccccccccc and ddddddddddddddddddddd):
+  discard
+elif aaaaaaaaa and
+    (
+      bbbbbbbbbb or
+      cccccccccccc and
+      (dddddddddddddddd or eeeeeeeeeeeeeee or fffffffffffffff or gggggggggggggg)
+    ):
+  discard
+case aaaaaaaaaa
+of aaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbb, ccccccccccccccccccccccc,
+    ddddddddddddddddddddddd:
+  discard
+of aaaa:
+  discard
+of aaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbb, ccccccccccccccccccccccc,
+    dddddddddddddddddddddd, aaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbb,
+    ccccccccccccccccccccccc, dddddddddddddddddddddd:
+  discard
+else:
+  discard

--- a/tests/after/exprs.nim.nph.yaml
+++ b/tests/after/exprs.nim.nph.yaml
@@ -185,202 +185,6 @@
       ]
     },
     {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "f"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "bool"
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkStmtList",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## Comment here\", line: 14, col: 2, offsetA: 158, offsetB: 173)",
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## another\", line: 15, col: 2, offsetA: 176, offsetB: 186)"
-          ],
-          "sons": [
-            {
-              "kind": "nkPar",
-              "sons": [
-                {
-                  "kind": "nkInfix",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "or"
-                    },
-                    {
-                      "kind": "nkIdent",
-                      "ident": "true"
-                    },
-                    {
-                      "kind": "nkIdent",
-                      "ident": "false"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "f"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "bool"
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkStmtList",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## Comment here\", line: 19, col: 2, offsetA: 225, offsetB: 240)",
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## another\", line: 20, col: 2, offsetA: 243, offsetB: 253)"
-          ],
-          "sons": [
-            {
-              "kind": "nkIfStmt",
-              "sons": [
-                {
-                  "kind": "nkElifBranch",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "true"
-                    },
-                    {
-                      "kind": "nkStmtList",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "false"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkElse",
-                  "sons": [
-                    {
-                      "kind": "nkStmtList",
-                      "prefix": [
-                        "(tokType: tkComment, base: base10, spacing: {}, indent: 4, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## comment\", line: 24, col: 4, offsetA: 287, offsetB: 297)",
-                        "(tokType: tkComment, base: base10, spacing: {}, indent: 4, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## comment 2\", line: 25, col: 4, offsetA: 302, offsetB: 314)"
-                      ],
-                      "sons": [
-                        {
-                          "kind": "nkIfStmt",
-                          "sons": [
-                            {
-                              "kind": "nkElifBranch",
-                              "sons": [
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "true"
-                                },
-                                {
-                                  "kind": "nkStmtList",
-                                  "prefix": [
-                                    "(tokType: tkComment, base: base10, spacing: {}, indent: 6, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## comment\", line: 27, col: 6, offsetA: 334, offsetB: 344)",
-                                    "(tokType: tkComment, base: base10, spacing: {}, indent: 6, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## comment\", line: 28, col: 6, offsetA: 351, offsetB: 361)"
-                                  ],
-                                  "sons": [
-                                    {
-                                      "kind": "nkPar",
-                                      "sons": [
-                                        {
-                                          "kind": "nkInfix",
-                                          "sons": [
-                                            {
-                                              "kind": "nkIdent",
-                                              "ident": "or"
-                                            },
-                                            {
-                                              "kind": "nkIdent",
-                                              "ident": "true"
-                                            },
-                                            {
-                                              "kind": "nkIdent",
-                                              "ident": "false"
-                                            }
-                                          ]
-                                        }
-                                      ]
-                                    }
-                                  ]
-                                }
-                              ]
-                            },
-                            {
-                              "kind": "nkElse",
-                              "sons": [
-                                {
-                                  "kind": "nkStmtList",
-                                  "sons": [
-                                    {
-                                      "kind": "nkIdent",
-                                      "ident": "false"
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
       "kind": "nkForStmt",
       "sons": [
         {
@@ -461,7 +265,7 @@
     {
       "kind": "nkForStmt",
       "prefix": [
-        "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# needs spaces\", line: 37, col: 0, offsetA: 462, offsetB: 476)"
+        "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# needs spaces\", line: 18, col: 0, offsetA: 201, offsetB: 215)"
       ],
       "sons": [
         {
@@ -592,7 +396,7 @@
     {
       "kind": "nkDiscardStmt",
       "prefix": [
-        "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# command syntax with colon\", line: 46, col: 0, offsetA: 559, offsetB: 586)"
+        "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# command syntax with colon\", line: 27, col: 0, offsetA: 298, offsetB: 325)"
       ],
       "sons": [
         {
@@ -663,9 +467,9 @@
     {
       "kind": "nkLetSection",
       "prefix": [
-        "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# we don\\\'t what `do` in let but need it in the above commend - this needs\", line: 53, col: 0, offsetA: 642, offsetB: 715)",
-        "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# more investigation - this is important for templates calls like Result.valueOr\", line: 54, col: 0, offsetA: 716, offsetB: 796)",
-        "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# which become ugly otherwise\", line: 55, col: 0, offsetA: 797, offsetB: 826)"
+        "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# we don\\\'t what `do` in let but need it in the above commend - this needs\", line: 34, col: 0, offsetA: 381, offsetB: 454)",
+        "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# more investigation - this is important for templates calls like Result.valueOr\", line: 35, col: 0, offsetA: 455, offsetB: 535)",
+        "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# which become ugly otherwise\", line: 36, col: 0, offsetA: 536, offsetB: 565)"
       ],
       "sons": [
         {
@@ -696,6 +500,1795 @@
                           "ident": "xxx"
                         }
                       ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "nkLetSection",
+      "sons": [
+        {
+          "kind": "nkIdentDefs",
+          "sons": [
+            {
+              "kind": "nkIdent",
+              "ident": "shortInfix"
+            },
+            {
+              "kind": "nkEmpty"
+            },
+            {
+              "kind": "nkInfix",
+              "sons": [
+                {
+                  "kind": "nkIdent",
+                  "ident": "+"
+                },
+                {
+                  "kind": "nkInfix",
+                  "sons": [
+                    {
+                      "kind": "nkIdent",
+                      "ident": "+"
+                    },
+                    {
+                      "kind": "nkInfix",
+                      "sons": [
+                        {
+                          "kind": "nkIdent",
+                          "ident": "*"
+                        },
+                        {
+                          "kind": "nkInfix",
+                          "sons": [
+                            {
+                              "kind": "nkIdent",
+                              "ident": "*"
+                            },
+                            {
+                              "kind": "nkIdent",
+                              "ident": "a"
+                            },
+                            {
+                              "kind": "nkIdent",
+                              "ident": "b"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "nkIdent",
+                          "ident": "c"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "nkInfix",
+                      "sons": [
+                        {
+                          "kind": "nkIdent",
+                          "ident": "*"
+                        },
+                        {
+                          "kind": "nkInfix",
+                          "sons": [
+                            {
+                              "kind": "nkIdent",
+                              "ident": "*"
+                            },
+                            {
+                              "kind": "nkIdent",
+                              "ident": "d"
+                            },
+                            {
+                              "kind": "nkIdent",
+                              "ident": "e"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "nkIdent",
+                          "ident": "f"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "nkInfix",
+                  "sons": [
+                    {
+                      "kind": "nkIdent",
+                      "ident": "*"
+                    },
+                    {
+                      "kind": "nkPar",
+                      "sons": [
+                        {
+                          "kind": "nkInfix",
+                          "sons": [
+                            {
+                              "kind": "nkIdent",
+                              "ident": "+"
+                            },
+                            {
+                              "kind": "nkIdent",
+                              "ident": "a"
+                            },
+                            {
+                              "kind": "nkIdent",
+                              "ident": "b"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "nkIdent",
+                      "ident": "g"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "nkLetSection",
+      "sons": [
+        {
+          "kind": "nkIdentDefs",
+          "sons": [
+            {
+              "kind": "nkIdent",
+              "ident": "longInfix"
+            },
+            {
+              "kind": "nkEmpty"
+            },
+            {
+              "kind": "nkPar",
+              "sons": [
+                {
+                  "kind": "nkInfix",
+                  "sons": [
+                    {
+                      "kind": "nkIdent",
+                      "ident": "+"
+                    },
+                    {
+                      "kind": "nkInfix",
+                      "sons": [
+                        {
+                          "kind": "nkIdent",
+                          "ident": "-"
+                        },
+                        {
+                          "kind": "nkInfix",
+                          "sons": [
+                            {
+                              "kind": "nkIdent",
+                              "ident": "-"
+                            },
+                            {
+                              "kind": "nkInfix",
+                              "sons": [
+                                {
+                                  "kind": "nkIdent",
+                                  "ident": "+"
+                                },
+                                {
+                                  "kind": "nkInfix",
+                                  "sons": [
+                                    {
+                                      "kind": "nkIdent",
+                                      "ident": "+"
+                                    },
+                                    {
+                                      "kind": "nkInfix",
+                                      "sons": [
+                                        {
+                                          "kind": "nkIdent",
+                                          "ident": "-"
+                                        },
+                                        {
+                                          "kind": "nkInfix",
+                                          "sons": [
+                                            {
+                                              "kind": "nkIdent",
+                                              "ident": "-"
+                                            },
+                                            {
+                                              "kind": "nkInfix",
+                                              "sons": [
+                                                {
+                                                  "kind": "nkIdent",
+                                                  "ident": "+"
+                                                },
+                                                {
+                                                  "kind": "nkInfix",
+                                                  "sons": [
+                                                    {
+                                                      "kind": "nkIdent",
+                                                      "ident": "+"
+                                                    },
+                                                    {
+                                                      "kind": "nkInfix",
+                                                      "sons": [
+                                                        {
+                                                          "kind": "nkIdent",
+                                                          "ident": "-"
+                                                        },
+                                                        {
+                                                          "kind": "nkInfix",
+                                                          "sons": [
+                                                            {
+                                                              "kind": "nkIdent",
+                                                              "ident": "-"
+                                                            },
+                                                            {
+                                                              "kind": "nkInfix",
+                                                              "sons": [
+                                                                {
+                                                                  "kind": "nkIdent",
+                                                                  "ident": "+"
+                                                                },
+                                                                {
+                                                                  "kind": "nkInfix",
+                                                                  "sons": [
+                                                                    {
+                                                                      "kind": "nkIdent",
+                                                                      "ident": "+"
+                                                                    },
+                                                                    {
+                                                                      "kind": "nkInfix",
+                                                                      "sons": [
+                                                                        {
+                                                                          "kind": "nkIdent",
+                                                                          "ident": "-"
+                                                                        },
+                                                                        {
+                                                                          "kind": "nkInfix",
+                                                                          "sons": [
+                                                                            {
+                                                                              "kind": "nkIdent",
+                                                                              "ident": "-"
+                                                                            },
+                                                                            {
+                                                                              "kind": "nkInfix",
+                                                                              "sons": [
+                                                                                {
+                                                                                  "kind": "nkIdent",
+                                                                                  "ident": "+"
+                                                                                },
+                                                                                {
+                                                                                  "kind": "nkInfix",
+                                                                                  "sons": [
+                                                                                    {
+                                                                                      "kind": "nkIdent",
+                                                                                      "ident": "+"
+                                                                                    },
+                                                                                    {
+                                                                                      "kind": "nkInfix",
+                                                                                      "sons": [
+                                                                                        {
+                                                                                          "kind": "nkIdent",
+                                                                                          "ident": "-"
+                                                                                        },
+                                                                                        {
+                                                                                          "kind": "nkInfix",
+                                                                                          "sons": [
+                                                                                            {
+                                                                                              "kind": "nkIdent",
+                                                                                              "ident": "-"
+                                                                                            },
+                                                                                            {
+                                                                                              "kind": "nkInfix",
+                                                                                              "sons": [
+                                                                                                {
+                                                                                                  "kind": "nkIdent",
+                                                                                                  "ident": "+"
+                                                                                                },
+                                                                                                {
+                                                                                                  "kind": "nkInfix",
+                                                                                                  "sons": [
+                                                                                                    {
+                                                                                                      "kind": "nkIdent",
+                                                                                                      "ident": "+"
+                                                                                                    },
+                                                                                                    {
+                                                                                                      "kind": "nkInfix",
+                                                                                                      "sons": [
+                                                                                                        {
+                                                                                                          "kind": "nkIdent",
+                                                                                                          "ident": "-"
+                                                                                                        },
+                                                                                                        {
+                                                                                                          "kind": "nkInfix",
+                                                                                                          "sons": [
+                                                                                                            {
+                                                                                                              "kind": "nkIdent",
+                                                                                                              "ident": "-"
+                                                                                                            },
+                                                                                                            {
+                                                                                                              "kind": "nkInfix",
+                                                                                                              "sons": [
+                                                                                                                {
+                                                                                                                  "kind": "nkIdent",
+                                                                                                                  "ident": "*"
+                                                                                                                },
+                                                                                                                {
+                                                                                                                  "kind": "nkInfix",
+                                                                                                                  "sons": [
+                                                                                                                    {
+                                                                                                                      "kind": "nkIdent",
+                                                                                                                      "ident": "*"
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                      "kind": "nkInfix",
+                                                                                                                      "sons": [
+                                                                                                                        {
+                                                                                                                          "kind": "nkIdent",
+                                                                                                                          "ident": "*"
+                                                                                                                        },
+                                                                                                                        {
+                                                                                                                          "kind": "nkIdent",
+                                                                                                                          "ident": "a30"
+                                                                                                                        },
+                                                                                                                        {
+                                                                                                                          "kind": "nkIdent",
+                                                                                                                          "ident": "a21"
+                                                                                                                        }
+                                                                                                                      ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                      "kind": "nkIdent",
+                                                                                                                      "ident": "a12"
+                                                                                                                    }
+                                                                                                                  ]
+                                                                                                                },
+                                                                                                                {
+                                                                                                                  "kind": "nkIdent",
+                                                                                                                  "ident": "a03"
+                                                                                                                }
+                                                                                                              ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                              "kind": "nkInfix",
+                                                                                                              "sons": [
+                                                                                                                {
+                                                                                                                  "kind": "nkIdent",
+                                                                                                                  "ident": "*"
+                                                                                                                },
+                                                                                                                {
+                                                                                                                  "kind": "nkInfix",
+                                                                                                                  "sons": [
+                                                                                                                    {
+                                                                                                                      "kind": "nkIdent",
+                                                                                                                      "ident": "*"
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                      "kind": "nkInfix",
+                                                                                                                      "sons": [
+                                                                                                                        {
+                                                                                                                          "kind": "nkIdent",
+                                                                                                                          "ident": "*"
+                                                                                                                        },
+                                                                                                                        {
+                                                                                                                          "kind": "nkIdent",
+                                                                                                                          "ident": "a20"
+                                                                                                                        },
+                                                                                                                        {
+                                                                                                                          "kind": "nkIdent",
+                                                                                                                          "ident": "a31"
+                                                                                                                        }
+                                                                                                                      ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                      "kind": "nkIdent",
+                                                                                                                      "ident": "a12"
+                                                                                                                    }
+                                                                                                                  ]
+                                                                                                                },
+                                                                                                                {
+                                                                                                                  "kind": "nkIdent",
+                                                                                                                  "ident": "a03"
+                                                                                                                }
+                                                                                                              ]
+                                                                                                            }
+                                                                                                          ]
+                                                                                                        },
+                                                                                                        {
+                                                                                                          "kind": "nkInfix",
+                                                                                                          "sons": [
+                                                                                                            {
+                                                                                                              "kind": "nkIdent",
+                                                                                                              "ident": "*"
+                                                                                                            },
+                                                                                                            {
+                                                                                                              "kind": "nkInfix",
+                                                                                                              "sons": [
+                                                                                                                {
+                                                                                                                  "kind": "nkIdent",
+                                                                                                                  "ident": "*"
+                                                                                                                },
+                                                                                                                {
+                                                                                                                  "kind": "nkInfix",
+                                                                                                                  "sons": [
+                                                                                                                    {
+                                                                                                                      "kind": "nkIdent",
+                                                                                                                      "ident": "*"
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                      "kind": "nkIdent",
+                                                                                                                      "ident": "a30"
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                      "kind": "nkIdent",
+                                                                                                                      "ident": "a11"
+                                                                                                                    }
+                                                                                                                  ]
+                                                                                                                },
+                                                                                                                {
+                                                                                                                  "kind": "nkIdent",
+                                                                                                                  "ident": "a22"
+                                                                                                                }
+                                                                                                              ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                              "kind": "nkIdent",
+                                                                                                              "ident": "a03"
+                                                                                                            }
+                                                                                                          ]
+                                                                                                        }
+                                                                                                      ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                      "kind": "nkInfix",
+                                                                                                      "sons": [
+                                                                                                        {
+                                                                                                          "kind": "nkIdent",
+                                                                                                          "ident": "*"
+                                                                                                        },
+                                                                                                        {
+                                                                                                          "kind": "nkInfix",
+                                                                                                          "sons": [
+                                                                                                            {
+                                                                                                              "kind": "nkIdent",
+                                                                                                              "ident": "*"
+                                                                                                            },
+                                                                                                            {
+                                                                                                              "kind": "nkInfix",
+                                                                                                              "sons": [
+                                                                                                                {
+                                                                                                                  "kind": "nkIdent",
+                                                                                                                  "ident": "*"
+                                                                                                                },
+                                                                                                                {
+                                                                                                                  "kind": "nkIdent",
+                                                                                                                  "ident": "a10"
+                                                                                                                },
+                                                                                                                {
+                                                                                                                  "kind": "nkIdent",
+                                                                                                                  "ident": "a31"
+                                                                                                                }
+                                                                                                              ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                              "kind": "nkIdent",
+                                                                                                              "ident": "a22"
+                                                                                                            }
+                                                                                                          ]
+                                                                                                        },
+                                                                                                        {
+                                                                                                          "kind": "nkIdent",
+                                                                                                          "ident": "a03"
+                                                                                                        }
+                                                                                                      ]
+                                                                                                    }
+                                                                                                  ]
+                                                                                                },
+                                                                                                {
+                                                                                                  "kind": "nkInfix",
+                                                                                                  "sons": [
+                                                                                                    {
+                                                                                                      "kind": "nkIdent",
+                                                                                                      "ident": "*"
+                                                                                                    },
+                                                                                                    {
+                                                                                                      "kind": "nkInfix",
+                                                                                                      "sons": [
+                                                                                                        {
+                                                                                                          "kind": "nkIdent",
+                                                                                                          "ident": "*"
+                                                                                                        },
+                                                                                                        {
+                                                                                                          "kind": "nkInfix",
+                                                                                                          "sons": [
+                                                                                                            {
+                                                                                                              "kind": "nkIdent",
+                                                                                                              "ident": "*"
+                                                                                                            },
+                                                                                                            {
+                                                                                                              "kind": "nkIdent",
+                                                                                                              "ident": "a20"
+                                                                                                            },
+                                                                                                            {
+                                                                                                              "kind": "nkIdent",
+                                                                                                              "ident": "a11"
+                                                                                                            }
+                                                                                                          ]
+                                                                                                        },
+                                                                                                        {
+                                                                                                          "kind": "nkIdent",
+                                                                                                          "ident": "a32"
+                                                                                                        }
+                                                                                                      ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                      "kind": "nkIdent",
+                                                                                                      "ident": "a03"
+                                                                                                    }
+                                                                                                  ]
+                                                                                                }
+                                                                                              ]
+                                                                                            },
+                                                                                            {
+                                                                                              "kind": "nkInfix",
+                                                                                              "sons": [
+                                                                                                {
+                                                                                                  "kind": "nkIdent",
+                                                                                                  "ident": "*"
+                                                                                                },
+                                                                                                {
+                                                                                                  "kind": "nkInfix",
+                                                                                                  "sons": [
+                                                                                                    {
+                                                                                                      "kind": "nkIdent",
+                                                                                                      "ident": "*"
+                                                                                                    },
+                                                                                                    {
+                                                                                                      "kind": "nkInfix",
+                                                                                                      "sons": [
+                                                                                                        {
+                                                                                                          "kind": "nkIdent",
+                                                                                                          "ident": "*"
+                                                                                                        },
+                                                                                                        {
+                                                                                                          "kind": "nkIdent",
+                                                                                                          "ident": "a10"
+                                                                                                        },
+                                                                                                        {
+                                                                                                          "kind": "nkIdent",
+                                                                                                          "ident": "a21"
+                                                                                                        }
+                                                                                                      ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                      "kind": "nkIdent",
+                                                                                                      "ident": "a32"
+                                                                                                    }
+                                                                                                  ]
+                                                                                                },
+                                                                                                {
+                                                                                                  "kind": "nkIdent",
+                                                                                                  "ident": "a03"
+                                                                                                }
+                                                                                              ]
+                                                                                            }
+                                                                                          ]
+                                                                                        },
+                                                                                        {
+                                                                                          "kind": "nkInfix",
+                                                                                          "sons": [
+                                                                                            {
+                                                                                              "kind": "nkIdent",
+                                                                                              "ident": "*"
+                                                                                            },
+                                                                                            {
+                                                                                              "kind": "nkInfix",
+                                                                                              "sons": [
+                                                                                                {
+                                                                                                  "kind": "nkIdent",
+                                                                                                  "ident": "*"
+                                                                                                },
+                                                                                                {
+                                                                                                  "kind": "nkInfix",
+                                                                                                  "sons": [
+                                                                                                    {
+                                                                                                      "kind": "nkIdent",
+                                                                                                      "ident": "*"
+                                                                                                    },
+                                                                                                    {
+                                                                                                      "kind": "nkIdent",
+                                                                                                      "ident": "a30"
+                                                                                                    },
+                                                                                                    {
+                                                                                                      "kind": "nkIdent",
+                                                                                                      "ident": "a21"
+                                                                                                    }
+                                                                                                  ]
+                                                                                                },
+                                                                                                {
+                                                                                                  "kind": "nkIdent",
+                                                                                                  "ident": "a02"
+                                                                                                }
+                                                                                              ]
+                                                                                            },
+                                                                                            {
+                                                                                              "kind": "nkIdent",
+                                                                                              "ident": "a13"
+                                                                                            }
+                                                                                          ]
+                                                                                        }
+                                                                                      ]
+                                                                                    },
+                                                                                    {
+                                                                                      "kind": "nkInfix",
+                                                                                      "sons": [
+                                                                                        {
+                                                                                          "kind": "nkIdent",
+                                                                                          "ident": "*"
+                                                                                        },
+                                                                                        {
+                                                                                          "kind": "nkInfix",
+                                                                                          "sons": [
+                                                                                            {
+                                                                                              "kind": "nkIdent",
+                                                                                              "ident": "*"
+                                                                                            },
+                                                                                            {
+                                                                                              "kind": "nkInfix",
+                                                                                              "sons": [
+                                                                                                {
+                                                                                                  "kind": "nkIdent",
+                                                                                                  "ident": "*"
+                                                                                                },
+                                                                                                {
+                                                                                                  "kind": "nkIdent",
+                                                                                                  "ident": "a20"
+                                                                                                },
+                                                                                                {
+                                                                                                  "kind": "nkIdent",
+                                                                                                  "ident": "a31"
+                                                                                                }
+                                                                                              ]
+                                                                                            },
+                                                                                            {
+                                                                                              "kind": "nkIdent",
+                                                                                              "ident": "a02"
+                                                                                            }
+                                                                                          ]
+                                                                                        },
+                                                                                        {
+                                                                                          "kind": "nkIdent",
+                                                                                          "ident": "a13"
+                                                                                        }
+                                                                                      ]
+                                                                                    }
+                                                                                  ]
+                                                                                },
+                                                                                {
+                                                                                  "kind": "nkInfix",
+                                                                                  "sons": [
+                                                                                    {
+                                                                                      "kind": "nkIdent",
+                                                                                      "ident": "*"
+                                                                                    },
+                                                                                    {
+                                                                                      "kind": "nkInfix",
+                                                                                      "sons": [
+                                                                                        {
+                                                                                          "kind": "nkIdent",
+                                                                                          "ident": "*"
+                                                                                        },
+                                                                                        {
+                                                                                          "kind": "nkInfix",
+                                                                                          "sons": [
+                                                                                            {
+                                                                                              "kind": "nkIdent",
+                                                                                              "ident": "*"
+                                                                                            },
+                                                                                            {
+                                                                                              "kind": "nkIdent",
+                                                                                              "ident": "a30"
+                                                                                            },
+                                                                                            {
+                                                                                              "kind": "nkIdent",
+                                                                                              "ident": "a01"
+                                                                                            }
+                                                                                          ]
+                                                                                        },
+                                                                                        {
+                                                                                          "kind": "nkIdent",
+                                                                                          "ident": "a22"
+                                                                                        }
+                                                                                      ]
+                                                                                    },
+                                                                                    {
+                                                                                      "kind": "nkIdent",
+                                                                                      "ident": "a13"
+                                                                                    }
+                                                                                  ]
+                                                                                }
+                                                                              ]
+                                                                            },
+                                                                            {
+                                                                              "kind": "nkInfix",
+                                                                              "sons": [
+                                                                                {
+                                                                                  "kind": "nkIdent",
+                                                                                  "ident": "*"
+                                                                                },
+                                                                                {
+                                                                                  "kind": "nkInfix",
+                                                                                  "sons": [
+                                                                                    {
+                                                                                      "kind": "nkIdent",
+                                                                                      "ident": "*"
+                                                                                    },
+                                                                                    {
+                                                                                      "kind": "nkInfix",
+                                                                                      "sons": [
+                                                                                        {
+                                                                                          "kind": "nkIdent",
+                                                                                          "ident": "*"
+                                                                                        },
+                                                                                        {
+                                                                                          "kind": "nkIdent",
+                                                                                          "ident": "a00"
+                                                                                        },
+                                                                                        {
+                                                                                          "kind": "nkIdent",
+                                                                                          "ident": "a31"
+                                                                                        }
+                                                                                      ]
+                                                                                    },
+                                                                                    {
+                                                                                      "kind": "nkIdent",
+                                                                                      "ident": "a22"
+                                                                                    }
+                                                                                  ]
+                                                                                },
+                                                                                {
+                                                                                  "kind": "nkIdent",
+                                                                                  "ident": "a13"
+                                                                                }
+                                                                              ]
+                                                                            }
+                                                                          ]
+                                                                        },
+                                                                        {
+                                                                          "kind": "nkInfix",
+                                                                          "sons": [
+                                                                            {
+                                                                              "kind": "nkIdent",
+                                                                              "ident": "*"
+                                                                            },
+                                                                            {
+                                                                              "kind": "nkInfix",
+                                                                              "sons": [
+                                                                                {
+                                                                                  "kind": "nkIdent",
+                                                                                  "ident": "*"
+                                                                                },
+                                                                                {
+                                                                                  "kind": "nkInfix",
+                                                                                  "sons": [
+                                                                                    {
+                                                                                      "kind": "nkIdent",
+                                                                                      "ident": "*"
+                                                                                    },
+                                                                                    {
+                                                                                      "kind": "nkIdent",
+                                                                                      "ident": "a20"
+                                                                                    },
+                                                                                    {
+                                                                                      "kind": "nkIdent",
+                                                                                      "ident": "a01"
+                                                                                    }
+                                                                                  ]
+                                                                                },
+                                                                                {
+                                                                                  "kind": "nkIdent",
+                                                                                  "ident": "a32"
+                                                                                }
+                                                                              ]
+                                                                            },
+                                                                            {
+                                                                              "kind": "nkIdent",
+                                                                              "ident": "a13"
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      ]
+                                                                    },
+                                                                    {
+                                                                      "kind": "nkInfix",
+                                                                      "sons": [
+                                                                        {
+                                                                          "kind": "nkIdent",
+                                                                          "ident": "*"
+                                                                        },
+                                                                        {
+                                                                          "kind": "nkInfix",
+                                                                          "sons": [
+                                                                            {
+                                                                              "kind": "nkIdent",
+                                                                              "ident": "*"
+                                                                            },
+                                                                            {
+                                                                              "kind": "nkInfix",
+                                                                              "sons": [
+                                                                                {
+                                                                                  "kind": "nkIdent",
+                                                                                  "ident": "*"
+                                                                                },
+                                                                                {
+                                                                                  "kind": "nkIdent",
+                                                                                  "ident": "a00"
+                                                                                },
+                                                                                {
+                                                                                  "kind": "nkIdent",
+                                                                                  "ident": "a21"
+                                                                                }
+                                                                              ]
+                                                                            },
+                                                                            {
+                                                                              "kind": "nkIdent",
+                                                                              "ident": "a32"
+                                                                            }
+                                                                          ]
+                                                                        },
+                                                                        {
+                                                                          "kind": "nkIdent",
+                                                                          "ident": "a13"
+                                                                        }
+                                                                      ]
+                                                                    }
+                                                                  ]
+                                                                },
+                                                                {
+                                                                  "kind": "nkInfix",
+                                                                  "sons": [
+                                                                    {
+                                                                      "kind": "nkIdent",
+                                                                      "ident": "*"
+                                                                    },
+                                                                    {
+                                                                      "kind": "nkInfix",
+                                                                      "sons": [
+                                                                        {
+                                                                          "kind": "nkIdent",
+                                                                          "ident": "*"
+                                                                        },
+                                                                        {
+                                                                          "kind": "nkInfix",
+                                                                          "sons": [
+                                                                            {
+                                                                              "kind": "nkIdent",
+                                                                              "ident": "*"
+                                                                            },
+                                                                            {
+                                                                              "kind": "nkIdent",
+                                                                              "ident": "a30"
+                                                                            },
+                                                                            {
+                                                                              "kind": "nkIdent",
+                                                                              "ident": "a11"
+                                                                            }
+                                                                          ]
+                                                                        },
+                                                                        {
+                                                                          "kind": "nkIdent",
+                                                                          "ident": "a02"
+                                                                        }
+                                                                      ]
+                                                                    },
+                                                                    {
+                                                                      "kind": "nkIdent",
+                                                                      "ident": "a23"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              ]
+                                                            },
+                                                            {
+                                                              "kind": "nkInfix",
+                                                              "sons": [
+                                                                {
+                                                                  "kind": "nkIdent",
+                                                                  "ident": "*"
+                                                                },
+                                                                {
+                                                                  "kind": "nkInfix",
+                                                                  "sons": [
+                                                                    {
+                                                                      "kind": "nkIdent",
+                                                                      "ident": "*"
+                                                                    },
+                                                                    {
+                                                                      "kind": "nkInfix",
+                                                                      "sons": [
+                                                                        {
+                                                                          "kind": "nkIdent",
+                                                                          "ident": "*"
+                                                                        },
+                                                                        {
+                                                                          "kind": "nkIdent",
+                                                                          "ident": "a10"
+                                                                        },
+                                                                        {
+                                                                          "kind": "nkIdent",
+                                                                          "ident": "a31"
+                                                                        }
+                                                                      ]
+                                                                    },
+                                                                    {
+                                                                      "kind": "nkIdent",
+                                                                      "ident": "a02"
+                                                                    }
+                                                                  ]
+                                                                },
+                                                                {
+                                                                  "kind": "nkIdent",
+                                                                  "ident": "a23"
+                                                                }
+                                                              ]
+                                                            }
+                                                          ]
+                                                        },
+                                                        {
+                                                          "kind": "nkInfix",
+                                                          "sons": [
+                                                            {
+                                                              "kind": "nkIdent",
+                                                              "ident": "*"
+                                                            },
+                                                            {
+                                                              "kind": "nkInfix",
+                                                              "sons": [
+                                                                {
+                                                                  "kind": "nkIdent",
+                                                                  "ident": "*"
+                                                                },
+                                                                {
+                                                                  "kind": "nkInfix",
+                                                                  "sons": [
+                                                                    {
+                                                                      "kind": "nkIdent",
+                                                                      "ident": "*"
+                                                                    },
+                                                                    {
+                                                                      "kind": "nkIdent",
+                                                                      "ident": "a30"
+                                                                    },
+                                                                    {
+                                                                      "kind": "nkIdent",
+                                                                      "ident": "a01"
+                                                                    }
+                                                                  ]
+                                                                },
+                                                                {
+                                                                  "kind": "nkIdent",
+                                                                  "ident": "a12"
+                                                                }
+                                                              ]
+                                                            },
+                                                            {
+                                                              "kind": "nkIdent",
+                                                              "ident": "a23"
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "kind": "nkInfix",
+                                                      "sons": [
+                                                        {
+                                                          "kind": "nkIdent",
+                                                          "ident": "*"
+                                                        },
+                                                        {
+                                                          "kind": "nkInfix",
+                                                          "sons": [
+                                                            {
+                                                              "kind": "nkIdent",
+                                                              "ident": "*"
+                                                            },
+                                                            {
+                                                              "kind": "nkInfix",
+                                                              "sons": [
+                                                                {
+                                                                  "kind": "nkIdent",
+                                                                  "ident": "*"
+                                                                },
+                                                                {
+                                                                  "kind": "nkIdent",
+                                                                  "ident": "a00"
+                                                                },
+                                                                {
+                                                                  "kind": "nkIdent",
+                                                                  "ident": "a31"
+                                                                }
+                                                              ]
+                                                            },
+                                                            {
+                                                              "kind": "nkIdent",
+                                                              "ident": "a12"
+                                                            }
+                                                          ]
+                                                        },
+                                                        {
+                                                          "kind": "nkIdent",
+                                                          "ident": "a23"
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "kind": "nkInfix",
+                                                  "sons": [
+                                                    {
+                                                      "kind": "nkIdent",
+                                                      "ident": "*"
+                                                    },
+                                                    {
+                                                      "kind": "nkInfix",
+                                                      "sons": [
+                                                        {
+                                                          "kind": "nkIdent",
+                                                          "ident": "*"
+                                                        },
+                                                        {
+                                                          "kind": "nkInfix",
+                                                          "sons": [
+                                                            {
+                                                              "kind": "nkIdent",
+                                                              "ident": "*"
+                                                            },
+                                                            {
+                                                              "kind": "nkIdent",
+                                                              "ident": "a10"
+                                                            },
+                                                            {
+                                                              "kind": "nkIdent",
+                                                              "ident": "a01"
+                                                            }
+                                                          ]
+                                                        },
+                                                        {
+                                                          "kind": "nkIdent",
+                                                          "ident": "a32"
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "kind": "nkIdent",
+                                                      "ident": "a23"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "kind": "nkInfix",
+                                              "sons": [
+                                                {
+                                                  "kind": "nkIdent",
+                                                  "ident": "*"
+                                                },
+                                                {
+                                                  "kind": "nkInfix",
+                                                  "sons": [
+                                                    {
+                                                      "kind": "nkIdent",
+                                                      "ident": "*"
+                                                    },
+                                                    {
+                                                      "kind": "nkInfix",
+                                                      "sons": [
+                                                        {
+                                                          "kind": "nkIdent",
+                                                          "ident": "*"
+                                                        },
+                                                        {
+                                                          "kind": "nkIdent",
+                                                          "ident": "a00"
+                                                        },
+                                                        {
+                                                          "kind": "nkIdent",
+                                                          "ident": "a11"
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "kind": "nkIdent",
+                                                      "ident": "a32"
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "kind": "nkIdent",
+                                                  "ident": "a23"
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "kind": "nkInfix",
+                                          "sons": [
+                                            {
+                                              "kind": "nkIdent",
+                                              "ident": "*"
+                                            },
+                                            {
+                                              "kind": "nkInfix",
+                                              "sons": [
+                                                {
+                                                  "kind": "nkIdent",
+                                                  "ident": "*"
+                                                },
+                                                {
+                                                  "kind": "nkInfix",
+                                                  "sons": [
+                                                    {
+                                                      "kind": "nkIdent",
+                                                      "ident": "*"
+                                                    },
+                                                    {
+                                                      "kind": "nkIdent",
+                                                      "ident": "a20"
+                                                    },
+                                                    {
+                                                      "kind": "nkIdent",
+                                                      "ident": "a11"
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "kind": "nkIdent",
+                                                  "ident": "a02"
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "kind": "nkIdent",
+                                              "ident": "a33"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "nkInfix",
+                                      "sons": [
+                                        {
+                                          "kind": "nkIdent",
+                                          "ident": "*"
+                                        },
+                                        {
+                                          "kind": "nkInfix",
+                                          "sons": [
+                                            {
+                                              "kind": "nkIdent",
+                                              "ident": "*"
+                                            },
+                                            {
+                                              "kind": "nkInfix",
+                                              "sons": [
+                                                {
+                                                  "kind": "nkIdent",
+                                                  "ident": "*"
+                                                },
+                                                {
+                                                  "kind": "nkIdent",
+                                                  "ident": "a10"
+                                                },
+                                                {
+                                                  "kind": "nkIdent",
+                                                  "ident": "a21"
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "kind": "nkIdent",
+                                              "ident": "a02"
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "kind": "nkIdent",
+                                          "ident": "a33"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "nkInfix",
+                                  "sons": [
+                                    {
+                                      "kind": "nkIdent",
+                                      "ident": "*"
+                                    },
+                                    {
+                                      "kind": "nkInfix",
+                                      "sons": [
+                                        {
+                                          "kind": "nkIdent",
+                                          "ident": "*"
+                                        },
+                                        {
+                                          "kind": "nkInfix",
+                                          "sons": [
+                                            {
+                                              "kind": "nkIdent",
+                                              "ident": "*"
+                                            },
+                                            {
+                                              "kind": "nkIdent",
+                                              "ident": "a20"
+                                            },
+                                            {
+                                              "kind": "nkIdent",
+                                              "ident": "a01"
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "kind": "nkIdent",
+                                          "ident": "a12"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "nkIdent",
+                                      "ident": "a33"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "nkInfix",
+                              "sons": [
+                                {
+                                  "kind": "nkIdent",
+                                  "ident": "*"
+                                },
+                                {
+                                  "kind": "nkInfix",
+                                  "sons": [
+                                    {
+                                      "kind": "nkIdent",
+                                      "ident": "*"
+                                    },
+                                    {
+                                      "kind": "nkInfix",
+                                      "sons": [
+                                        {
+                                          "kind": "nkIdent",
+                                          "ident": "*"
+                                        },
+                                        {
+                                          "kind": "nkIdent",
+                                          "ident": "a00"
+                                        },
+                                        {
+                                          "kind": "nkIdent",
+                                          "ident": "a21"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "nkIdent",
+                                      "ident": "a12"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "nkIdent",
+                                  "ident": "a33"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "nkInfix",
+                          "sons": [
+                            {
+                              "kind": "nkIdent",
+                              "ident": "*"
+                            },
+                            {
+                              "kind": "nkInfix",
+                              "sons": [
+                                {
+                                  "kind": "nkIdent",
+                                  "ident": "*"
+                                },
+                                {
+                                  "kind": "nkInfix",
+                                  "sons": [
+                                    {
+                                      "kind": "nkIdent",
+                                      "ident": "*"
+                                    },
+                                    {
+                                      "kind": "nkIdent",
+                                      "ident": "a10"
+                                    },
+                                    {
+                                      "kind": "nkIdent",
+                                      "ident": "a01"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "nkIdent",
+                                  "ident": "a22"
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "nkIdent",
+                              "ident": "a33"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "nkInfix",
+                      "sons": [
+                        {
+                          "kind": "nkIdent",
+                          "ident": "*"
+                        },
+                        {
+                          "kind": "nkInfix",
+                          "sons": [
+                            {
+                              "kind": "nkIdent",
+                              "ident": "*"
+                            },
+                            {
+                              "kind": "nkInfix",
+                              "sons": [
+                                {
+                                  "kind": "nkIdent",
+                                  "ident": "*"
+                                },
+                                {
+                                  "kind": "nkIdent",
+                                  "ident": "a00"
+                                },
+                                {
+                                  "kind": "nkIdent",
+                                  "ident": "a11"
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "nkIdent",
+                              "ident": "a22"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "nkIdent",
+                          "ident": "a33"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "nkIfStmt",
+      "sons": [
+        {
+          "kind": "nkElifBranch",
+          "sons": [
+            {
+              "kind": "nkInfix",
+              "sons": [
+                {
+                  "kind": "nkIdent",
+                  "ident": "and"
+                },
+                {
+                  "kind": "nkInfix",
+                  "sons": [
+                    {
+                      "kind": "nkIdent",
+                      "ident": "and"
+                    },
+                    {
+                      "kind": "nkInfix",
+                      "sons": [
+                        {
+                          "kind": "nkIdent",
+                          "ident": "and"
+                        },
+                        {
+                          "kind": "nkInfix",
+                          "sons": [
+                            {
+                              "kind": "nkIdent",
+                              "ident": "and"
+                            },
+                            {
+                              "kind": "nkIdent",
+                              "ident": "aaaaaaaaaaaaaaaaaaaa"
+                            },
+                            {
+                              "kind": "nkIdent",
+                              "ident": "bbbbbbbbbbbbbbbbbbbbbbb"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "nkIdent",
+                          "ident": "ccccccccccccccccccccccccc"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "nkIdent",
+                      "ident": "ddddddddddddddddd"
+                    }
+                  ]
+                },
+                {
+                  "kind": "nkIdent",
+                  "ident": "fffffffffffffffff"
+                }
+              ]
+            },
+            {
+              "kind": "nkStmtList",
+              "sons": [
+                {
+                  "kind": "nkDiscardStmt",
+                  "sons": [
+                    {
+                      "kind": "nkEmpty"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "nkIfStmt",
+      "sons": [
+        {
+          "kind": "nkElifBranch",
+          "sons": [
+            {
+              "kind": "nkInfix",
+              "sons": [
+                {
+                  "kind": "nkIdent",
+                  "ident": "or"
+                },
+                {
+                  "kind": "nkPar",
+                  "sons": [
+                    {
+                      "kind": "nkInfix",
+                      "sons": [
+                        {
+                          "kind": "nkIdent",
+                          "ident": "and"
+                        },
+                        {
+                          "kind": "nkIdent",
+                          "ident": "aaaaaaaaaaaaaaaa"
+                        },
+                        {
+                          "kind": "nkIdent",
+                          "ident": "bbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "nkPar",
+                  "sons": [
+                    {
+                      "kind": "nkInfix",
+                      "sons": [
+                        {
+                          "kind": "nkIdent",
+                          "ident": "and"
+                        },
+                        {
+                          "kind": "nkIdent",
+                          "ident": "ccccccccccccccccccccccccccc"
+                        },
+                        {
+                          "kind": "nkIdent",
+                          "ident": "ddddddddddddddddddddd"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "nkStmtList",
+              "sons": [
+                {
+                  "kind": "nkDiscardStmt",
+                  "sons": [
+                    {
+                      "kind": "nkEmpty"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "nkElifBranch",
+          "sons": [
+            {
+              "kind": "nkInfix",
+              "sons": [
+                {
+                  "kind": "nkIdent",
+                  "ident": "and"
+                },
+                {
+                  "kind": "nkIdent",
+                  "ident": "aaaaaaaaa"
+                },
+                {
+                  "kind": "nkPar",
+                  "sons": [
+                    {
+                      "kind": "nkInfix",
+                      "sons": [
+                        {
+                          "kind": "nkIdent",
+                          "ident": "or"
+                        },
+                        {
+                          "kind": "nkIdent",
+                          "ident": "bbbbbbbbbb"
+                        },
+                        {
+                          "kind": "nkInfix",
+                          "sons": [
+                            {
+                              "kind": "nkIdent",
+                              "ident": "and"
+                            },
+                            {
+                              "kind": "nkIdent",
+                              "ident": "cccccccccccc"
+                            },
+                            {
+                              "kind": "nkPar",
+                              "sons": [
+                                {
+                                  "kind": "nkInfix",
+                                  "sons": [
+                                    {
+                                      "kind": "nkIdent",
+                                      "ident": "or"
+                                    },
+                                    {
+                                      "kind": "nkInfix",
+                                      "sons": [
+                                        {
+                                          "kind": "nkIdent",
+                                          "ident": "or"
+                                        },
+                                        {
+                                          "kind": "nkInfix",
+                                          "sons": [
+                                            {
+                                              "kind": "nkIdent",
+                                              "ident": "or"
+                                            },
+                                            {
+                                              "kind": "nkIdent",
+                                              "ident": "dddddddddddddddd"
+                                            },
+                                            {
+                                              "kind": "nkIdent",
+                                              "ident": "eeeeeeeeeeeeeee"
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "kind": "nkIdent",
+                                          "ident": "fffffffffffffff"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "nkIdent",
+                                      "ident": "gggggggggggggg"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "nkStmtList",
+              "sons": [
+                {
+                  "kind": "nkDiscardStmt",
+                  "sons": [
+                    {
+                      "kind": "nkEmpty"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "nkCaseStmt",
+      "sons": [
+        {
+          "kind": "nkIdent",
+          "ident": "aaaaaaaaaa"
+        },
+        {
+          "kind": "nkOfBranch",
+          "sons": [
+            {
+              "kind": "nkIdent",
+              "ident": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            },
+            {
+              "kind": "nkIdent",
+              "ident": "bbbbbbbbbbbbbbbbbbbbbbbbbb"
+            },
+            {
+              "kind": "nkIdent",
+              "ident": "ccccccccccccccccccccccc"
+            },
+            {
+              "kind": "nkIdent",
+              "ident": "ddddddddddddddddddddddd"
+            },
+            {
+              "kind": "nkStmtList",
+              "sons": [
+                {
+                  "kind": "nkDiscardStmt",
+                  "sons": [
+                    {
+                      "kind": "nkEmpty"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "nkOfBranch",
+          "sons": [
+            {
+              "kind": "nkIdent",
+              "ident": "aaaa"
+            },
+            {
+              "kind": "nkStmtList",
+              "sons": [
+                {
+                  "kind": "nkDiscardStmt",
+                  "sons": [
+                    {
+                      "kind": "nkEmpty"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "nkOfBranch",
+          "sons": [
+            {
+              "kind": "nkIdent",
+              "ident": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            },
+            {
+              "kind": "nkIdent",
+              "ident": "bbbbbbbbbbbbbbbbbbbbbbbbbb"
+            },
+            {
+              "kind": "nkIdent",
+              "ident": "ccccccccccccccccccccccc"
+            },
+            {
+              "kind": "nkIdent",
+              "ident": "dddddddddddddddddddddd"
+            },
+            {
+              "kind": "nkIdent",
+              "ident": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            },
+            {
+              "kind": "nkIdent",
+              "ident": "bbbbbbbbbbbbbbbbbbbbbbbbbb"
+            },
+            {
+              "kind": "nkIdent",
+              "ident": "ccccccccccccccccccccccc"
+            },
+            {
+              "kind": "nkIdent",
+              "ident": "dddddddddddddddddddddd"
+            },
+            {
+              "kind": "nkStmtList",
+              "sons": [
+                {
+                  "kind": "nkDiscardStmt",
+                  "sons": [
+                    {
+                      "kind": "nkEmpty"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "nkElse",
+          "sons": [
+            {
+              "kind": "nkStmtList",
+              "sons": [
+                {
+                  "kind": "nkDiscardStmt",
+                  "sons": [
+                    {
+                      "kind": "nkEmpty"
                     }
                   ]
                 }

--- a/tests/after/import.nim
+++ b/tests/after/import.nim
@@ -1,12 +1,15 @@
 import tables
+import "."/tables
+import "."/[tables, sets]
+import sets as dummies
 import
-  "."/tables
+  aaaaaaaaaaaaaa as bbbbbbbbbbbbbb,
+  ccccccccccccc as dddddddddddddd,
+  eeeeeeeeeeeee as fffffffffffffff,
+  gggggggggggggggggg as hhhhhhhhhhhhhhhh
 import
-  "."/[tables, sets]
-import
-  sets as dummies
-import
-  "."/[
+  "."/
+    [
       tables, sets, long, modules, even, more, more, a_really_long_module_here, more,
       more, more, more, more
     ]
@@ -18,3 +21,19 @@ export a, b, c
 export
   aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccc,
   dddddddddddddddddd
+
+include a
+include
+  aaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbb, ccccccccccccccccccccccccc,
+  dddddddddddddddddd
+
+import
+  "a"/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
+  "ccccccccccccccccccccccccc"/dddddddddddddddddddddd
+
+from a import a, b, c
+from aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa import
+  aaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbb, cccccccccccccccc, ddddddddddddddd,
+  eeeeeeeeeeeeeeeeeeeeeee, ffffffffffffff
+
+{.push, raises: [].}

--- a/tests/after/import.nim.nph.yaml
+++ b/tests/after/import.nim.nph.yaml
@@ -93,6 +93,79 @@
           "sons": [
             {
               "kind": "nkIdent",
+              "ident": "as"
+            },
+            {
+              "kind": "nkIdent",
+              "ident": "aaaaaaaaaaaaaa"
+            },
+            {
+              "kind": "nkIdent",
+              "ident": "bbbbbbbbbbbbbb"
+            }
+          ]
+        },
+        {
+          "kind": "nkInfix",
+          "sons": [
+            {
+              "kind": "nkIdent",
+              "ident": "as"
+            },
+            {
+              "kind": "nkIdent",
+              "ident": "ccccccccccccc"
+            },
+            {
+              "kind": "nkIdent",
+              "ident": "dddddddddddddd"
+            }
+          ]
+        },
+        {
+          "kind": "nkInfix",
+          "sons": [
+            {
+              "kind": "nkIdent",
+              "ident": "as"
+            },
+            {
+              "kind": "nkIdent",
+              "ident": "eeeeeeeeeeeee"
+            },
+            {
+              "kind": "nkIdent",
+              "ident": "fffffffffffffff"
+            }
+          ]
+        },
+        {
+          "kind": "nkInfix",
+          "sons": [
+            {
+              "kind": "nkIdent",
+              "ident": "as"
+            },
+            {
+              "kind": "nkIdent",
+              "ident": "gggggggggggggggggg"
+            },
+            {
+              "kind": "nkIdent",
+              "ident": "hhhhhhhhhhhhhhhh"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "nkImportStmt",
+      "sons": [
+        {
+          "kind": "nkInfix",
+          "sons": [
+            {
+              "kind": "nkIdent",
               "ident": "/"
             },
             {
@@ -225,6 +298,150 @@
         {
           "kind": "nkIdent",
           "ident": "dddddddddddddddddd"
+        }
+      ]
+    },
+    {
+      "kind": "nkIncludeStmt",
+      "sons": [
+        {
+          "kind": "nkIdent",
+          "ident": "a"
+        }
+      ]
+    },
+    {
+      "kind": "nkIncludeStmt",
+      "sons": [
+        {
+          "kind": "nkIdent",
+          "ident": "aaaaaaaaaaaaaaaaaaaa"
+        },
+        {
+          "kind": "nkIdent",
+          "ident": "bbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        },
+        {
+          "kind": "nkIdent",
+          "ident": "ccccccccccccccccccccccccc"
+        },
+        {
+          "kind": "nkIdent",
+          "ident": "dddddddddddddddddd"
+        }
+      ]
+    },
+    {
+      "kind": "nkImportStmt",
+      "sons": [
+        {
+          "kind": "nkInfix",
+          "sons": [
+            {
+              "kind": "nkIdent",
+              "ident": "/"
+            },
+            {
+              "kind": "nkStrLit",
+              "strVal": "a"
+            },
+            {
+              "kind": "nkIdent",
+              "ident": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+            }
+          ]
+        },
+        {
+          "kind": "nkInfix",
+          "sons": [
+            {
+              "kind": "nkIdent",
+              "ident": "/"
+            },
+            {
+              "kind": "nkStrLit",
+              "strVal": "ccccccccccccccccccccccccc"
+            },
+            {
+              "kind": "nkIdent",
+              "ident": "dddddddddddddddddddddd"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "nkFromStmt",
+      "sons": [
+        {
+          "kind": "nkIdent",
+          "ident": "a"
+        },
+        {
+          "kind": "nkIdent",
+          "ident": "a"
+        },
+        {
+          "kind": "nkIdent",
+          "ident": "b"
+        },
+        {
+          "kind": "nkIdent",
+          "ident": "c"
+        }
+      ]
+    },
+    {
+      "kind": "nkFromStmt",
+      "sons": [
+        {
+          "kind": "nkIdent",
+          "ident": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        },
+        {
+          "kind": "nkIdent",
+          "ident": "aaaaaaaaaaaaaaaaaaaaaa"
+        },
+        {
+          "kind": "nkIdent",
+          "ident": "bbbbbbbbbbbbbbb"
+        },
+        {
+          "kind": "nkIdent",
+          "ident": "cccccccccccccccc"
+        },
+        {
+          "kind": "nkIdent",
+          "ident": "ddddddddddddddd"
+        },
+        {
+          "kind": "nkIdent",
+          "ident": "eeeeeeeeeeeeeeeeeeeeeee"
+        },
+        {
+          "kind": "nkIdent",
+          "ident": "ffffffffffffff"
+        }
+      ]
+    },
+    {
+      "kind": "nkPragma",
+      "sons": [
+        {
+          "kind": "nkIdent",
+          "ident": "push"
+        },
+        {
+          "kind": "nkExprColonExpr",
+          "sons": [
+            {
+              "kind": "nkIdent",
+              "ident": "raises"
+            },
+            {
+              "kind": "nkBracket"
+            }
+          ]
         }
       ]
     }

--- a/tests/after/procs.nim
+++ b/tests/after/procs.nim
@@ -6,7 +6,7 @@ proc a(v: int) =
 
 proc a(
     aaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbb, ccccccccccccccccccccccccccc,
-    vvvvvvvvvvvvvvvvvvvvvv: string
+    vvvvvvvvvvvvvvvvvvvvvv: string;
 ) =
   discard
 
@@ -14,7 +14,7 @@ proc a(
     aaaaaaaaaaaaaaaaaaaaaaa: int;
     bbbbbbbbbbbbbbbbbbbbbb: int;
     ccccccccccccccccccccccccccc: int;
-    vvvvvvvvvvvvvvvvvvvvvv: string
+    vvvvvvvvvvvvvvvvvvvvvv: string;
 ) =
   discard
 
@@ -44,40 +44,42 @@ proc aaa[A, B, C](v: int)
 proc aaaa*[A, B, C](v: int)
 
 proc aaaaa[A, B, C](
-    aaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbb, cccccccccccccccc,
-    ddddddddddddddddddd: int
+  aaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbb, cccccccccccccccc,
+  ddddddddddddddddddd: int;
 )
 
 proc aaaa*[
-    Aaaaaaaaaaaaaaaaaaaaaaaa, Bbbbbbbbbbbbbbbbbbbbbbbbbb, Cccccccccccccccccccccc,
-    Dddddddddddddddddddddd
+  Aaaaaaaaaaaaaaaaaaaaaaaa, Bbbbbbbbbbbbbbbbbbbbbbbbbb, Cccccccccccccccccccccc,
+  Dddddddddddddddddddddd
 ](v: int)
 
 proc aaaaaaaaa*[
-    Aaaaaaaaaaaaaaaaaaaaaaaa, Bbbbbbbbbbbbbbbbbbbbbbbbbb, Cccccccccccccccccccccc,
-    Dddddddddddddddddddddd
+  Aaaaaaaaaaaaaaaaaaaaaaaa, Bbbbbbbbbbbbbbbbbbbbbbbbbb, Cccccccccccccccccccccc,
+  Dddddddddddddddddddddd
 ](
-    aaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbb, cccccccccccccccc,
-    ddddddddddddddddddd: int
+  aaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbb, cccccccccccccccc,
+  ddddddddddddddddddd: int;
 )
 
 proc aaaaaaaa[T: Aaaa](v: int)
 
 proc aaaaaaaa[
-    Tttttttttttttttttttttttttttttttttttttttttt: Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  Tttttttttttttttttttttttttttttttttttttttttt: Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 ](v: int)
 
 proc aaaaaaaa[T: Aaaa; S: static int](v: int)
 
 proc aaaaaaaa[
-    T: Aaaaaaaaaaaaaaaaaaaaaaaa | Bbbbbbbbbbbbbbbbbbbbbbbbbbbb | Cccccccccccccccccccccccccc
+  T: Aaaaaaaaaaaaaaaaaaaaaaaa | Bbbbbbbbbbbbbbbbbbbbbbbbbbbb | Cccccccccccccccccccccccccc
 ](v: int)
 
 proc aaaaaaaaaaa(
-    v: Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa | Bbbbbbbbbbbbbbbbbbbbbbbbbbbbb | Cccccccccccccccccccccccccc
+  v: Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa | Bbbbbbbbbbbbbbbbbbbbbbbbbbbbb |
+    Cccccccccccccccccccccccccc;
 )
 
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 42 + 33 + 44
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 42 + 33 +
+    44
 
 functionCall(
   aaaaaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaaa,
@@ -91,23 +93,28 @@ aasdcsaa(
   ccccccccccc = ddddddddddddd,
   eeeeeeeeeeee = ffffffffffff,
   gggggg,
-  hhhhhhhh
+  hhhhhhhh,
 )
 
-type
-  Ap = proc()
+type Ap = proc()
 
-type
-  Bp = proc
+type Bp = proc
 
-type
-  Cp = proc(v: int)
+type Cp = proc(v: int)
 
-type
-  Dp = proc() {.nimcall.}
+type Dp = proc() {.nimcall.}
 
-type
-  Ep = proc {.nimcall.}
+type Ep = proc {.nimcall.}
 
-type
-  Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = proc {.bbbbbbbbbbbbbbbbbbbbbbbb.}
+type Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = proc {.bbbbbbbbbbbbbbbbbbbbbbbb.}
+
+type Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa =
+  proc(aaaaaaaa: Bbbbbbb; ccccccccc: Dddddddddddd; eeeeee: Ffffff)
+
+type Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa =
+  proc(
+    aaaaaaaa: Bbbbbbb;
+    ccccccccc: Dddddddddddd;
+    eeeeeeeeeeeee: Ffffffffffffffff;
+    gggggggggggggg: Hhhhhhhhhhhhhhhhhhhh;
+  )

--- a/tests/after/procs.nim.nph.yaml
+++ b/tests/after/procs.nim.nph.yaml
@@ -1773,6 +1773,184 @@
           ]
         }
       ]
+    },
+    {
+      "kind": "nkTypeSection",
+      "sons": [
+        {
+          "kind": "nkTypeDef",
+          "sons": [
+            {
+              "kind": "nkIdent",
+              "ident": "Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            },
+            {
+              "kind": "nkEmpty"
+            },
+            {
+              "kind": "nkProcTy",
+              "sons": [
+                {
+                  "kind": "nkFormalParams",
+                  "sons": [
+                    {
+                      "kind": "nkEmpty"
+                    },
+                    {
+                      "kind": "nkIdentDefs",
+                      "sons": [
+                        {
+                          "kind": "nkIdent",
+                          "ident": "aaaaaaaa"
+                        },
+                        {
+                          "kind": "nkIdent",
+                          "ident": "Bbbbbbb"
+                        },
+                        {
+                          "kind": "nkEmpty"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "nkIdentDefs",
+                      "sons": [
+                        {
+                          "kind": "nkIdent",
+                          "ident": "ccccccccc"
+                        },
+                        {
+                          "kind": "nkIdent",
+                          "ident": "Dddddddddddd"
+                        },
+                        {
+                          "kind": "nkEmpty"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "nkIdentDefs",
+                      "sons": [
+                        {
+                          "kind": "nkIdent",
+                          "ident": "eeeeee"
+                        },
+                        {
+                          "kind": "nkIdent",
+                          "ident": "Ffffff"
+                        },
+                        {
+                          "kind": "nkEmpty"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "nkEmpty"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "nkTypeSection",
+      "sons": [
+        {
+          "kind": "nkTypeDef",
+          "sons": [
+            {
+              "kind": "nkIdent",
+              "ident": "Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            },
+            {
+              "kind": "nkEmpty"
+            },
+            {
+              "kind": "nkProcTy",
+              "sons": [
+                {
+                  "kind": "nkFormalParams",
+                  "sons": [
+                    {
+                      "kind": "nkEmpty"
+                    },
+                    {
+                      "kind": "nkIdentDefs",
+                      "sons": [
+                        {
+                          "kind": "nkIdent",
+                          "ident": "aaaaaaaa"
+                        },
+                        {
+                          "kind": "nkIdent",
+                          "ident": "Bbbbbbb"
+                        },
+                        {
+                          "kind": "nkEmpty"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "nkIdentDefs",
+                      "sons": [
+                        {
+                          "kind": "nkIdent",
+                          "ident": "ccccccccc"
+                        },
+                        {
+                          "kind": "nkIdent",
+                          "ident": "Dddddddddddd"
+                        },
+                        {
+                          "kind": "nkEmpty"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "nkIdentDefs",
+                      "sons": [
+                        {
+                          "kind": "nkIdent",
+                          "ident": "eeeeeeeeeeeee"
+                        },
+                        {
+                          "kind": "nkIdent",
+                          "ident": "Ffffffffffffffff"
+                        },
+                        {
+                          "kind": "nkEmpty"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "nkIdentDefs",
+                      "sons": [
+                        {
+                          "kind": "nkIdent",
+                          "ident": "gggggggggggggg"
+                        },
+                        {
+                          "kind": "nkIdent",
+                          "ident": "Hhhhhhhhhhhhhhhhhhhh"
+                        },
+                        {
+                          "kind": "nkEmpty"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "nkEmpty"
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/tests/after/types.nim
+++ b/tests/after/types.nim
@@ -1,0 +1,23 @@
+type A = int
+
+type B = A | B
+
+type Bbbbbbbbbbbbbbbbbbbbbbbbbbbbb =
+  Aaaaaaaaaaaaaa | Bbbbbbbbbbbbbbbbb | Cccccccccccccccccccccc | Dddddddddddddddddddddd
+
+type A[
+  T: Aaaaaaaaaaaaaaaaaaa | Bbbbbbbbbbbbbbbbbbbbbbbb | Cccccccccccccccccccc |
+    Dddddddddddddddd | Eeeeeeeeeeeeeeeeeee
+] = Bbbbbbbbbbbbbbbbbb[T]
+
+proc f(
+  a: Aaaaaaaaaaaaaaaaaaaaaaa | Bbbbbbbbbbbbbbbbbbbbbb | Ccccccccccccccccccccccccccc |
+    Ddddddddddddddddddddddddd | Eeeeeeeeeeeeeeeee;
+)
+
+type CaseObject = object
+  case f: bool
+  of false:
+    vfalse: int
+  of true:
+    vtrue: int

--- a/tests/after/types.nim.nph.yaml
+++ b/tests/after/types.nim.nph.yaml
@@ -1,0 +1,434 @@
+{
+  "kind": "nkStmtList",
+  "sons": [
+    {
+      "kind": "nkTypeSection",
+      "sons": [
+        {
+          "kind": "nkTypeDef",
+          "sons": [
+            {
+              "kind": "nkIdent",
+              "ident": "A"
+            },
+            {
+              "kind": "nkEmpty"
+            },
+            {
+              "kind": "nkIdent",
+              "ident": "int"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "nkTypeSection",
+      "sons": [
+        {
+          "kind": "nkTypeDef",
+          "sons": [
+            {
+              "kind": "nkIdent",
+              "ident": "B"
+            },
+            {
+              "kind": "nkEmpty"
+            },
+            {
+              "kind": "nkInfix",
+              "sons": [
+                {
+                  "kind": "nkIdent",
+                  "ident": "|"
+                },
+                {
+                  "kind": "nkIdent",
+                  "ident": "A"
+                },
+                {
+                  "kind": "nkIdent",
+                  "ident": "B"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "nkTypeSection",
+      "sons": [
+        {
+          "kind": "nkTypeDef",
+          "sons": [
+            {
+              "kind": "nkIdent",
+              "ident": "Bbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+            },
+            {
+              "kind": "nkEmpty"
+            },
+            {
+              "kind": "nkInfix",
+              "sons": [
+                {
+                  "kind": "nkIdent",
+                  "ident": "|"
+                },
+                {
+                  "kind": "nkInfix",
+                  "sons": [
+                    {
+                      "kind": "nkIdent",
+                      "ident": "|"
+                    },
+                    {
+                      "kind": "nkInfix",
+                      "sons": [
+                        {
+                          "kind": "nkIdent",
+                          "ident": "|"
+                        },
+                        {
+                          "kind": "nkIdent",
+                          "ident": "Aaaaaaaaaaaaaa"
+                        },
+                        {
+                          "kind": "nkIdent",
+                          "ident": "Bbbbbbbbbbbbbbbbb"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "nkIdent",
+                      "ident": "Cccccccccccccccccccccc"
+                    }
+                  ]
+                },
+                {
+                  "kind": "nkIdent",
+                  "ident": "Dddddddddddddddddddddd"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "nkTypeSection",
+      "sons": [
+        {
+          "kind": "nkTypeDef",
+          "sons": [
+            {
+              "kind": "nkIdent",
+              "ident": "A"
+            },
+            {
+              "kind": "nkGenericParams",
+              "sons": [
+                {
+                  "kind": "nkIdentDefs",
+                  "sons": [
+                    {
+                      "kind": "nkIdent",
+                      "ident": "T"
+                    },
+                    {
+                      "kind": "nkInfix",
+                      "sons": [
+                        {
+                          "kind": "nkIdent",
+                          "ident": "|"
+                        },
+                        {
+                          "kind": "nkInfix",
+                          "sons": [
+                            {
+                              "kind": "nkIdent",
+                              "ident": "|"
+                            },
+                            {
+                              "kind": "nkInfix",
+                              "sons": [
+                                {
+                                  "kind": "nkIdent",
+                                  "ident": "|"
+                                },
+                                {
+                                  "kind": "nkInfix",
+                                  "sons": [
+                                    {
+                                      "kind": "nkIdent",
+                                      "ident": "|"
+                                    },
+                                    {
+                                      "kind": "nkIdent",
+                                      "ident": "Aaaaaaaaaaaaaaaaaaa"
+                                    },
+                                    {
+                                      "kind": "nkIdent",
+                                      "ident": "Bbbbbbbbbbbbbbbbbbbbbbbb"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "nkIdent",
+                                  "ident": "Cccccccccccccccccccc"
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "nkIdent",
+                              "ident": "Dddddddddddddddd"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "nkIdent",
+                          "ident": "Eeeeeeeeeeeeeeeeeee"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "nkEmpty"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "nkBracketExpr",
+              "sons": [
+                {
+                  "kind": "nkIdent",
+                  "ident": "Bbbbbbbbbbbbbbbbbb"
+                },
+                {
+                  "kind": "nkIdent",
+                  "ident": "T"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "nkProcDef",
+      "sons": [
+        {
+          "kind": "nkIdent",
+          "ident": "f"
+        },
+        {
+          "kind": "nkEmpty"
+        },
+        {
+          "kind": "nkEmpty"
+        },
+        {
+          "kind": "nkFormalParams",
+          "sons": [
+            {
+              "kind": "nkEmpty"
+            },
+            {
+              "kind": "nkIdentDefs",
+              "sons": [
+                {
+                  "kind": "nkIdent",
+                  "ident": "a"
+                },
+                {
+                  "kind": "nkInfix",
+                  "sons": [
+                    {
+                      "kind": "nkIdent",
+                      "ident": "|"
+                    },
+                    {
+                      "kind": "nkInfix",
+                      "sons": [
+                        {
+                          "kind": "nkIdent",
+                          "ident": "|"
+                        },
+                        {
+                          "kind": "nkInfix",
+                          "sons": [
+                            {
+                              "kind": "nkIdent",
+                              "ident": "|"
+                            },
+                            {
+                              "kind": "nkInfix",
+                              "sons": [
+                                {
+                                  "kind": "nkIdent",
+                                  "ident": "|"
+                                },
+                                {
+                                  "kind": "nkIdent",
+                                  "ident": "Aaaaaaaaaaaaaaaaaaaaaaa"
+                                },
+                                {
+                                  "kind": "nkIdent",
+                                  "ident": "Bbbbbbbbbbbbbbbbbbbbbb"
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "nkIdent",
+                              "ident": "Ccccccccccccccccccccccccccc"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "nkIdent",
+                          "ident": "Ddddddddddddddddddddddddd"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "nkIdent",
+                      "ident": "Eeeeeeeeeeeeeeeee"
+                    }
+                  ]
+                },
+                {
+                  "kind": "nkEmpty"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "nkEmpty"
+        },
+        {
+          "kind": "nkEmpty"
+        },
+        {
+          "kind": "nkEmpty"
+        }
+      ]
+    },
+    {
+      "kind": "nkTypeSection",
+      "sons": [
+        {
+          "kind": "nkTypeDef",
+          "sons": [
+            {
+              "kind": "nkIdent",
+              "ident": "CaseObject"
+            },
+            {
+              "kind": "nkEmpty"
+            },
+            {
+              "kind": "nkObjectTy",
+              "sons": [
+                {
+                  "kind": "nkEmpty"
+                },
+                {
+                  "kind": "nkEmpty"
+                },
+                {
+                  "kind": "nkRecList",
+                  "sons": [
+                    {
+                      "kind": "nkRecCase",
+                      "sons": [
+                        {
+                          "kind": "nkIdentDefs",
+                          "sons": [
+                            {
+                              "kind": "nkIdent",
+                              "ident": "f"
+                            },
+                            {
+                              "kind": "nkIdent",
+                              "ident": "bool"
+                            },
+                            {
+                              "kind": "nkEmpty"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "nkOfBranch",
+                          "sons": [
+                            {
+                              "kind": "nkIdent",
+                              "ident": "false"
+                            },
+                            {
+                              "kind": "nkRecList",
+                              "sons": [
+                                {
+                                  "kind": "nkIdentDefs",
+                                  "sons": [
+                                    {
+                                      "kind": "nkIdent",
+                                      "ident": "vfalse"
+                                    },
+                                    {
+                                      "kind": "nkIdent",
+                                      "ident": "int"
+                                    },
+                                    {
+                                      "kind": "nkEmpty"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "nkOfBranch",
+                          "sons": [
+                            {
+                              "kind": "nkIdent",
+                              "ident": "true"
+                            },
+                            {
+                              "kind": "nkRecList",
+                              "sons": [
+                                {
+                                  "kind": "nkIdentDefs",
+                                  "sons": [
+                                    {
+                                      "kind": "nkIdent",
+                                      "ident": "vtrue"
+                                    },
+                                    {
+                                      "kind": "nkIdent",
+                                      "ident": "int"
+                                    },
+                                    {
+                                      "kind": "nkEmpty"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/before/comments.nim
+++ b/tests/before/comments.nim
@@ -276,3 +276,23 @@ block:
   .z()
   # also after call
   .d()
+
+proc f: bool =
+  ## Comment here
+  ## another
+  (true or false)
+
+proc f: bool =
+  ## Comment here
+  ## another
+  if true:
+    false
+  else:
+    ## comment
+    ## comment 2
+    if true:
+      ## comment
+      ## comment 2
+      (true or false)
+    else:
+      false

--- a/tests/before/comments.nim.nph.yaml
+++ b/tests/before/comments.nim.nph.yaml
@@ -2290,6 +2290,202 @@
           ]
         }
       ]
+    },
+    {
+      "kind": "nkProcDef",
+      "sons": [
+        {
+          "kind": "nkIdent",
+          "ident": "f"
+        },
+        {
+          "kind": "nkEmpty"
+        },
+        {
+          "kind": "nkEmpty"
+        },
+        {
+          "kind": "nkFormalParams",
+          "sons": [
+            {
+              "kind": "nkIdent",
+              "ident": "bool"
+            }
+          ]
+        },
+        {
+          "kind": "nkEmpty"
+        },
+        {
+          "kind": "nkEmpty"
+        },
+        {
+          "kind": "nkStmtList",
+          "prefix": [
+            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## Comment here\", line: 281, col: 2, offsetA: 4813, offsetB: 4828)",
+            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## another\", line: 282, col: 2, offsetA: 4831, offsetB: 4841)"
+          ],
+          "sons": [
+            {
+              "kind": "nkPar",
+              "sons": [
+                {
+                  "kind": "nkInfix",
+                  "sons": [
+                    {
+                      "kind": "nkIdent",
+                      "ident": "or"
+                    },
+                    {
+                      "kind": "nkIdent",
+                      "ident": "true"
+                    },
+                    {
+                      "kind": "nkIdent",
+                      "ident": "false"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "nkProcDef",
+      "sons": [
+        {
+          "kind": "nkIdent",
+          "ident": "f"
+        },
+        {
+          "kind": "nkEmpty"
+        },
+        {
+          "kind": "nkEmpty"
+        },
+        {
+          "kind": "nkFormalParams",
+          "sons": [
+            {
+              "kind": "nkIdent",
+              "ident": "bool"
+            }
+          ]
+        },
+        {
+          "kind": "nkEmpty"
+        },
+        {
+          "kind": "nkEmpty"
+        },
+        {
+          "kind": "nkStmtList",
+          "prefix": [
+            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## Comment here\", line: 286, col: 2, offsetA: 4878, offsetB: 4893)",
+            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## another\", line: 287, col: 2, offsetA: 4896, offsetB: 4906)"
+          ],
+          "sons": [
+            {
+              "kind": "nkIfStmt",
+              "sons": [
+                {
+                  "kind": "nkElifBranch",
+                  "sons": [
+                    {
+                      "kind": "nkIdent",
+                      "ident": "true"
+                    },
+                    {
+                      "kind": "nkStmtList",
+                      "sons": [
+                        {
+                          "kind": "nkIdent",
+                          "ident": "false"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "nkElse",
+                  "sons": [
+                    {
+                      "kind": "nkStmtList",
+                      "prefix": [
+                        "(tokType: tkComment, base: base10, spacing: {}, indent: 4, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## comment\", line: 291, col: 4, offsetA: 4940, offsetB: 4950)",
+                        "(tokType: tkComment, base: base10, spacing: {}, indent: 4, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## comment 2\", line: 292, col: 4, offsetA: 4955, offsetB: 4967)"
+                      ],
+                      "sons": [
+                        {
+                          "kind": "nkIfStmt",
+                          "sons": [
+                            {
+                              "kind": "nkElifBranch",
+                              "sons": [
+                                {
+                                  "kind": "nkIdent",
+                                  "ident": "true"
+                                },
+                                {
+                                  "kind": "nkStmtList",
+                                  "prefix": [
+                                    "(tokType: tkComment, base: base10, spacing: {}, indent: 6, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## comment\", line: 294, col: 6, offsetA: 4987, offsetB: 4997)",
+                                    "(tokType: tkComment, base: base10, spacing: {}, indent: 6, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## comment 2\", line: 295, col: 6, offsetA: 5004, offsetB: 5016)"
+                                  ],
+                                  "sons": [
+                                    {
+                                      "kind": "nkPar",
+                                      "sons": [
+                                        {
+                                          "kind": "nkInfix",
+                                          "sons": [
+                                            {
+                                              "kind": "nkIdent",
+                                              "ident": "or"
+                                            },
+                                            {
+                                              "kind": "nkIdent",
+                                              "ident": "true"
+                                            },
+                                            {
+                                              "kind": "nkIdent",
+                                              "ident": "false"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "nkElse",
+                              "sons": [
+                                {
+                                  "kind": "nkStmtList",
+                                  "sons": [
+                                    {
+                                      "kind": "nkIdent",
+                                      "ident": "false"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/tests/before/exprs.nim
+++ b/tests/before/exprs.nim
@@ -5,27 +5,6 @@ var c3 = row[p] + (if runeA != runeB:
 
 var c3 = row[p] + (if runeA != runeB: 1 else: 0)
 
-
-proc f: bool =
-  ## Comment here
-  ## another
-  (true or false)
-
-proc f: bool =
-  ## Comment here
-  ## another
-  if true:
-    false
-  else:
-    ## comment
-    ## comment 2
-    if true:
-      ## comment
-      ## comment
-      (true or false)
-    else:
-      false
-
 for a in 0..<1:
   discard
 
@@ -55,3 +34,31 @@ res.add (
 # which become ugly otherwise
 let xxx = implicitdo:
     return xxx
+
+let shortInfix = a*b*c+d*e*f+(a+b)*g
+
+let longInfix = (
+    a30*a21*a12*a03 - a20*a31*a12*a03 - a30*a11*a22*a03 + a10*a31*a22*a03 +
+    a20*a11*a32*a03 - a10*a21*a32*a03 - a30*a21*a02*a13 + a20*a31*a02*a13 +
+    a30*a01*a22*a13 - a00*a31*a22*a13 - a20*a01*a32*a13 + a00*a21*a32*a13 +
+    a30*a11*a02*a23 - a10*a31*a02*a23 - a30*a01*a12*a23 + a00*a31*a12*a23 +
+    a10*a01*a32*a23 - a00*a11*a32*a23 - a20*a11*a02*a33 + a10*a21*a02*a33 +
+    a20*a01*a12*a33 - a00*a21*a12*a33 - a10*a01*a22*a33 + a00*a11*a22*a33
+  )
+
+if aaaaaaaaaaaaaaaaaaaa and bbbbbbbbbbbbbbbbbbbbbbb and ccccccccccccccccccccccccc and ddddddddddddddddd and fffffffffffffffff:
+  discard
+
+if (aaaaaaaaaaaaaaaa and bbbbbbbbbbbbbbbbbbbbbbbbbbbb) or (ccccccccccccccccccccccccccc and ddddddddddddddddddddd):
+  discard
+elif aaaaaaaaa and (bbbbbbbbbb or cccccccccccc and (dddddddddddddddd or eeeeeeeeeeeeeee or fffffffffffffff or gggggggggggggg)):
+  discard
+
+
+case aaaaaaaaaa
+of aaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbb, ccccccccccccccccccccccc, ddddddddddddddddddddddd: discard
+of aaaa: discard
+of aaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbb, ccccccccccccccccccccccc, dddddddddddddddddddddd, aaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbb, ccccccccccccccccccccccc, dddddddddddddddddddddd:
+  discard
+else:
+  discard

--- a/tests/before/exprs.nim.nph.yaml
+++ b/tests/before/exprs.nim.nph.yaml
@@ -180,202 +180,6 @@
       ]
     },
     {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "f"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "bool"
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkStmtList",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## Comment here\", line: 10, col: 2, offsetA: 128, offsetB: 143)",
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## another\", line: 11, col: 2, offsetA: 146, offsetB: 156)"
-          ],
-          "sons": [
-            {
-              "kind": "nkPar",
-              "sons": [
-                {
-                  "kind": "nkInfix",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "or"
-                    },
-                    {
-                      "kind": "nkIdent",
-                      "ident": "true"
-                    },
-                    {
-                      "kind": "nkIdent",
-                      "ident": "false"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "f"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "bool"
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkStmtList",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## Comment here\", line: 15, col: 2, offsetA: 193, offsetB: 208)",
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## another\", line: 16, col: 2, offsetA: 211, offsetB: 221)"
-          ],
-          "sons": [
-            {
-              "kind": "nkIfStmt",
-              "sons": [
-                {
-                  "kind": "nkElifBranch",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "true"
-                    },
-                    {
-                      "kind": "nkStmtList",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "false"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkElse",
-                  "sons": [
-                    {
-                      "kind": "nkStmtList",
-                      "prefix": [
-                        "(tokType: tkComment, base: base10, spacing: {}, indent: 4, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## comment\", line: 20, col: 4, offsetA: 255, offsetB: 265)",
-                        "(tokType: tkComment, base: base10, spacing: {}, indent: 4, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## comment 2\", line: 21, col: 4, offsetA: 270, offsetB: 282)"
-                      ],
-                      "sons": [
-                        {
-                          "kind": "nkIfStmt",
-                          "sons": [
-                            {
-                              "kind": "nkElifBranch",
-                              "sons": [
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "true"
-                                },
-                                {
-                                  "kind": "nkStmtList",
-                                  "prefix": [
-                                    "(tokType: tkComment, base: base10, spacing: {}, indent: 6, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## comment\", line: 23, col: 6, offsetA: 302, offsetB: 312)",
-                                    "(tokType: tkComment, base: base10, spacing: {}, indent: 6, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## comment\", line: 24, col: 6, offsetA: 319, offsetB: 329)"
-                                  ],
-                                  "sons": [
-                                    {
-                                      "kind": "nkPar",
-                                      "sons": [
-                                        {
-                                          "kind": "nkInfix",
-                                          "sons": [
-                                            {
-                                              "kind": "nkIdent",
-                                              "ident": "or"
-                                            },
-                                            {
-                                              "kind": "nkIdent",
-                                              "ident": "true"
-                                            },
-                                            {
-                                              "kind": "nkIdent",
-                                              "ident": "false"
-                                            }
-                                          ]
-                                        }
-                                      ]
-                                    }
-                                  ]
-                                }
-                              ]
-                            },
-                            {
-                              "kind": "nkElse",
-                              "sons": [
-                                {
-                                  "kind": "nkStmtList",
-                                  "sons": [
-                                    {
-                                      "kind": "nkIdent",
-                                      "ident": "false"
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
       "kind": "nkForStmt",
       "sons": [
         {
@@ -456,7 +260,7 @@
     {
       "kind": "nkForStmt",
       "prefix": [
-        "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# needs spaces\", line: 35, col: 0, offsetA: 428, offsetB: 442)"
+        "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# needs spaces\", line: 14, col: 0, offsetA: 163, offsetB: 177)"
       ],
       "sons": [
         {
@@ -587,7 +391,7 @@
     {
       "kind": "nkDiscardStmt",
       "prefix": [
-        "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# command syntax with colon\", line: 44, col: 0, offsetA: 521, offsetB: 548)"
+        "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# command syntax with colon\", line: 23, col: 0, offsetA: 256, offsetB: 283)"
       ],
       "sons": [
         {
@@ -698,6 +502,1795 @@
                           "ident": "xxx"
                         }
                       ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "nkLetSection",
+      "sons": [
+        {
+          "kind": "nkIdentDefs",
+          "sons": [
+            {
+              "kind": "nkIdent",
+              "ident": "shortInfix"
+            },
+            {
+              "kind": "nkEmpty"
+            },
+            {
+              "kind": "nkInfix",
+              "sons": [
+                {
+                  "kind": "nkIdent",
+                  "ident": "+"
+                },
+                {
+                  "kind": "nkInfix",
+                  "sons": [
+                    {
+                      "kind": "nkIdent",
+                      "ident": "+"
+                    },
+                    {
+                      "kind": "nkInfix",
+                      "sons": [
+                        {
+                          "kind": "nkIdent",
+                          "ident": "*"
+                        },
+                        {
+                          "kind": "nkInfix",
+                          "sons": [
+                            {
+                              "kind": "nkIdent",
+                              "ident": "*"
+                            },
+                            {
+                              "kind": "nkIdent",
+                              "ident": "a"
+                            },
+                            {
+                              "kind": "nkIdent",
+                              "ident": "b"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "nkIdent",
+                          "ident": "c"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "nkInfix",
+                      "sons": [
+                        {
+                          "kind": "nkIdent",
+                          "ident": "*"
+                        },
+                        {
+                          "kind": "nkInfix",
+                          "sons": [
+                            {
+                              "kind": "nkIdent",
+                              "ident": "*"
+                            },
+                            {
+                              "kind": "nkIdent",
+                              "ident": "d"
+                            },
+                            {
+                              "kind": "nkIdent",
+                              "ident": "e"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "nkIdent",
+                          "ident": "f"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "nkInfix",
+                  "sons": [
+                    {
+                      "kind": "nkIdent",
+                      "ident": "*"
+                    },
+                    {
+                      "kind": "nkPar",
+                      "sons": [
+                        {
+                          "kind": "nkInfix",
+                          "sons": [
+                            {
+                              "kind": "nkIdent",
+                              "ident": "+"
+                            },
+                            {
+                              "kind": "nkIdent",
+                              "ident": "a"
+                            },
+                            {
+                              "kind": "nkIdent",
+                              "ident": "b"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "nkIdent",
+                      "ident": "g"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "nkLetSection",
+      "sons": [
+        {
+          "kind": "nkIdentDefs",
+          "sons": [
+            {
+              "kind": "nkIdent",
+              "ident": "longInfix"
+            },
+            {
+              "kind": "nkEmpty"
+            },
+            {
+              "kind": "nkPar",
+              "sons": [
+                {
+                  "kind": "nkInfix",
+                  "sons": [
+                    {
+                      "kind": "nkIdent",
+                      "ident": "+"
+                    },
+                    {
+                      "kind": "nkInfix",
+                      "sons": [
+                        {
+                          "kind": "nkIdent",
+                          "ident": "-"
+                        },
+                        {
+                          "kind": "nkInfix",
+                          "sons": [
+                            {
+                              "kind": "nkIdent",
+                              "ident": "-"
+                            },
+                            {
+                              "kind": "nkInfix",
+                              "sons": [
+                                {
+                                  "kind": "nkIdent",
+                                  "ident": "+"
+                                },
+                                {
+                                  "kind": "nkInfix",
+                                  "sons": [
+                                    {
+                                      "kind": "nkIdent",
+                                      "ident": "+"
+                                    },
+                                    {
+                                      "kind": "nkInfix",
+                                      "sons": [
+                                        {
+                                          "kind": "nkIdent",
+                                          "ident": "-"
+                                        },
+                                        {
+                                          "kind": "nkInfix",
+                                          "sons": [
+                                            {
+                                              "kind": "nkIdent",
+                                              "ident": "-"
+                                            },
+                                            {
+                                              "kind": "nkInfix",
+                                              "sons": [
+                                                {
+                                                  "kind": "nkIdent",
+                                                  "ident": "+"
+                                                },
+                                                {
+                                                  "kind": "nkInfix",
+                                                  "sons": [
+                                                    {
+                                                      "kind": "nkIdent",
+                                                      "ident": "+"
+                                                    },
+                                                    {
+                                                      "kind": "nkInfix",
+                                                      "sons": [
+                                                        {
+                                                          "kind": "nkIdent",
+                                                          "ident": "-"
+                                                        },
+                                                        {
+                                                          "kind": "nkInfix",
+                                                          "sons": [
+                                                            {
+                                                              "kind": "nkIdent",
+                                                              "ident": "-"
+                                                            },
+                                                            {
+                                                              "kind": "nkInfix",
+                                                              "sons": [
+                                                                {
+                                                                  "kind": "nkIdent",
+                                                                  "ident": "+"
+                                                                },
+                                                                {
+                                                                  "kind": "nkInfix",
+                                                                  "sons": [
+                                                                    {
+                                                                      "kind": "nkIdent",
+                                                                      "ident": "+"
+                                                                    },
+                                                                    {
+                                                                      "kind": "nkInfix",
+                                                                      "sons": [
+                                                                        {
+                                                                          "kind": "nkIdent",
+                                                                          "ident": "-"
+                                                                        },
+                                                                        {
+                                                                          "kind": "nkInfix",
+                                                                          "sons": [
+                                                                            {
+                                                                              "kind": "nkIdent",
+                                                                              "ident": "-"
+                                                                            },
+                                                                            {
+                                                                              "kind": "nkInfix",
+                                                                              "sons": [
+                                                                                {
+                                                                                  "kind": "nkIdent",
+                                                                                  "ident": "+"
+                                                                                },
+                                                                                {
+                                                                                  "kind": "nkInfix",
+                                                                                  "sons": [
+                                                                                    {
+                                                                                      "kind": "nkIdent",
+                                                                                      "ident": "+"
+                                                                                    },
+                                                                                    {
+                                                                                      "kind": "nkInfix",
+                                                                                      "sons": [
+                                                                                        {
+                                                                                          "kind": "nkIdent",
+                                                                                          "ident": "-"
+                                                                                        },
+                                                                                        {
+                                                                                          "kind": "nkInfix",
+                                                                                          "sons": [
+                                                                                            {
+                                                                                              "kind": "nkIdent",
+                                                                                              "ident": "-"
+                                                                                            },
+                                                                                            {
+                                                                                              "kind": "nkInfix",
+                                                                                              "sons": [
+                                                                                                {
+                                                                                                  "kind": "nkIdent",
+                                                                                                  "ident": "+"
+                                                                                                },
+                                                                                                {
+                                                                                                  "kind": "nkInfix",
+                                                                                                  "sons": [
+                                                                                                    {
+                                                                                                      "kind": "nkIdent",
+                                                                                                      "ident": "+"
+                                                                                                    },
+                                                                                                    {
+                                                                                                      "kind": "nkInfix",
+                                                                                                      "sons": [
+                                                                                                        {
+                                                                                                          "kind": "nkIdent",
+                                                                                                          "ident": "-"
+                                                                                                        },
+                                                                                                        {
+                                                                                                          "kind": "nkInfix",
+                                                                                                          "sons": [
+                                                                                                            {
+                                                                                                              "kind": "nkIdent",
+                                                                                                              "ident": "-"
+                                                                                                            },
+                                                                                                            {
+                                                                                                              "kind": "nkInfix",
+                                                                                                              "sons": [
+                                                                                                                {
+                                                                                                                  "kind": "nkIdent",
+                                                                                                                  "ident": "*"
+                                                                                                                },
+                                                                                                                {
+                                                                                                                  "kind": "nkInfix",
+                                                                                                                  "sons": [
+                                                                                                                    {
+                                                                                                                      "kind": "nkIdent",
+                                                                                                                      "ident": "*"
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                      "kind": "nkInfix",
+                                                                                                                      "sons": [
+                                                                                                                        {
+                                                                                                                          "kind": "nkIdent",
+                                                                                                                          "ident": "*"
+                                                                                                                        },
+                                                                                                                        {
+                                                                                                                          "kind": "nkIdent",
+                                                                                                                          "ident": "a30"
+                                                                                                                        },
+                                                                                                                        {
+                                                                                                                          "kind": "nkIdent",
+                                                                                                                          "ident": "a21"
+                                                                                                                        }
+                                                                                                                      ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                      "kind": "nkIdent",
+                                                                                                                      "ident": "a12"
+                                                                                                                    }
+                                                                                                                  ]
+                                                                                                                },
+                                                                                                                {
+                                                                                                                  "kind": "nkIdent",
+                                                                                                                  "ident": "a03"
+                                                                                                                }
+                                                                                                              ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                              "kind": "nkInfix",
+                                                                                                              "sons": [
+                                                                                                                {
+                                                                                                                  "kind": "nkIdent",
+                                                                                                                  "ident": "*"
+                                                                                                                },
+                                                                                                                {
+                                                                                                                  "kind": "nkInfix",
+                                                                                                                  "sons": [
+                                                                                                                    {
+                                                                                                                      "kind": "nkIdent",
+                                                                                                                      "ident": "*"
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                      "kind": "nkInfix",
+                                                                                                                      "sons": [
+                                                                                                                        {
+                                                                                                                          "kind": "nkIdent",
+                                                                                                                          "ident": "*"
+                                                                                                                        },
+                                                                                                                        {
+                                                                                                                          "kind": "nkIdent",
+                                                                                                                          "ident": "a20"
+                                                                                                                        },
+                                                                                                                        {
+                                                                                                                          "kind": "nkIdent",
+                                                                                                                          "ident": "a31"
+                                                                                                                        }
+                                                                                                                      ]
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                      "kind": "nkIdent",
+                                                                                                                      "ident": "a12"
+                                                                                                                    }
+                                                                                                                  ]
+                                                                                                                },
+                                                                                                                {
+                                                                                                                  "kind": "nkIdent",
+                                                                                                                  "ident": "a03"
+                                                                                                                }
+                                                                                                              ]
+                                                                                                            }
+                                                                                                          ]
+                                                                                                        },
+                                                                                                        {
+                                                                                                          "kind": "nkInfix",
+                                                                                                          "sons": [
+                                                                                                            {
+                                                                                                              "kind": "nkIdent",
+                                                                                                              "ident": "*"
+                                                                                                            },
+                                                                                                            {
+                                                                                                              "kind": "nkInfix",
+                                                                                                              "sons": [
+                                                                                                                {
+                                                                                                                  "kind": "nkIdent",
+                                                                                                                  "ident": "*"
+                                                                                                                },
+                                                                                                                {
+                                                                                                                  "kind": "nkInfix",
+                                                                                                                  "sons": [
+                                                                                                                    {
+                                                                                                                      "kind": "nkIdent",
+                                                                                                                      "ident": "*"
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                      "kind": "nkIdent",
+                                                                                                                      "ident": "a30"
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                      "kind": "nkIdent",
+                                                                                                                      "ident": "a11"
+                                                                                                                    }
+                                                                                                                  ]
+                                                                                                                },
+                                                                                                                {
+                                                                                                                  "kind": "nkIdent",
+                                                                                                                  "ident": "a22"
+                                                                                                                }
+                                                                                                              ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                              "kind": "nkIdent",
+                                                                                                              "ident": "a03"
+                                                                                                            }
+                                                                                                          ]
+                                                                                                        }
+                                                                                                      ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                      "kind": "nkInfix",
+                                                                                                      "sons": [
+                                                                                                        {
+                                                                                                          "kind": "nkIdent",
+                                                                                                          "ident": "*"
+                                                                                                        },
+                                                                                                        {
+                                                                                                          "kind": "nkInfix",
+                                                                                                          "sons": [
+                                                                                                            {
+                                                                                                              "kind": "nkIdent",
+                                                                                                              "ident": "*"
+                                                                                                            },
+                                                                                                            {
+                                                                                                              "kind": "nkInfix",
+                                                                                                              "sons": [
+                                                                                                                {
+                                                                                                                  "kind": "nkIdent",
+                                                                                                                  "ident": "*"
+                                                                                                                },
+                                                                                                                {
+                                                                                                                  "kind": "nkIdent",
+                                                                                                                  "ident": "a10"
+                                                                                                                },
+                                                                                                                {
+                                                                                                                  "kind": "nkIdent",
+                                                                                                                  "ident": "a31"
+                                                                                                                }
+                                                                                                              ]
+                                                                                                            },
+                                                                                                            {
+                                                                                                              "kind": "nkIdent",
+                                                                                                              "ident": "a22"
+                                                                                                            }
+                                                                                                          ]
+                                                                                                        },
+                                                                                                        {
+                                                                                                          "kind": "nkIdent",
+                                                                                                          "ident": "a03"
+                                                                                                        }
+                                                                                                      ]
+                                                                                                    }
+                                                                                                  ]
+                                                                                                },
+                                                                                                {
+                                                                                                  "kind": "nkInfix",
+                                                                                                  "sons": [
+                                                                                                    {
+                                                                                                      "kind": "nkIdent",
+                                                                                                      "ident": "*"
+                                                                                                    },
+                                                                                                    {
+                                                                                                      "kind": "nkInfix",
+                                                                                                      "sons": [
+                                                                                                        {
+                                                                                                          "kind": "nkIdent",
+                                                                                                          "ident": "*"
+                                                                                                        },
+                                                                                                        {
+                                                                                                          "kind": "nkInfix",
+                                                                                                          "sons": [
+                                                                                                            {
+                                                                                                              "kind": "nkIdent",
+                                                                                                              "ident": "*"
+                                                                                                            },
+                                                                                                            {
+                                                                                                              "kind": "nkIdent",
+                                                                                                              "ident": "a20"
+                                                                                                            },
+                                                                                                            {
+                                                                                                              "kind": "nkIdent",
+                                                                                                              "ident": "a11"
+                                                                                                            }
+                                                                                                          ]
+                                                                                                        },
+                                                                                                        {
+                                                                                                          "kind": "nkIdent",
+                                                                                                          "ident": "a32"
+                                                                                                        }
+                                                                                                      ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                      "kind": "nkIdent",
+                                                                                                      "ident": "a03"
+                                                                                                    }
+                                                                                                  ]
+                                                                                                }
+                                                                                              ]
+                                                                                            },
+                                                                                            {
+                                                                                              "kind": "nkInfix",
+                                                                                              "sons": [
+                                                                                                {
+                                                                                                  "kind": "nkIdent",
+                                                                                                  "ident": "*"
+                                                                                                },
+                                                                                                {
+                                                                                                  "kind": "nkInfix",
+                                                                                                  "sons": [
+                                                                                                    {
+                                                                                                      "kind": "nkIdent",
+                                                                                                      "ident": "*"
+                                                                                                    },
+                                                                                                    {
+                                                                                                      "kind": "nkInfix",
+                                                                                                      "sons": [
+                                                                                                        {
+                                                                                                          "kind": "nkIdent",
+                                                                                                          "ident": "*"
+                                                                                                        },
+                                                                                                        {
+                                                                                                          "kind": "nkIdent",
+                                                                                                          "ident": "a10"
+                                                                                                        },
+                                                                                                        {
+                                                                                                          "kind": "nkIdent",
+                                                                                                          "ident": "a21"
+                                                                                                        }
+                                                                                                      ]
+                                                                                                    },
+                                                                                                    {
+                                                                                                      "kind": "nkIdent",
+                                                                                                      "ident": "a32"
+                                                                                                    }
+                                                                                                  ]
+                                                                                                },
+                                                                                                {
+                                                                                                  "kind": "nkIdent",
+                                                                                                  "ident": "a03"
+                                                                                                }
+                                                                                              ]
+                                                                                            }
+                                                                                          ]
+                                                                                        },
+                                                                                        {
+                                                                                          "kind": "nkInfix",
+                                                                                          "sons": [
+                                                                                            {
+                                                                                              "kind": "nkIdent",
+                                                                                              "ident": "*"
+                                                                                            },
+                                                                                            {
+                                                                                              "kind": "nkInfix",
+                                                                                              "sons": [
+                                                                                                {
+                                                                                                  "kind": "nkIdent",
+                                                                                                  "ident": "*"
+                                                                                                },
+                                                                                                {
+                                                                                                  "kind": "nkInfix",
+                                                                                                  "sons": [
+                                                                                                    {
+                                                                                                      "kind": "nkIdent",
+                                                                                                      "ident": "*"
+                                                                                                    },
+                                                                                                    {
+                                                                                                      "kind": "nkIdent",
+                                                                                                      "ident": "a30"
+                                                                                                    },
+                                                                                                    {
+                                                                                                      "kind": "nkIdent",
+                                                                                                      "ident": "a21"
+                                                                                                    }
+                                                                                                  ]
+                                                                                                },
+                                                                                                {
+                                                                                                  "kind": "nkIdent",
+                                                                                                  "ident": "a02"
+                                                                                                }
+                                                                                              ]
+                                                                                            },
+                                                                                            {
+                                                                                              "kind": "nkIdent",
+                                                                                              "ident": "a13"
+                                                                                            }
+                                                                                          ]
+                                                                                        }
+                                                                                      ]
+                                                                                    },
+                                                                                    {
+                                                                                      "kind": "nkInfix",
+                                                                                      "sons": [
+                                                                                        {
+                                                                                          "kind": "nkIdent",
+                                                                                          "ident": "*"
+                                                                                        },
+                                                                                        {
+                                                                                          "kind": "nkInfix",
+                                                                                          "sons": [
+                                                                                            {
+                                                                                              "kind": "nkIdent",
+                                                                                              "ident": "*"
+                                                                                            },
+                                                                                            {
+                                                                                              "kind": "nkInfix",
+                                                                                              "sons": [
+                                                                                                {
+                                                                                                  "kind": "nkIdent",
+                                                                                                  "ident": "*"
+                                                                                                },
+                                                                                                {
+                                                                                                  "kind": "nkIdent",
+                                                                                                  "ident": "a20"
+                                                                                                },
+                                                                                                {
+                                                                                                  "kind": "nkIdent",
+                                                                                                  "ident": "a31"
+                                                                                                }
+                                                                                              ]
+                                                                                            },
+                                                                                            {
+                                                                                              "kind": "nkIdent",
+                                                                                              "ident": "a02"
+                                                                                            }
+                                                                                          ]
+                                                                                        },
+                                                                                        {
+                                                                                          "kind": "nkIdent",
+                                                                                          "ident": "a13"
+                                                                                        }
+                                                                                      ]
+                                                                                    }
+                                                                                  ]
+                                                                                },
+                                                                                {
+                                                                                  "kind": "nkInfix",
+                                                                                  "sons": [
+                                                                                    {
+                                                                                      "kind": "nkIdent",
+                                                                                      "ident": "*"
+                                                                                    },
+                                                                                    {
+                                                                                      "kind": "nkInfix",
+                                                                                      "sons": [
+                                                                                        {
+                                                                                          "kind": "nkIdent",
+                                                                                          "ident": "*"
+                                                                                        },
+                                                                                        {
+                                                                                          "kind": "nkInfix",
+                                                                                          "sons": [
+                                                                                            {
+                                                                                              "kind": "nkIdent",
+                                                                                              "ident": "*"
+                                                                                            },
+                                                                                            {
+                                                                                              "kind": "nkIdent",
+                                                                                              "ident": "a30"
+                                                                                            },
+                                                                                            {
+                                                                                              "kind": "nkIdent",
+                                                                                              "ident": "a01"
+                                                                                            }
+                                                                                          ]
+                                                                                        },
+                                                                                        {
+                                                                                          "kind": "nkIdent",
+                                                                                          "ident": "a22"
+                                                                                        }
+                                                                                      ]
+                                                                                    },
+                                                                                    {
+                                                                                      "kind": "nkIdent",
+                                                                                      "ident": "a13"
+                                                                                    }
+                                                                                  ]
+                                                                                }
+                                                                              ]
+                                                                            },
+                                                                            {
+                                                                              "kind": "nkInfix",
+                                                                              "sons": [
+                                                                                {
+                                                                                  "kind": "nkIdent",
+                                                                                  "ident": "*"
+                                                                                },
+                                                                                {
+                                                                                  "kind": "nkInfix",
+                                                                                  "sons": [
+                                                                                    {
+                                                                                      "kind": "nkIdent",
+                                                                                      "ident": "*"
+                                                                                    },
+                                                                                    {
+                                                                                      "kind": "nkInfix",
+                                                                                      "sons": [
+                                                                                        {
+                                                                                          "kind": "nkIdent",
+                                                                                          "ident": "*"
+                                                                                        },
+                                                                                        {
+                                                                                          "kind": "nkIdent",
+                                                                                          "ident": "a00"
+                                                                                        },
+                                                                                        {
+                                                                                          "kind": "nkIdent",
+                                                                                          "ident": "a31"
+                                                                                        }
+                                                                                      ]
+                                                                                    },
+                                                                                    {
+                                                                                      "kind": "nkIdent",
+                                                                                      "ident": "a22"
+                                                                                    }
+                                                                                  ]
+                                                                                },
+                                                                                {
+                                                                                  "kind": "nkIdent",
+                                                                                  "ident": "a13"
+                                                                                }
+                                                                              ]
+                                                                            }
+                                                                          ]
+                                                                        },
+                                                                        {
+                                                                          "kind": "nkInfix",
+                                                                          "sons": [
+                                                                            {
+                                                                              "kind": "nkIdent",
+                                                                              "ident": "*"
+                                                                            },
+                                                                            {
+                                                                              "kind": "nkInfix",
+                                                                              "sons": [
+                                                                                {
+                                                                                  "kind": "nkIdent",
+                                                                                  "ident": "*"
+                                                                                },
+                                                                                {
+                                                                                  "kind": "nkInfix",
+                                                                                  "sons": [
+                                                                                    {
+                                                                                      "kind": "nkIdent",
+                                                                                      "ident": "*"
+                                                                                    },
+                                                                                    {
+                                                                                      "kind": "nkIdent",
+                                                                                      "ident": "a20"
+                                                                                    },
+                                                                                    {
+                                                                                      "kind": "nkIdent",
+                                                                                      "ident": "a01"
+                                                                                    }
+                                                                                  ]
+                                                                                },
+                                                                                {
+                                                                                  "kind": "nkIdent",
+                                                                                  "ident": "a32"
+                                                                                }
+                                                                              ]
+                                                                            },
+                                                                            {
+                                                                              "kind": "nkIdent",
+                                                                              "ident": "a13"
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      ]
+                                                                    },
+                                                                    {
+                                                                      "kind": "nkInfix",
+                                                                      "sons": [
+                                                                        {
+                                                                          "kind": "nkIdent",
+                                                                          "ident": "*"
+                                                                        },
+                                                                        {
+                                                                          "kind": "nkInfix",
+                                                                          "sons": [
+                                                                            {
+                                                                              "kind": "nkIdent",
+                                                                              "ident": "*"
+                                                                            },
+                                                                            {
+                                                                              "kind": "nkInfix",
+                                                                              "sons": [
+                                                                                {
+                                                                                  "kind": "nkIdent",
+                                                                                  "ident": "*"
+                                                                                },
+                                                                                {
+                                                                                  "kind": "nkIdent",
+                                                                                  "ident": "a00"
+                                                                                },
+                                                                                {
+                                                                                  "kind": "nkIdent",
+                                                                                  "ident": "a21"
+                                                                                }
+                                                                              ]
+                                                                            },
+                                                                            {
+                                                                              "kind": "nkIdent",
+                                                                              "ident": "a32"
+                                                                            }
+                                                                          ]
+                                                                        },
+                                                                        {
+                                                                          "kind": "nkIdent",
+                                                                          "ident": "a13"
+                                                                        }
+                                                                      ]
+                                                                    }
+                                                                  ]
+                                                                },
+                                                                {
+                                                                  "kind": "nkInfix",
+                                                                  "sons": [
+                                                                    {
+                                                                      "kind": "nkIdent",
+                                                                      "ident": "*"
+                                                                    },
+                                                                    {
+                                                                      "kind": "nkInfix",
+                                                                      "sons": [
+                                                                        {
+                                                                          "kind": "nkIdent",
+                                                                          "ident": "*"
+                                                                        },
+                                                                        {
+                                                                          "kind": "nkInfix",
+                                                                          "sons": [
+                                                                            {
+                                                                              "kind": "nkIdent",
+                                                                              "ident": "*"
+                                                                            },
+                                                                            {
+                                                                              "kind": "nkIdent",
+                                                                              "ident": "a30"
+                                                                            },
+                                                                            {
+                                                                              "kind": "nkIdent",
+                                                                              "ident": "a11"
+                                                                            }
+                                                                          ]
+                                                                        },
+                                                                        {
+                                                                          "kind": "nkIdent",
+                                                                          "ident": "a02"
+                                                                        }
+                                                                      ]
+                                                                    },
+                                                                    {
+                                                                      "kind": "nkIdent",
+                                                                      "ident": "a23"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              ]
+                                                            },
+                                                            {
+                                                              "kind": "nkInfix",
+                                                              "sons": [
+                                                                {
+                                                                  "kind": "nkIdent",
+                                                                  "ident": "*"
+                                                                },
+                                                                {
+                                                                  "kind": "nkInfix",
+                                                                  "sons": [
+                                                                    {
+                                                                      "kind": "nkIdent",
+                                                                      "ident": "*"
+                                                                    },
+                                                                    {
+                                                                      "kind": "nkInfix",
+                                                                      "sons": [
+                                                                        {
+                                                                          "kind": "nkIdent",
+                                                                          "ident": "*"
+                                                                        },
+                                                                        {
+                                                                          "kind": "nkIdent",
+                                                                          "ident": "a10"
+                                                                        },
+                                                                        {
+                                                                          "kind": "nkIdent",
+                                                                          "ident": "a31"
+                                                                        }
+                                                                      ]
+                                                                    },
+                                                                    {
+                                                                      "kind": "nkIdent",
+                                                                      "ident": "a02"
+                                                                    }
+                                                                  ]
+                                                                },
+                                                                {
+                                                                  "kind": "nkIdent",
+                                                                  "ident": "a23"
+                                                                }
+                                                              ]
+                                                            }
+                                                          ]
+                                                        },
+                                                        {
+                                                          "kind": "nkInfix",
+                                                          "sons": [
+                                                            {
+                                                              "kind": "nkIdent",
+                                                              "ident": "*"
+                                                            },
+                                                            {
+                                                              "kind": "nkInfix",
+                                                              "sons": [
+                                                                {
+                                                                  "kind": "nkIdent",
+                                                                  "ident": "*"
+                                                                },
+                                                                {
+                                                                  "kind": "nkInfix",
+                                                                  "sons": [
+                                                                    {
+                                                                      "kind": "nkIdent",
+                                                                      "ident": "*"
+                                                                    },
+                                                                    {
+                                                                      "kind": "nkIdent",
+                                                                      "ident": "a30"
+                                                                    },
+                                                                    {
+                                                                      "kind": "nkIdent",
+                                                                      "ident": "a01"
+                                                                    }
+                                                                  ]
+                                                                },
+                                                                {
+                                                                  "kind": "nkIdent",
+                                                                  "ident": "a12"
+                                                                }
+                                                              ]
+                                                            },
+                                                            {
+                                                              "kind": "nkIdent",
+                                                              "ident": "a23"
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "kind": "nkInfix",
+                                                      "sons": [
+                                                        {
+                                                          "kind": "nkIdent",
+                                                          "ident": "*"
+                                                        },
+                                                        {
+                                                          "kind": "nkInfix",
+                                                          "sons": [
+                                                            {
+                                                              "kind": "nkIdent",
+                                                              "ident": "*"
+                                                            },
+                                                            {
+                                                              "kind": "nkInfix",
+                                                              "sons": [
+                                                                {
+                                                                  "kind": "nkIdent",
+                                                                  "ident": "*"
+                                                                },
+                                                                {
+                                                                  "kind": "nkIdent",
+                                                                  "ident": "a00"
+                                                                },
+                                                                {
+                                                                  "kind": "nkIdent",
+                                                                  "ident": "a31"
+                                                                }
+                                                              ]
+                                                            },
+                                                            {
+                                                              "kind": "nkIdent",
+                                                              "ident": "a12"
+                                                            }
+                                                          ]
+                                                        },
+                                                        {
+                                                          "kind": "nkIdent",
+                                                          "ident": "a23"
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "kind": "nkInfix",
+                                                  "sons": [
+                                                    {
+                                                      "kind": "nkIdent",
+                                                      "ident": "*"
+                                                    },
+                                                    {
+                                                      "kind": "nkInfix",
+                                                      "sons": [
+                                                        {
+                                                          "kind": "nkIdent",
+                                                          "ident": "*"
+                                                        },
+                                                        {
+                                                          "kind": "nkInfix",
+                                                          "sons": [
+                                                            {
+                                                              "kind": "nkIdent",
+                                                              "ident": "*"
+                                                            },
+                                                            {
+                                                              "kind": "nkIdent",
+                                                              "ident": "a10"
+                                                            },
+                                                            {
+                                                              "kind": "nkIdent",
+                                                              "ident": "a01"
+                                                            }
+                                                          ]
+                                                        },
+                                                        {
+                                                          "kind": "nkIdent",
+                                                          "ident": "a32"
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "kind": "nkIdent",
+                                                      "ident": "a23"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "kind": "nkInfix",
+                                              "sons": [
+                                                {
+                                                  "kind": "nkIdent",
+                                                  "ident": "*"
+                                                },
+                                                {
+                                                  "kind": "nkInfix",
+                                                  "sons": [
+                                                    {
+                                                      "kind": "nkIdent",
+                                                      "ident": "*"
+                                                    },
+                                                    {
+                                                      "kind": "nkInfix",
+                                                      "sons": [
+                                                        {
+                                                          "kind": "nkIdent",
+                                                          "ident": "*"
+                                                        },
+                                                        {
+                                                          "kind": "nkIdent",
+                                                          "ident": "a00"
+                                                        },
+                                                        {
+                                                          "kind": "nkIdent",
+                                                          "ident": "a11"
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "kind": "nkIdent",
+                                                      "ident": "a32"
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "kind": "nkIdent",
+                                                  "ident": "a23"
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "kind": "nkInfix",
+                                          "sons": [
+                                            {
+                                              "kind": "nkIdent",
+                                              "ident": "*"
+                                            },
+                                            {
+                                              "kind": "nkInfix",
+                                              "sons": [
+                                                {
+                                                  "kind": "nkIdent",
+                                                  "ident": "*"
+                                                },
+                                                {
+                                                  "kind": "nkInfix",
+                                                  "sons": [
+                                                    {
+                                                      "kind": "nkIdent",
+                                                      "ident": "*"
+                                                    },
+                                                    {
+                                                      "kind": "nkIdent",
+                                                      "ident": "a20"
+                                                    },
+                                                    {
+                                                      "kind": "nkIdent",
+                                                      "ident": "a11"
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "kind": "nkIdent",
+                                                  "ident": "a02"
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "kind": "nkIdent",
+                                              "ident": "a33"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "nkInfix",
+                                      "sons": [
+                                        {
+                                          "kind": "nkIdent",
+                                          "ident": "*"
+                                        },
+                                        {
+                                          "kind": "nkInfix",
+                                          "sons": [
+                                            {
+                                              "kind": "nkIdent",
+                                              "ident": "*"
+                                            },
+                                            {
+                                              "kind": "nkInfix",
+                                              "sons": [
+                                                {
+                                                  "kind": "nkIdent",
+                                                  "ident": "*"
+                                                },
+                                                {
+                                                  "kind": "nkIdent",
+                                                  "ident": "a10"
+                                                },
+                                                {
+                                                  "kind": "nkIdent",
+                                                  "ident": "a21"
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "kind": "nkIdent",
+                                              "ident": "a02"
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "kind": "nkIdent",
+                                          "ident": "a33"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "nkInfix",
+                                  "sons": [
+                                    {
+                                      "kind": "nkIdent",
+                                      "ident": "*"
+                                    },
+                                    {
+                                      "kind": "nkInfix",
+                                      "sons": [
+                                        {
+                                          "kind": "nkIdent",
+                                          "ident": "*"
+                                        },
+                                        {
+                                          "kind": "nkInfix",
+                                          "sons": [
+                                            {
+                                              "kind": "nkIdent",
+                                              "ident": "*"
+                                            },
+                                            {
+                                              "kind": "nkIdent",
+                                              "ident": "a20"
+                                            },
+                                            {
+                                              "kind": "nkIdent",
+                                              "ident": "a01"
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "kind": "nkIdent",
+                                          "ident": "a12"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "nkIdent",
+                                      "ident": "a33"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "nkInfix",
+                              "sons": [
+                                {
+                                  "kind": "nkIdent",
+                                  "ident": "*"
+                                },
+                                {
+                                  "kind": "nkInfix",
+                                  "sons": [
+                                    {
+                                      "kind": "nkIdent",
+                                      "ident": "*"
+                                    },
+                                    {
+                                      "kind": "nkInfix",
+                                      "sons": [
+                                        {
+                                          "kind": "nkIdent",
+                                          "ident": "*"
+                                        },
+                                        {
+                                          "kind": "nkIdent",
+                                          "ident": "a00"
+                                        },
+                                        {
+                                          "kind": "nkIdent",
+                                          "ident": "a21"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "nkIdent",
+                                      "ident": "a12"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "nkIdent",
+                                  "ident": "a33"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "nkInfix",
+                          "sons": [
+                            {
+                              "kind": "nkIdent",
+                              "ident": "*"
+                            },
+                            {
+                              "kind": "nkInfix",
+                              "sons": [
+                                {
+                                  "kind": "nkIdent",
+                                  "ident": "*"
+                                },
+                                {
+                                  "kind": "nkInfix",
+                                  "sons": [
+                                    {
+                                      "kind": "nkIdent",
+                                      "ident": "*"
+                                    },
+                                    {
+                                      "kind": "nkIdent",
+                                      "ident": "a10"
+                                    },
+                                    {
+                                      "kind": "nkIdent",
+                                      "ident": "a01"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "nkIdent",
+                                  "ident": "a22"
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "nkIdent",
+                              "ident": "a33"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "nkInfix",
+                      "sons": [
+                        {
+                          "kind": "nkIdent",
+                          "ident": "*"
+                        },
+                        {
+                          "kind": "nkInfix",
+                          "sons": [
+                            {
+                              "kind": "nkIdent",
+                              "ident": "*"
+                            },
+                            {
+                              "kind": "nkInfix",
+                              "sons": [
+                                {
+                                  "kind": "nkIdent",
+                                  "ident": "*"
+                                },
+                                {
+                                  "kind": "nkIdent",
+                                  "ident": "a00"
+                                },
+                                {
+                                  "kind": "nkIdent",
+                                  "ident": "a11"
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "nkIdent",
+                              "ident": "a22"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "nkIdent",
+                          "ident": "a33"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "nkIfStmt",
+      "sons": [
+        {
+          "kind": "nkElifBranch",
+          "sons": [
+            {
+              "kind": "nkInfix",
+              "sons": [
+                {
+                  "kind": "nkIdent",
+                  "ident": "and"
+                },
+                {
+                  "kind": "nkInfix",
+                  "sons": [
+                    {
+                      "kind": "nkIdent",
+                      "ident": "and"
+                    },
+                    {
+                      "kind": "nkInfix",
+                      "sons": [
+                        {
+                          "kind": "nkIdent",
+                          "ident": "and"
+                        },
+                        {
+                          "kind": "nkInfix",
+                          "sons": [
+                            {
+                              "kind": "nkIdent",
+                              "ident": "and"
+                            },
+                            {
+                              "kind": "nkIdent",
+                              "ident": "aaaaaaaaaaaaaaaaaaaa"
+                            },
+                            {
+                              "kind": "nkIdent",
+                              "ident": "bbbbbbbbbbbbbbbbbbbbbbb"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "nkIdent",
+                          "ident": "ccccccccccccccccccccccccc"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "nkIdent",
+                      "ident": "ddddddddddddddddd"
+                    }
+                  ]
+                },
+                {
+                  "kind": "nkIdent",
+                  "ident": "fffffffffffffffff"
+                }
+              ]
+            },
+            {
+              "kind": "nkStmtList",
+              "sons": [
+                {
+                  "kind": "nkDiscardStmt",
+                  "sons": [
+                    {
+                      "kind": "nkEmpty"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "nkIfStmt",
+      "sons": [
+        {
+          "kind": "nkElifBranch",
+          "sons": [
+            {
+              "kind": "nkInfix",
+              "sons": [
+                {
+                  "kind": "nkIdent",
+                  "ident": "or"
+                },
+                {
+                  "kind": "nkPar",
+                  "sons": [
+                    {
+                      "kind": "nkInfix",
+                      "sons": [
+                        {
+                          "kind": "nkIdent",
+                          "ident": "and"
+                        },
+                        {
+                          "kind": "nkIdent",
+                          "ident": "aaaaaaaaaaaaaaaa"
+                        },
+                        {
+                          "kind": "nkIdent",
+                          "ident": "bbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "nkPar",
+                  "sons": [
+                    {
+                      "kind": "nkInfix",
+                      "sons": [
+                        {
+                          "kind": "nkIdent",
+                          "ident": "and"
+                        },
+                        {
+                          "kind": "nkIdent",
+                          "ident": "ccccccccccccccccccccccccccc"
+                        },
+                        {
+                          "kind": "nkIdent",
+                          "ident": "ddddddddddddddddddddd"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "nkStmtList",
+              "sons": [
+                {
+                  "kind": "nkDiscardStmt",
+                  "sons": [
+                    {
+                      "kind": "nkEmpty"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "nkElifBranch",
+          "sons": [
+            {
+              "kind": "nkInfix",
+              "sons": [
+                {
+                  "kind": "nkIdent",
+                  "ident": "and"
+                },
+                {
+                  "kind": "nkIdent",
+                  "ident": "aaaaaaaaa"
+                },
+                {
+                  "kind": "nkPar",
+                  "sons": [
+                    {
+                      "kind": "nkInfix",
+                      "sons": [
+                        {
+                          "kind": "nkIdent",
+                          "ident": "or"
+                        },
+                        {
+                          "kind": "nkIdent",
+                          "ident": "bbbbbbbbbb"
+                        },
+                        {
+                          "kind": "nkInfix",
+                          "sons": [
+                            {
+                              "kind": "nkIdent",
+                              "ident": "and"
+                            },
+                            {
+                              "kind": "nkIdent",
+                              "ident": "cccccccccccc"
+                            },
+                            {
+                              "kind": "nkPar",
+                              "sons": [
+                                {
+                                  "kind": "nkInfix",
+                                  "sons": [
+                                    {
+                                      "kind": "nkIdent",
+                                      "ident": "or"
+                                    },
+                                    {
+                                      "kind": "nkInfix",
+                                      "sons": [
+                                        {
+                                          "kind": "nkIdent",
+                                          "ident": "or"
+                                        },
+                                        {
+                                          "kind": "nkInfix",
+                                          "sons": [
+                                            {
+                                              "kind": "nkIdent",
+                                              "ident": "or"
+                                            },
+                                            {
+                                              "kind": "nkIdent",
+                                              "ident": "dddddddddddddddd"
+                                            },
+                                            {
+                                              "kind": "nkIdent",
+                                              "ident": "eeeeeeeeeeeeeee"
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "kind": "nkIdent",
+                                          "ident": "fffffffffffffff"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "kind": "nkIdent",
+                                      "ident": "gggggggggggggg"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "nkStmtList",
+              "sons": [
+                {
+                  "kind": "nkDiscardStmt",
+                  "sons": [
+                    {
+                      "kind": "nkEmpty"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "nkCaseStmt",
+      "sons": [
+        {
+          "kind": "nkIdent",
+          "ident": "aaaaaaaaaa"
+        },
+        {
+          "kind": "nkOfBranch",
+          "sons": [
+            {
+              "kind": "nkIdent",
+              "ident": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            },
+            {
+              "kind": "nkIdent",
+              "ident": "bbbbbbbbbbbbbbbbbbbbbbbbbb"
+            },
+            {
+              "kind": "nkIdent",
+              "ident": "ccccccccccccccccccccccc"
+            },
+            {
+              "kind": "nkIdent",
+              "ident": "ddddddddddddddddddddddd"
+            },
+            {
+              "kind": "nkStmtList",
+              "sons": [
+                {
+                  "kind": "nkDiscardStmt",
+                  "sons": [
+                    {
+                      "kind": "nkEmpty"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "nkOfBranch",
+          "sons": [
+            {
+              "kind": "nkIdent",
+              "ident": "aaaa"
+            },
+            {
+              "kind": "nkStmtList",
+              "sons": [
+                {
+                  "kind": "nkDiscardStmt",
+                  "sons": [
+                    {
+                      "kind": "nkEmpty"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "nkOfBranch",
+          "sons": [
+            {
+              "kind": "nkIdent",
+              "ident": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            },
+            {
+              "kind": "nkIdent",
+              "ident": "bbbbbbbbbbbbbbbbbbbbbbbbbb"
+            },
+            {
+              "kind": "nkIdent",
+              "ident": "ccccccccccccccccccccccc"
+            },
+            {
+              "kind": "nkIdent",
+              "ident": "dddddddddddddddddddddd"
+            },
+            {
+              "kind": "nkIdent",
+              "ident": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            },
+            {
+              "kind": "nkIdent",
+              "ident": "bbbbbbbbbbbbbbbbbbbbbbbbbb"
+            },
+            {
+              "kind": "nkIdent",
+              "ident": "ccccccccccccccccccccccc"
+            },
+            {
+              "kind": "nkIdent",
+              "ident": "dddddddddddddddddddddd"
+            },
+            {
+              "kind": "nkStmtList",
+              "sons": [
+                {
+                  "kind": "nkDiscardStmt",
+                  "sons": [
+                    {
+                      "kind": "nkEmpty"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "nkElse",
+          "sons": [
+            {
+              "kind": "nkStmtList",
+              "sons": [
+                {
+                  "kind": "nkDiscardStmt",
+                  "sons": [
+                    {
+                      "kind": "nkEmpty"
                     }
                   ]
                 }

--- a/tests/before/import.nim
+++ b/tests/before/import.nim
@@ -2,6 +2,7 @@ import tables
 import "." / tables
 import "." / [tables, sets]
 import sets as dummies
+import aaaaaaaaaaaaaa as bbbbbbbbbbbbbb, ccccccccccccc as dddddddddddddd, eeeeeeeeeeeee as fffffffffffffff, gggggggggggggggggg as hhhhhhhhhhhhhhhh
 
 import "." / [tables, sets, long, modules, even, more, more, a_really_long_module_here, more, more, more, more, more]
 
@@ -12,3 +13,14 @@ from tables import Xxx, yyy
 export a, b, c
 
 export aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccc, dddddddddddddddddd
+
+include a
+include aaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbb, ccccccccccccccccccccccccc, dddddddddddddddddd
+
+import "a"/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, "ccccccccccccccccccccccccc"/dddddddddddddddddddddd
+
+from a import a, b, c
+
+from aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa import aaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbb, cccccccccccccccc, ddddddddddddddd, eeeeeeeeeeeeeeeeeeeeeee, ffffffffffffff
+
+{.push raises: [].}

--- a/tests/before/import.nim.nph.yaml
+++ b/tests/before/import.nim.nph.yaml
@@ -93,6 +93,79 @@
           "sons": [
             {
               "kind": "nkIdent",
+              "ident": "as"
+            },
+            {
+              "kind": "nkIdent",
+              "ident": "aaaaaaaaaaaaaa"
+            },
+            {
+              "kind": "nkIdent",
+              "ident": "bbbbbbbbbbbbbb"
+            }
+          ]
+        },
+        {
+          "kind": "nkInfix",
+          "sons": [
+            {
+              "kind": "nkIdent",
+              "ident": "as"
+            },
+            {
+              "kind": "nkIdent",
+              "ident": "ccccccccccccc"
+            },
+            {
+              "kind": "nkIdent",
+              "ident": "dddddddddddddd"
+            }
+          ]
+        },
+        {
+          "kind": "nkInfix",
+          "sons": [
+            {
+              "kind": "nkIdent",
+              "ident": "as"
+            },
+            {
+              "kind": "nkIdent",
+              "ident": "eeeeeeeeeeeee"
+            },
+            {
+              "kind": "nkIdent",
+              "ident": "fffffffffffffff"
+            }
+          ]
+        },
+        {
+          "kind": "nkInfix",
+          "sons": [
+            {
+              "kind": "nkIdent",
+              "ident": "as"
+            },
+            {
+              "kind": "nkIdent",
+              "ident": "gggggggggggggggggg"
+            },
+            {
+              "kind": "nkIdent",
+              "ident": "hhhhhhhhhhhhhhhh"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "nkImportStmt",
+      "sons": [
+        {
+          "kind": "nkInfix",
+          "sons": [
+            {
+              "kind": "nkIdent",
               "ident": "/"
             },
             {
@@ -225,6 +298,150 @@
         {
           "kind": "nkIdent",
           "ident": "dddddddddddddddddd"
+        }
+      ]
+    },
+    {
+      "kind": "nkIncludeStmt",
+      "sons": [
+        {
+          "kind": "nkIdent",
+          "ident": "a"
+        }
+      ]
+    },
+    {
+      "kind": "nkIncludeStmt",
+      "sons": [
+        {
+          "kind": "nkIdent",
+          "ident": "aaaaaaaaaaaaaaaaaaaa"
+        },
+        {
+          "kind": "nkIdent",
+          "ident": "bbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        },
+        {
+          "kind": "nkIdent",
+          "ident": "ccccccccccccccccccccccccc"
+        },
+        {
+          "kind": "nkIdent",
+          "ident": "dddddddddddddddddd"
+        }
+      ]
+    },
+    {
+      "kind": "nkImportStmt",
+      "sons": [
+        {
+          "kind": "nkInfix",
+          "sons": [
+            {
+              "kind": "nkIdent",
+              "ident": "/"
+            },
+            {
+              "kind": "nkStrLit",
+              "strVal": "a"
+            },
+            {
+              "kind": "nkIdent",
+              "ident": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+            }
+          ]
+        },
+        {
+          "kind": "nkInfix",
+          "sons": [
+            {
+              "kind": "nkIdent",
+              "ident": "/"
+            },
+            {
+              "kind": "nkStrLit",
+              "strVal": "ccccccccccccccccccccccccc"
+            },
+            {
+              "kind": "nkIdent",
+              "ident": "dddddddddddddddddddddd"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "nkFromStmt",
+      "sons": [
+        {
+          "kind": "nkIdent",
+          "ident": "a"
+        },
+        {
+          "kind": "nkIdent",
+          "ident": "a"
+        },
+        {
+          "kind": "nkIdent",
+          "ident": "b"
+        },
+        {
+          "kind": "nkIdent",
+          "ident": "c"
+        }
+      ]
+    },
+    {
+      "kind": "nkFromStmt",
+      "sons": [
+        {
+          "kind": "nkIdent",
+          "ident": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        },
+        {
+          "kind": "nkIdent",
+          "ident": "aaaaaaaaaaaaaaaaaaaaaa"
+        },
+        {
+          "kind": "nkIdent",
+          "ident": "bbbbbbbbbbbbbbb"
+        },
+        {
+          "kind": "nkIdent",
+          "ident": "cccccccccccccccc"
+        },
+        {
+          "kind": "nkIdent",
+          "ident": "ddddddddddddddd"
+        },
+        {
+          "kind": "nkIdent",
+          "ident": "eeeeeeeeeeeeeeeeeeeeeee"
+        },
+        {
+          "kind": "nkIdent",
+          "ident": "ffffffffffffff"
+        }
+      ]
+    },
+    {
+      "kind": "nkPragma",
+      "sons": [
+        {
+          "kind": "nkIdent",
+          "ident": "push"
+        },
+        {
+          "kind": "nkExprColonExpr",
+          "sons": [
+            {
+              "kind": "nkIdent",
+              "ident": "raises"
+            },
+            {
+              "kind": "nkBracket"
+            }
+          ]
         }
       ]
     }

--- a/tests/before/procs.nim
+++ b/tests/before/procs.nim
@@ -40,3 +40,5 @@ type Cp = proc(v: int)
 type Dp = proc() {.nimcall.}
 type Ep = proc {.nimcall.}
 type Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = proc {.bbbbbbbbbbbbbbbbbbbbbbbb.}
+type Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = proc (aaaaaaaa: Bbbbbbb, ccccccccc: Dddddddddddd, eeeeee: Ffffff)
+type Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = proc (aaaaaaaa: Bbbbbbb, ccccccccc: Dddddddddddd, eeeeeeeeeeeee: Ffffffffffffffff, gggggggggggggg: Hhhhhhhhhhhhhhhhhhhh)

--- a/tests/before/procs.nim.nph.yaml
+++ b/tests/before/procs.nim.nph.yaml
@@ -1773,6 +1773,184 @@
           ]
         }
       ]
+    },
+    {
+      "kind": "nkTypeSection",
+      "sons": [
+        {
+          "kind": "nkTypeDef",
+          "sons": [
+            {
+              "kind": "nkIdent",
+              "ident": "Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            },
+            {
+              "kind": "nkEmpty"
+            },
+            {
+              "kind": "nkProcTy",
+              "sons": [
+                {
+                  "kind": "nkFormalParams",
+                  "sons": [
+                    {
+                      "kind": "nkEmpty"
+                    },
+                    {
+                      "kind": "nkIdentDefs",
+                      "sons": [
+                        {
+                          "kind": "nkIdent",
+                          "ident": "aaaaaaaa"
+                        },
+                        {
+                          "kind": "nkIdent",
+                          "ident": "Bbbbbbb"
+                        },
+                        {
+                          "kind": "nkEmpty"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "nkIdentDefs",
+                      "sons": [
+                        {
+                          "kind": "nkIdent",
+                          "ident": "ccccccccc"
+                        },
+                        {
+                          "kind": "nkIdent",
+                          "ident": "Dddddddddddd"
+                        },
+                        {
+                          "kind": "nkEmpty"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "nkIdentDefs",
+                      "sons": [
+                        {
+                          "kind": "nkIdent",
+                          "ident": "eeeeee"
+                        },
+                        {
+                          "kind": "nkIdent",
+                          "ident": "Ffffff"
+                        },
+                        {
+                          "kind": "nkEmpty"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "nkEmpty"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "nkTypeSection",
+      "sons": [
+        {
+          "kind": "nkTypeDef",
+          "sons": [
+            {
+              "kind": "nkIdent",
+              "ident": "Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            },
+            {
+              "kind": "nkEmpty"
+            },
+            {
+              "kind": "nkProcTy",
+              "sons": [
+                {
+                  "kind": "nkFormalParams",
+                  "sons": [
+                    {
+                      "kind": "nkEmpty"
+                    },
+                    {
+                      "kind": "nkIdentDefs",
+                      "sons": [
+                        {
+                          "kind": "nkIdent",
+                          "ident": "aaaaaaaa"
+                        },
+                        {
+                          "kind": "nkIdent",
+                          "ident": "Bbbbbbb"
+                        },
+                        {
+                          "kind": "nkEmpty"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "nkIdentDefs",
+                      "sons": [
+                        {
+                          "kind": "nkIdent",
+                          "ident": "ccccccccc"
+                        },
+                        {
+                          "kind": "nkIdent",
+                          "ident": "Dddddddddddd"
+                        },
+                        {
+                          "kind": "nkEmpty"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "nkIdentDefs",
+                      "sons": [
+                        {
+                          "kind": "nkIdent",
+                          "ident": "eeeeeeeeeeeee"
+                        },
+                        {
+                          "kind": "nkIdent",
+                          "ident": "Ffffffffffffffff"
+                        },
+                        {
+                          "kind": "nkEmpty"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "nkIdentDefs",
+                      "sons": [
+                        {
+                          "kind": "nkIdent",
+                          "ident": "gggggggggggggg"
+                        },
+                        {
+                          "kind": "nkIdent",
+                          "ident": "Hhhhhhhhhhhhhhhhhhhh"
+                        },
+                        {
+                          "kind": "nkEmpty"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "nkEmpty"
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/tests/before/types.nim
+++ b/tests/before/types.nim
@@ -1,0 +1,15 @@
+type A = int
+
+type B = A | B
+type Bbbbbbbbbbbbbbbbbbbbbbbbbbbbb = Aaaaaaaaaaaaaa | Bbbbbbbbbbbbbbbbb | Cccccccccccccccccccccc | Dddddddddddddddddddddd
+
+type A[T: Aaaaaaaaaaaaaaaaaaa|Bbbbbbbbbbbbbbbbbbbbbbbb|Cccccccccccccccccccc|Dddddddddddddddd|Eeeeeeeeeeeeeeeeeee] = Bbbbbbbbbbbbbbbbbb[T]
+
+proc f(a: Aaaaaaaaaaaaaaaaaaaaaaa | Bbbbbbbbbbbbbbbbbbbbbb | Ccccccccccccccccccccccccccc | Ddddddddddddddddddddddddd | Eeeeeeeeeeeeeeeee)
+
+type CaseObject = object
+  case f: bool
+  of false:
+    vfalse: int
+  of true:
+    vtrue: int

--- a/tests/before/types.nim.nph.yaml
+++ b/tests/before/types.nim.nph.yaml
@@ -1,0 +1,434 @@
+{
+  "kind": "nkStmtList",
+  "sons": [
+    {
+      "kind": "nkTypeSection",
+      "sons": [
+        {
+          "kind": "nkTypeDef",
+          "sons": [
+            {
+              "kind": "nkIdent",
+              "ident": "A"
+            },
+            {
+              "kind": "nkEmpty"
+            },
+            {
+              "kind": "nkIdent",
+              "ident": "int"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "nkTypeSection",
+      "sons": [
+        {
+          "kind": "nkTypeDef",
+          "sons": [
+            {
+              "kind": "nkIdent",
+              "ident": "B"
+            },
+            {
+              "kind": "nkEmpty"
+            },
+            {
+              "kind": "nkInfix",
+              "sons": [
+                {
+                  "kind": "nkIdent",
+                  "ident": "|"
+                },
+                {
+                  "kind": "nkIdent",
+                  "ident": "A"
+                },
+                {
+                  "kind": "nkIdent",
+                  "ident": "B"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "nkTypeSection",
+      "sons": [
+        {
+          "kind": "nkTypeDef",
+          "sons": [
+            {
+              "kind": "nkIdent",
+              "ident": "Bbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+            },
+            {
+              "kind": "nkEmpty"
+            },
+            {
+              "kind": "nkInfix",
+              "sons": [
+                {
+                  "kind": "nkIdent",
+                  "ident": "|"
+                },
+                {
+                  "kind": "nkInfix",
+                  "sons": [
+                    {
+                      "kind": "nkIdent",
+                      "ident": "|"
+                    },
+                    {
+                      "kind": "nkInfix",
+                      "sons": [
+                        {
+                          "kind": "nkIdent",
+                          "ident": "|"
+                        },
+                        {
+                          "kind": "nkIdent",
+                          "ident": "Aaaaaaaaaaaaaa"
+                        },
+                        {
+                          "kind": "nkIdent",
+                          "ident": "Bbbbbbbbbbbbbbbbb"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "nkIdent",
+                      "ident": "Cccccccccccccccccccccc"
+                    }
+                  ]
+                },
+                {
+                  "kind": "nkIdent",
+                  "ident": "Dddddddddddddddddddddd"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "nkTypeSection",
+      "sons": [
+        {
+          "kind": "nkTypeDef",
+          "sons": [
+            {
+              "kind": "nkIdent",
+              "ident": "A"
+            },
+            {
+              "kind": "nkGenericParams",
+              "sons": [
+                {
+                  "kind": "nkIdentDefs",
+                  "sons": [
+                    {
+                      "kind": "nkIdent",
+                      "ident": "T"
+                    },
+                    {
+                      "kind": "nkInfix",
+                      "sons": [
+                        {
+                          "kind": "nkIdent",
+                          "ident": "|"
+                        },
+                        {
+                          "kind": "nkInfix",
+                          "sons": [
+                            {
+                              "kind": "nkIdent",
+                              "ident": "|"
+                            },
+                            {
+                              "kind": "nkInfix",
+                              "sons": [
+                                {
+                                  "kind": "nkIdent",
+                                  "ident": "|"
+                                },
+                                {
+                                  "kind": "nkInfix",
+                                  "sons": [
+                                    {
+                                      "kind": "nkIdent",
+                                      "ident": "|"
+                                    },
+                                    {
+                                      "kind": "nkIdent",
+                                      "ident": "Aaaaaaaaaaaaaaaaaaa"
+                                    },
+                                    {
+                                      "kind": "nkIdent",
+                                      "ident": "Bbbbbbbbbbbbbbbbbbbbbbbb"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "nkIdent",
+                                  "ident": "Cccccccccccccccccccc"
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "nkIdent",
+                              "ident": "Dddddddddddddddd"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "nkIdent",
+                          "ident": "Eeeeeeeeeeeeeeeeeee"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "nkEmpty"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "nkBracketExpr",
+              "sons": [
+                {
+                  "kind": "nkIdent",
+                  "ident": "Bbbbbbbbbbbbbbbbbb"
+                },
+                {
+                  "kind": "nkIdent",
+                  "ident": "T"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "nkProcDef",
+      "sons": [
+        {
+          "kind": "nkIdent",
+          "ident": "f"
+        },
+        {
+          "kind": "nkEmpty"
+        },
+        {
+          "kind": "nkEmpty"
+        },
+        {
+          "kind": "nkFormalParams",
+          "sons": [
+            {
+              "kind": "nkEmpty"
+            },
+            {
+              "kind": "nkIdentDefs",
+              "sons": [
+                {
+                  "kind": "nkIdent",
+                  "ident": "a"
+                },
+                {
+                  "kind": "nkInfix",
+                  "sons": [
+                    {
+                      "kind": "nkIdent",
+                      "ident": "|"
+                    },
+                    {
+                      "kind": "nkInfix",
+                      "sons": [
+                        {
+                          "kind": "nkIdent",
+                          "ident": "|"
+                        },
+                        {
+                          "kind": "nkInfix",
+                          "sons": [
+                            {
+                              "kind": "nkIdent",
+                              "ident": "|"
+                            },
+                            {
+                              "kind": "nkInfix",
+                              "sons": [
+                                {
+                                  "kind": "nkIdent",
+                                  "ident": "|"
+                                },
+                                {
+                                  "kind": "nkIdent",
+                                  "ident": "Aaaaaaaaaaaaaaaaaaaaaaa"
+                                },
+                                {
+                                  "kind": "nkIdent",
+                                  "ident": "Bbbbbbbbbbbbbbbbbbbbbb"
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "nkIdent",
+                              "ident": "Ccccccccccccccccccccccccccc"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "nkIdent",
+                          "ident": "Ddddddddddddddddddddddddd"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "nkIdent",
+                      "ident": "Eeeeeeeeeeeeeeeee"
+                    }
+                  ]
+                },
+                {
+                  "kind": "nkEmpty"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "nkEmpty"
+        },
+        {
+          "kind": "nkEmpty"
+        },
+        {
+          "kind": "nkEmpty"
+        }
+      ]
+    },
+    {
+      "kind": "nkTypeSection",
+      "sons": [
+        {
+          "kind": "nkTypeDef",
+          "sons": [
+            {
+              "kind": "nkIdent",
+              "ident": "CaseObject"
+            },
+            {
+              "kind": "nkEmpty"
+            },
+            {
+              "kind": "nkObjectTy",
+              "sons": [
+                {
+                  "kind": "nkEmpty"
+                },
+                {
+                  "kind": "nkEmpty"
+                },
+                {
+                  "kind": "nkRecList",
+                  "sons": [
+                    {
+                      "kind": "nkRecCase",
+                      "sons": [
+                        {
+                          "kind": "nkIdentDefs",
+                          "sons": [
+                            {
+                              "kind": "nkIdent",
+                              "ident": "f"
+                            },
+                            {
+                              "kind": "nkIdent",
+                              "ident": "bool"
+                            },
+                            {
+                              "kind": "nkEmpty"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "nkOfBranch",
+                          "sons": [
+                            {
+                              "kind": "nkIdent",
+                              "ident": "false"
+                            },
+                            {
+                              "kind": "nkRecList",
+                              "sons": [
+                                {
+                                  "kind": "nkIdentDefs",
+                                  "sons": [
+                                    {
+                                      "kind": "nkIdent",
+                                      "ident": "vfalse"
+                                    },
+                                    {
+                                      "kind": "nkIdent",
+                                      "ident": "int"
+                                    },
+                                    {
+                                      "kind": "nkEmpty"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "nkOfBranch",
+                          "sons": [
+                            {
+                              "kind": "nkIdent",
+                              "ident": "true"
+                            },
+                            {
+                              "kind": "nkRecList",
+                              "sons": [
+                                {
+                                  "kind": "nkIdentDefs",
+                                  "sons": [
+                                    {
+                                      "kind": "nkIdent",
+                                      "ident": "vtrue"
+                                    },
+                                    {
+                                      "kind": "nkIdent",
+                                      "ident": "int"
+                                    },
+                                    {
+                                      "kind": "nkEmpty"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* more compact import/type/var/let/const/etc sections when subnodes are simple
* fix infix line breaks
* single indent in proc forward declarations and typedefs - double when there's a body
* if/elif/except/while condition double indent when needed
* comma at end of one-per-line lists when permissible
  * helps git merges when adding to the list
* literals are considered "simple" for list formatting
* empty brackets are not linebroken