### PR TITLE
the blank line update

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,20 @@ were originally written.
 Improvements in this area are much welcome - the compiler AST was not really
 written with comment preservation in mind and `nph`'s handling is not great.
 
+### How are blank lines handled?
+
+Coming up with a fully automatic rendering of blank lines is tricky because they
+are often used to signal logical groupings of code for which no other mechanism
+exists to represent them.
+
+`nph` current will:
+
+* generally retain blank space in code but normalise it to a single line
+* insert blanks around complex statements
+
+This strategy is expected to evolve over time, including the meaning of
+"complex".
+
 ### What features will likely not be added?
 
 * formatting options - things that change the way the formatting is done for

--- a/src/astcmp.nim
+++ b/src/astcmp.nim
@@ -28,21 +28,26 @@ proc equivalent*(a, b: PNode): Outcome =
     if b.kind in {nkFormalParams, nkRecList, nkStmtList, nkStmtListExpr} and
         b.sons.len == 1:
       return equivalent(a, b.sons[0])
+
     if a.kind in {nkFormalParams, nkRecList, nkStmtList, nkStmtListExpr} and
         a.sons.len == 1:
       return equivalent(a.sons[0], b)
+
     if b.kind in {nkFormalParams, nkRecList, nkStmtList, nkStmtListExpr} and
         b.sons.len == 0 and a.kind == nkEmpty:
       return Outcome(kind: Same)
+
     if a.kind in {nkFormalParams, nkRecList, nkStmtList, nkStmtListExpr} and
         a.sons.len == 0 and b.kind == nkEmpty:
       return Outcome(kind: Same)
+
     if a.kind == nkPrefix and a.len == 2 and a[0].kind == nkIdent and a[0].ident.s == "-" and
         b.kind == a[1].kind:
       # `- 1` is transformed to `-1` which semantically is not exactly the same but close enough
       # TODO the positive and negative ranges of integers are not the same - is this a problem?
       #      what about more complex expressions?
       return Outcome(kind: Same)
+
     # runnableExamples: static: ... turns into a staticStmt when broken up in
     # lines (!)
     if a.kind == nkCall and b.kind == nkStaticStmt and a.sons.len > 1 and
@@ -68,6 +73,7 @@ proc equivalent*(a, b: PNode): Outcome =
       let
         af = a.sons.filterIt(it.kind != nkCommentStmt)
         bf = b.sons.filterIt(it.kind != nkCommentStmt)
+
       if af.len() != bf.len():
         false
       else:
@@ -77,6 +83,7 @@ proc equivalent*(a, b: PNode): Outcome =
             return eq
 
         true
+
   if not eq:
     Outcome(kind: Different, a: a, b: b)
   else:

--- a/src/nph.nim
+++ b/src/nph.nim
@@ -4,6 +4,7 @@
 
 import
   "."/[astcmp, phast, phastalgo, phmsgs, phlineinfos, phoptions, phparser, phrenderer]
+
 import "$nim"/compiler/idents
 
 from "$nim"/compiler/astalgo import nil
@@ -57,7 +58,8 @@ proc prettyPrint(infile, outfile: string; debug, check, printTokens: bool): bool
       else:
         readFile(infile)
     node = parse(input, infile, printTokens, conf)
-    output = renderTree(node, {}, conf) & "\n"
+    output = renderTree(node, conf) & "\n"
+
   if infile != "-":
     if debug:
       # Always write file in debug mode
@@ -83,6 +85,7 @@ proc prettyPrint(infile, outfile: string; debug, check, printTokens: bool): bool
         outfile
       ,
     )
+
   if eq.kind == Different:
     stderr.writeLine "--- Input ---"
     stderr.writeLine input
@@ -103,6 +106,7 @@ proc prettyPrint(infile, outfile: string; debug, check, printTokens: bool): bool
           writeFile(outfile, input)
 
     quit 2
+
   if check:
     false # We failed the equivalence check above
   else:
@@ -123,6 +127,7 @@ proc main() =
     debug = false
     check = false
     printTokens = false
+
   for kind, key, val in getopt():
     case kind
     of cmdArgument:
@@ -149,10 +154,13 @@ proc main() =
         writeHelp()
     of cmdEnd:
       assert(false) # cannot happen
+
   if infiles.len == 0:
     quit "[Error] no input file.", 3
+
   if outfile.len != 0 and outdir.len != 0:
     quit "[Error] out and outDir cannot both be specified", 3
+
   if outfile.len == 0 and outdir.len == 0:
     outfiles = infiles
   elif outfile.len != 0 and infiles.len > 1:
@@ -165,6 +173,7 @@ proc main() =
     outfiles = @[outfile]
   elif outdir.len != 0:
     outfiles = infiles.mapIt($(joinPath(outdir, it)))
+
   for (infile, outfile) in zip(infiles, outfiles):
     let (dir, _, _) = splitFile(outfile)
 

--- a/src/phast.nim
+++ b/src/phast.nim
@@ -369,6 +369,7 @@ const
   sfBase* = sfDiscriminant
   sfCustomPragma* = sfRegister # symbol is custom pragma template
   sfTemplateRedefinition* = sfExportc # symbol is a redefinition of an earlier template
+
 const
   # getting ready for the future expr/stmt merge
   nkWhen* = nkWhenStmt
@@ -382,7 +383,8 @@ const
   pragmasEffects* = 4 # not an effect, but a slot for pragmas in proc type
   forbiddenEffects* = 5 # list of illegal effects
   effectListLen* = 6 # list of effects list
-  nkLastBlockStmts* = {nkRaiseStmt, nkReturnStmt, nkBreakStmt, nkContinueStmt} # these must be last statements in a block
+  nkLastBlockStmts* = {nkRaiseStmt, nkReturnStmt, nkBreakStmt, nkContinueStmt}
+    # these must be last statements in a block
 
 type TTypeKind* = enum
   # order is important!
@@ -991,7 +993,8 @@ const
       mLeStr, mLtStr, mEqSet, mLeSet, mLtSet, mMulSet, mPlusSet, mMinusSet, mConStrStr,
       mAppendStrCh, mAppendStrStr, mAppendSeqElem, mInSet, mRepr, mOpenArrayToSeq
     }
-  generatedMagics* = {mNone, mIsolate, mFinished, mOpenArrayToSeq} ## magics that are generated as normal procs in the backend
+  generatedMagics* = {mNone, mIsolate, mFinished, mOpenArrayToSeq}
+    ## magics that are generated as normal procs in the backend
 
 type ItemId* = object
   module*: int32
@@ -1364,7 +1367,8 @@ const
       tyUInt .. tyUInt64
     } # weird name because it contains tyFloat
   ConstantDataTypes*: TTypeKinds = {tyArray, tySet, tyTuple, tySequence}
-  NilableTypes*: TTypeKinds = {tyPointer, tyCstring, tyRef, tyPtr, tyProc, tyError} # TODO
+  NilableTypes*: TTypeKinds = {tyPointer, tyCstring, tyRef, tyPtr, tyProc, tyError}
+    # TODO
   PtrLikeKinds*: TTypeKinds = {tyPointer, tyPtr} # for VM
   PersistentNodeFlags*: TNodeFlags =
     {
@@ -1561,6 +1565,7 @@ proc getDeclPragma*(n: PNode): PNode =
   else:
     # support as needed for `nkIdentDefs` etc.
     result = nil
+
   if result != nil:
     assert result.kind == nkPragma, $(result.kind, n.kind)
 
@@ -1909,6 +1914,7 @@ proc newType*(kind: TTypeKind; id: ItemId; owner: PSym): PType =
       itemId: id,
       uniqueId: id,
     )
+
   when false:
     if result.itemId.module == 55 and result.itemId.item == 2:
       echo "KNID ", kind
@@ -1918,12 +1924,14 @@ proc newType*(kind: TTypeKind; id: ItemId; owner: PSym): PType =
 proc mergeLoc(a: var TLoc; b: TLoc) =
   if a.k == low(typeof(a.k)):
     a.k = b.k
+
   if a.storage == low(typeof(a.storage)):
     a.storage = b.storage
 
   a.flags.incl b.flags
   if a.lode == nil:
     a.lode = b.lode
+
   if a.r == "":
     a.r = b.r
 
@@ -1937,6 +1945,7 @@ proc assignType*(dest, src: PType) =
   dest.n = src.n
   dest.size = src.size
   dest.align = src.align
+
   # this fixes 'type TLock = TSysLock':
   if src.sym != nil:
     if dest.sym != nil:
@@ -1964,6 +1973,7 @@ proc exactReplica*(t: PType): PType =
 
 proc copySym*(s: PSym; idgen: IdGenerator): PSym =
   result = newSym(s.kind, s.name, idgen, s.owner, s.info, s.options)
+
   #result.ast = nil            # BUGFIX; was: s.ast which made problems
   result.typ = s.typ
   result.flags = s.flags
@@ -1982,8 +1992,10 @@ proc createModuleAlias*(
     s: PSym; idgen: IdGenerator; newIdent: PIdent; info: TLineInfo; options: TOptions
 ): PSym =
   result = newSym(s.kind, newIdent, idgen, s.owner, info, options)
+
   # keep ID!
   result.ast = s.ast
+
   #result.id = s.id # XXX figure out what to do with the ID.
   result.flags = s.flags
   result.options = s.options
@@ -2059,6 +2071,7 @@ proc propagateToOwner*(owner, elem: PType; propagateHasAsgn = true) =
   if tfNotNil in elem.flags:
     if owner.kind in {tyGenericInst, tyGenericBody, tyGenericInvocation}:
       owner.flags.incl tfNotNil
+
   if elem.isMetaType:
     owner.flags.incl tfHasMeta
 
@@ -2068,6 +2081,7 @@ proc propagateToOwner*(owner, elem: PType; propagateHasAsgn = true) =
     if o2.kind in {tyTuple, tyObject, tyArray, tySequence, tySet, tyDistinct}:
       o2.flags.incl mask
       owner.flags.incl mask
+
   if owner.kind notin {tyProc, tyGenericInst, tyGenericBody, tyGenericInvocation, tyPtr}:
     let elemB = elem.skipTypes({tyGenericInst, tyAlias, tySink})
     if elemB.isGCedMem or tfHasGCedMem in elemB.flags:
@@ -2089,6 +2103,7 @@ proc addSonNilAllowed*(father, son: PNode) =
 proc delSon*(father: PNode; idx: int) =
   if father.len == 0:
     return
+
   for i in idx ..< father.len - 1:
     father[i] = father[i + 1]
 
@@ -2107,6 +2122,7 @@ proc copyNode*(src: PNode): PNode =
   when defined(useNodeIds):
     if result.id == nodeIdToDebug:
       echo "COMES FROM ", src.id
+
   case src.kind
   of nkCharLit .. nkUInt64Lit:
     result.intVal = src.intVal
@@ -2120,6 +2136,7 @@ proc copyNode*(src: PNode): PNode =
     result.strVal = src.strVal
   else:
     discard
+
   when defined(nimsuggest):
     result.endInfo = src.endInfo
 
@@ -2136,6 +2153,7 @@ template transitionNodeKindCommon(k: TNodeKind) =
       mid: obj.mid,
       postfix: obj.postfix,
     )
+
   # n.comment = obj.comment # shouldn't be needed, the address doesnt' change
   when defined(useNodeIds):
     n.id = obj.id
@@ -2179,8 +2197,10 @@ template transitionSymKindCommon*(k: TSymKind) =
       annex: obj.annex,
       constraint: obj.constraint,
     )
+
   when hasFFI:
     s.cname = obj.cname
+
   when defined(nimsuggest):
     s.allUsages = obj.allUsages
 
@@ -2215,6 +2235,7 @@ template copyNodeImpl(dst, src, processSonsStmt) =
   when defined(useNodeIds):
     if dst.id == nodeIdToDebug:
       echo "COMES FROM ", src.id
+
   case src.kind
   of nkCharLit .. nkUInt64Lit:
     dst.intVal = src.intVal
@@ -2267,6 +2288,7 @@ proc hasNilSon*(n: PNode): bool =
 proc containsNode*(n: PNode; kinds: TNodeKinds): bool =
   if n == nil:
     return
+
   case n.kind
   of nkEmpty .. nkNilLit:
     result = n.kind in kinds
@@ -2496,6 +2518,7 @@ proc findUnresolvedStatic*(n: PNode): PNode =
   # n.typ == nil: see issue #14802
   if n.kind == nkSym and n.typ != nil and n.typ.kind == tyStatic and n.typ.n == nil:
     return n
+
   for son in n:
     let n = son.findUnresolvedStatic
     if n != nil:
@@ -2508,6 +2531,7 @@ when false:
     # only for debugging
     if n.isNil:
       return true
+
     for i in 0 ..< n.safeLen:
       if n[i].containsNil:
         return true

--- a/src/phlineinfos.nim
+++ b/src/phlineinfos.nim
@@ -280,6 +280,7 @@ const MsgKindToStr*: array[TMsgKind, string] =
     hintMsgOrigin: "$1",
     hintDeclaredLoc: "$1"
   ]
+
 const
   fatalMsgs* = {errUnknown .. errInternal}
   errMin* = errUnknown
@@ -298,9 +299,11 @@ proc computeNotesVerbosity(): array[0 .. 3, TNoteKinds] =
   result[3] =
     {low(TNoteKind) .. high(TNoteKind)} -
       {warnObservableStores, warnResultUsed, warnAnyEnumConv, warnBareExcept}
+
   result[2] =
     result[3] -
       {hintStackTrace, hintExtendedContext, hintDeclaredLoc, hintProcessingStmt}
+
   result[1] =
     result[2] -
       {
@@ -308,6 +311,7 @@ proc computeNotesVerbosity(): array[0 .. 3, TNoteKinds] =
         hintCodeBegin, hintCodeEnd, hintSource, hintGlobalVar, hintGCStats,
         hintMsgOrigin, hintPerformance
       }
+
   result[0] =
     result[1] -
       {
@@ -386,8 +390,8 @@ type Severity* {.pure.} = enum ## VS Code only supports these three
 
 const
   trackPosInvalidFileIdx* = FileIndex(-2)
-      # special marker so that no suggestions
-      # are produced within comments and string literals
+    # special marker so that no suggestions
+    # are produced within comments and string literals
   commandLineIdx* = FileIndex(-3)
 
 type MsgConfig* = object ## does not need to be stored in the incremental cache

--- a/src/phoptions.nim
+++ b/src/phoptions.nim
@@ -12,6 +12,7 @@
 import
   std/[os, strutils, strtabs, sets, tables],
   "$nim"/compiler/[platform, prefixmatches, pathutils, nimpaths]
+
 import ./phlineinfos
 
 from std/terminal import isatty
@@ -147,7 +148,8 @@ const
   DocConfig* = RelativeFile"nimdoc.cfg"
   DocTexConfig* = RelativeFile"nimdoc.tex.cfg"
   htmldocsDir* = htmldocsDirname.RelativeDir
-  docRootDefault* = "@default" # using `@` instead of `$` to avoid shell quoting complications
+  docRootDefault* = "@default"
+    # using `@` instead of `$` to avoid shell quoting complications
   oKeepVariableNames* = true
   spellSuggestSecretSauce* = -1
 
@@ -399,10 +401,12 @@ type
     ideCmd*: IdeCmd
     oldNewlines*: bool
     cCompiler*: TSystemCC # the used compiler
-    modifiedyNotes*: TNoteKinds # notes that have been set/unset from either cmdline/configs
+    modifiedyNotes*: TNoteKinds
+      # notes that have been set/unset from either cmdline/configs
     cmdlineNotes*: TNoteKinds # notes that have been set/unset from cmdline
     foreignPackageNotes*: TNoteKinds
-    notes*: TNoteKinds # notes after resolving all logic(defaults, verbosity)/cmdline/configs
+    notes*: TNoteKinds
+      # notes after resolving all logic(defaults, verbosity)/cmdline/configs
     warningAsErrors*: TNoteKinds
     mainPackageNotes*: TNoteKinds
     mainPackageId*: int
@@ -463,9 +467,10 @@ type
     suggestMaxResults*: int
     lastLineInfo*: TLineInfo
     writelnHook*: proc(output: string) {.closure, gcsafe.}
-    structuredErrorHook*: proc(
-      config: ConfigRef; info: TLineInfo; msg: string; severity: Severity
-    ) {.closure, gcsafe.}
+    structuredErrorHook*:
+      proc(config: ConfigRef; info: TLineInfo; msg: string; severity: Severity) {.
+        closure, gcsafe
+      .}
     cppCustomNamespace*: string
     nimMainPrefix*: string
     vmProfileData*: ProfileData
@@ -550,7 +555,8 @@ const
   DefaultOptions* =
     {
       optObjCheck, optFieldCheck, optRangeCheck, optBoundsCheck, optOverflowCheck,
-      optAssert, optWarns, optRefCheck, optHints, optStackTrace, optLineTrace, # consider adding `optStackTraceMsgs`
+      optAssert, optWarns, optRefCheck, optHints, optStackTrace, optLineTrace,
+        # consider adding `optStackTraceMsgs`
       optTrMacros, optStyleCheck, optCursorInference
     }
   DefaultGlobalOptions* = {optThreadAnalysis, optExcessiveStackTrace, optJsBigInt64}
@@ -663,9 +669,11 @@ proc newConfigRef*(): ConfigRef =
 
   initConfigRefCommon(result)
   setTargetFromSystem(result.target)
+
   # enable colors by default on terminals
   if terminal.isatty(stderr):
     incl(result.globalOptions, optUseColors)
+
   when defined(nimDebugUtils):
     onNewConfigRef(result)
 
@@ -853,6 +861,7 @@ proc setDefaultLibpath*(conf: ConfigRef) =
     # Special rule to support other tools (nimble) which import the compiler
     # modules and make use of them.
     let realNimPath = findExe("nim")
+
     # Find out if $nim/../../lib/system.nim exists.
     let parentNimLibPath = realNimPath.parentDir.parentDir / "lib"
     if not fileExists(conf.libpath.string / "system.nim") and
@@ -1017,6 +1026,7 @@ const stdlibDirs* =
     "impure", "wrappers", "wrappers/linenoise", "windows", "posix", "js",
     "deprecated/pure"
   ]
+
 const
   pkgPrefix = "pkg/"
   stdPrefix = "std/"
@@ -1080,6 +1090,7 @@ proc findModule*(conf: ConfigRef; modulename, currentModule: string): AbsoluteFi
       if m.startsWith('.') and not fileExists(result):
         result = AbsoluteFile ""
         hasRelativeDot = true
+
     if not fileExists(result) and not hasRelativeDot:
       result = findFile(conf, m)
 
@@ -1103,9 +1114,11 @@ proc findProjectNimFile*(conf: ConfigRef; pkg: string): string =
           let x = changeFileExt(dir / name, ".nim")
           if fileExists(x):
             candidates.add x
+
           if ext == ".nimble":
             if nimblepkg.len == 0:
               nimblepkg = name
+
               # Since nimble packages can have their source in a subfolder,
               # check the last folder we were in for a possible match.
               if dir != prev:
@@ -1123,9 +1136,11 @@ proc findProjectNimFile*(conf: ConfigRef; pkg: string): string =
         nimblepkg
       else:
         pkgname
+
     for c in candidates:
       if pkgname in c.extractFilename():
         return c
+
     if candidates.len > 0:
       return candidates[0]
 
@@ -1148,6 +1163,7 @@ proc canonicalImportAux*(conf: ConfigRef; file: AbsoluteFile): string =
     let relPath = relativeTo(file, dir)
     if not relPath.isEmpty and (ret.isEmpty or relPath.string.len < ret.string.len):
       ret = relPath
+
   if ret.isEmpty:
     ret = relativeTo(file, conf.projectPath)
 
@@ -1164,6 +1180,7 @@ proc canonDynlibName(s: string): string =
       3
     else:
       0
+
   let ende = strutils.find(s, {'(', ')', '.'})
   if ende >= 0:
     result = s.substr(start, ende - 1)

--- a/tests/after/comments.nim
+++ b/tests/after/comments.nim
@@ -1,30 +1,35 @@
 #
 #
+
 # Some commentary
+
 ## A doc comment
 ##
 ##
+
 ## More doc comments
 ##
+
 #
 # Comment
 #
+
 #[ a multiline comment
 this is also part of it
 and this
 ]#
+
 ##[
   these also come in doc variants
 ]##
+
 #[
   #[
     they can be nested
   ]#
 ]#
 
-x 324
-
-# A comment after
+x 324 # A comment after
 
 template x() =
   ## A template doc comment
@@ -32,7 +37,6 @@ template x() =
     discard
   except Exception:
     mixin `$` # A comment after mixin
-
     echo 4
 
 type
@@ -51,13 +55,19 @@ type
       ## Seek relative to end
       # text file handling:
 
+  ## Position relative to which seek should happen.
+  # The values are ordered so that they match with stdio
+  # SEEK_SET, SEEK_CUR and SEEK_END respectively.
   Object = object
     # comment
     ## more comment
     field: int # Field comment
     # comment between fields
     field2: int ## Field comment again
+    fiiiiiiiiiiiiiiiiiiiiiiiieeeeeeeeeld: int
+      # loooooooooooooooooooong comment past the max line length
 
+  # and here
   Inherited = object of RootObj
     # inherited eol comment
     # inherited next line indent comments
@@ -71,8 +81,7 @@ type
   SomeAlias* = int
       ## alias eol
       ## alias next
-  SomeAlias2 {.nodecl.} = # after pragma
-    int ## alias2 eol
+  SomeAlias2 {.nodecl.} = int ## alias2 eol
   SomeAlias3 # alias after symbol
     [T] = # alias after equals
       int # alias after type
@@ -99,16 +108,19 @@ when defined(somecond): # when colon line
 else: # else colon line
   # else first line
   discard
+
 if true:
   # if next line
   discard
 else:
   # else next line
   discard
+
 if true: # if colon line
   discard
 else: # else colon line
   discard
+
 if true:
   # if dedented colon line
   discard
@@ -127,6 +139,7 @@ proc x() =
   ## A proc doc comment
   if true:
     numberOfCharsRead -= 2 # handle Ctrl+Z as EOF
+
     for i in 0 ..< numberOfCharsRead:
       discard
 
@@ -138,18 +151,20 @@ proc x() =
 # before module
 import module # with a comment
 import module ## with a comment
+
 try: # try colon line
   # try first line
   discard
-# try last line
-except:
+  # try last line
+except: # except colon line
   # except first line
   discard
-# except last line
-finally:
+  # except last line
+finally: # Finally colon line
   # finally first line
   discard
-# finally last line
+  # finally last line
+
 try:
   # try first dedent line
   f()
@@ -161,10 +176,12 @@ except:
 finally:
   # finally first dedent line
   discard
+
 # finally last dedent line
 for i in 0 .. 1: # for colon line
   # for first line
   discard
+
 case a # case line
 of true: # of colon line
   # of first line
@@ -187,7 +204,8 @@ let x =
       # lambda first line
       discard
       discard
-while false:
+
+while false: # while colon line
   # while first line
   discard
 
@@ -199,11 +217,11 @@ discard Object(
     # object eol
     # object first line
     field: 0, # field line
-    field2: 42 # field colon line
+    field2: # Field colon next line
+      42 # field colon line
   )
 
 a = b
-
 ## Doc comment after assignment
 ## needs to be double
 
@@ -214,17 +232,21 @@ proc ffff() =
 ## needs to be double
 abc and # dedented comment in infix
 def
+
 abc and # indented comment in infix
 def
+
 if abc and # dedented comment in infix
 def:
   discard
+
 if abc and # indented comment in infix
 def:
   discard
 
 a(b = c # comment after keyword parameter
   )
+
 a(b = c)
 
 # dedented comment after keyword parameter
@@ -271,3 +293,9 @@ proc f(): bool =
       (true or false)
     else:
       false
+
+command "a", "b", "c" # command eol comment
+
+command "first arg", # first arg comment
+  "second arg", # second arg comment
+  "third arg" # third arg comment

--- a/tests/after/comments.nim.nph.yaml
+++ b/tests/after/comments.nim.nph.yaml
@@ -1,2502 +1,1179 @@
-{
-  "kind": "nkStmtList",
-  "sons": [
-    {
-      "kind": "nkCommentStmt",
-      "comment": "#"
-    },
-    {
-      "kind": "nkCommentStmt",
-      "comment": "#"
-    },
-    {
-      "kind": "nkCommentStmt",
-      "comment": "# Some commentary"
-    },
-    {
-      "kind": "nkCommentStmt",
-      "comment": "## A doc comment"
-    },
-    {
-      "kind": "nkCommentStmt",
-      "comment": "##"
-    },
-    {
-      "kind": "nkCommentStmt",
-      "comment": "##"
-    },
-    {
-      "kind": "nkCommentStmt",
-      "comment": "## More doc comments"
-    },
-    {
-      "kind": "nkCommentStmt",
-      "comment": "##"
-    },
-    {
-      "kind": "nkCommentStmt",
-      "comment": "#"
-    },
-    {
-      "kind": "nkCommentStmt",
-      "comment": "# Comment"
-    },
-    {
-      "kind": "nkCommentStmt",
-      "comment": "#"
-    },
-    {
-      "kind": "nkCommentStmt",
-      "comment": "#[ a multiline comment\u000Athis is also part of it\u000Aand this\u000A]#"
-    },
-    {
-      "kind": "nkCommentStmt",
-      "comment": "##[\u000A  these also come in doc variants\u000A]##"
-    },
-    {
-      "kind": "nkCommentStmt",
-      "comment": "#[\u000A  #[\u000A    they can be nested\u000A  ]#\u000A]#"
-    },
-    {
-      "kind": "nkCommand",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "x"
-        },
-        {
-          "kind": "nkIntLit",
-          "intVal": 324
-        }
-      ]
-    },
-    {
-      "kind": "nkCommentStmt",
-      "comment": "# A comment after"
-    },
-    {
-      "kind": "nkTemplateDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "x"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkStmtList",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## A template doc comment\", line: 30, col: 2, offsetA: 267, offsetB: 292)"
-          ],
-          "sons": [
-            {
-              "kind": "nkTryStmt",
-              "sons": [
-                {
-                  "kind": "nkStmtList",
-                  "sons": [
-                    {
-                      "kind": "nkDiscardStmt",
-                      "sons": [
-                        {
-                          "kind": "nkEmpty"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkExceptBranch",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "Exception"
-                    },
-                    {
-                      "kind": "nkStmtList",
-                      "sons": [
-                        {
-                          "kind": "nkMixinStmt",
-                          "sons": [
-                            {
-                              "kind": "nkAccQuoted",
-                              "sons": [
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "$"
-                                }
-                              ],
-                              "postfix": [
-                                "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# A comment after mixin\", line: 34, col: 14, offsetA: 346, offsetB: 369)"
-                              ]
-                            }
-                          ]
-                        },
-                        {
-                          "kind": "nkCommand",
-                          "sons": [
-                            {
-                              "kind": "nkIdent",
-                              "ident": "echo"
-                            },
-                            {
-                              "kind": "nkIntLit",
-                              "intVal": 4
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkTypeSection",
-      "sons": [
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkPragmaExpr",
-              "sons": [
-                {
-                  "kind": "nkPostfix",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "*"
-                    },
-                    {
-                      "kind": "nkIdent",
-                      "ident": "SingleValueSetting"
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkPragma",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "pure"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkEnumTy",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkIdent",
-                  "prefix": [
-                    "(tokType: tkComment, base: base10, spacing: {}, indent: 4, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## \\\\\", line: 40, col: 4, offsetA: 430, offsetB: 434)",
-                    "(tokType: tkComment, base: base10, spacing: {}, indent: 4, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## settings resulting in a single string value\", line: 41, col: 4, offsetA: 439, offsetB: 485)"
-                  ],
-                  "ident": "arguments",
-                  "postfix": [
-                    "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## experimental: the arguments passed after \\\'-r\\\'\", line: 42, col: 14, offsetA: 500, offsetB: 548)"
-                  ]
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "backend",
-                  "postfix": [
-                    "(tokType: tkComment, base: base10, spacing: {}, indent: 6, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## the backend (eg: c|cpp|objc|js); both `nim doc --backend:js`\", line: 44, col: 6, offsetA: 567, offsetB: 630)",
-                    "(tokType: tkComment, base: base10, spacing: {}, indent: 6, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## and `nim js` would imply backend=js\", line: 45, col: 6, offsetA: 637, offsetB: 675)"
-                  ]
-                },
-                {
-                  "kind": "nkPragmaExpr",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "gc"
-                    },
-                    {
-                      "kind": "nkPragma",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "deprecated"
-                        }
-                      ]
-                    }
-                  ],
-                  "postfix": [
-                    "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## gc selected\", line: 46, col: 22, offsetA: 698, offsetB: 712)"
-                  ]
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "mm",
-                  "postfix": [
-                    "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## memory management selected\", line: 47, col: 7, offsetA: 720, offsetB: 749)"
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkPostfix",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "*"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "FileSeekPos"
-                }
-              ]
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkEnumTy",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "fspEnd",
-                  "postfix": [
-                    "(tokType: tkComment, base: base10, spacing: {}, indent: 6, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## Seek relative to end\", line: 51, col: 6, offsetA: 790, offsetB: 813)",
-                    "(tokType: tkComment, base: base10, spacing: {}, indent: 6, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# text file handling:\", line: 52, col: 6, offsetA: 820, offsetB: 841)"
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "Object"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkObjectTy",
-              "mid": [
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 4, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# comment\", line: 55, col: 4, offsetA: 865, offsetB: 874)",
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 4, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## more comment\", line: 56, col: 4, offsetA: 879, offsetB: 894)"
-              ],
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkRecList",
-                  "sons": [
-                    {
-                      "kind": "nkIdentDefs",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "field"
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "int"
-                        },
-                        {
-                          "kind": "nkEmpty"
-                        }
-                      ],
-                      "postfix": [
-                        "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# Field comment\", line: 57, col: 15, offsetA: 910, offsetB: 925)"
-                      ]
-                    },
-                    {
-                      "kind": "nkIdentDefs",
-                      "prefix": [
-                        "(tokType: tkComment, base: base10, spacing: {}, indent: 4, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# comment between fields\", line: 58, col: 4, offsetA: 930, offsetB: 954)"
-                      ],
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "field2"
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "int"
-                        },
-                        {
-                          "kind": "nkEmpty"
-                        }
-                      ],
-                      "postfix": [
-                        "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## Field comment again\", line: 59, col: 16, offsetA: 971, offsetB: 993)"
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "Inherited"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkObjectTy",
-              "mid": [
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 4, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# inherited eol comment\", line: 62, col: 4, offsetA: 1031, offsetB: 1054)",
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 4, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# inherited next line indent comments\", line: 63, col: 4, offsetA: 1059, offsetB: 1096)"
-              ],
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkOfInherit",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "RootObj"
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkRecList",
-                  "sons": [
-                    {
-                      "kind": "nkIdentDefs",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "f"
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "int"
-                        },
-                        {
-                          "kind": "nkEmpty"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "CaseObject"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkObjectTy",
-              "mid": [
-                "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# caseobj eol\", line: 66, col: 22, offsetA: 1131, offsetB: 1144)"
-              ],
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkRecList",
-                  "sons": [
-                    {
-                      "kind": "nkRecCase",
-                      "sons": [
-                        {
-                          "kind": "nkIdentDefs",
-                          "sons": [
-                            {
-                              "kind": "nkIdent",
-                              "ident": "k"
-                            },
-                            {
-                              "kind": "nkIdent",
-                              "ident": "bool"
-                            },
-                            {
-                              "kind": "nkEmpty"
-                            }
-                          ],
-                          "postfix": [
-                            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# casetype eol\", line: 67, col: 17, offsetA: 1162, offsetB: 1176)"
-                          ]
-                        },
-                        {
-                          "kind": "nkOfBranch",
-                          "mid": [
-                            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# of eol\", line: 68, col: 20, offsetA: 1197, offsetB: 1205)"
-                          ],
-                          "sons": [
-                            {
-                              "kind": "nkIdent",
-                              "ident": "true"
-                            },
-                            {
-                              "kind": "nkIdent",
-                              "ident": "false"
-                            },
-                            {
-                              "kind": "nkRecList",
-                              "sons": [
-                                {
-                                  "kind": "nkIdentDefs",
-                                  "sons": [
-                                    {
-                                      "kind": "nkIdent",
-                                      "ident": "v"
-                                    },
-                                    {
-                                      "kind": "nkIdent",
-                                      "ident": "string"
-                                    },
-                                    {
-                                      "kind": "nkEmpty"
-                                    }
-                                  ],
-                                  "postfix": [
-                                    "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# case field eol\", line: 69, col: 16, offsetA: 1222, offsetB: 1238)"
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkPostfix",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "*"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "SomeAlias"
-                }
-              ]
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "int",
-              "postfix": [
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 6, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## alias eol\", line: 72, col: 6, offsetA: 1265, offsetB: 1277)",
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 6, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## alias next\", line: 73, col: 6, offsetA: 1284, offsetB: 1297)"
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkPragmaExpr",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "SomeAlias2"
-                },
-                {
-                  "kind": "nkPragma",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "nodecl"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIdent",
-              "prefix": [
-                "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# after pragma\", line: 74, col: 26, offsetA: 1324, offsetB: 1338)"
-              ],
-              "ident": "int",
-              "postfix": [
-                "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## alias2 eol\", line: 75, col: 8, offsetA: 1347, offsetB: 1360)"
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "SomeAlias3",
-              "postfix": [
-                "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# alias after symbol\", line: 76, col: 13, offsetA: 1374, offsetB: 1394)"
-              ]
-            },
-            {
-              "kind": "nkGenericParams",
-              "sons": [
-                {
-                  "kind": "nkIdentDefs",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "T"
-                    },
-                    {
-                      "kind": "nkEmpty"
-                    },
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "kind": "nkIdent",
-              "prefix": [
-                "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# alias after equals\", line: 77, col: 10, offsetA: 1405, offsetB: 1425)"
-              ],
-              "ident": "int",
-              "postfix": [
-                "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# alias after type\", line: 78, col: 10, offsetA: 1436, offsetB: 1454)"
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "SomeAlias4"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkBracketExpr",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "SomeAlias3"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "int"
-                }
-              ],
-              "postfix": [
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 6, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## after alias4\", line: 80, col: 6, offsetA: 1492, offsetB: 1507)",
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 6, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## more after alias4\", line: 81, col: 6, offsetA: 1514, offsetB: 1534)"
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkTypeDef",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## Some comment before whenobj\", line: 82, col: 2, offsetA: 1537, offsetB: 1567)"
-          ],
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "WhenObject"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkObjectTy",
-              "mid": [
-                "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# whenobject object line\", line: 83, col: 22, offsetA: 1590, offsetB: 1614)"
-              ],
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkRecList",
-                  "sons": [
-                    {
-                      "kind": "nkRecWhen",
-                      "sons": [
-                        {
-                          "kind": "nkElifBranch",
-                          "mid": [
-                            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# when object false line\", line: 84, col: 16, offsetA: 1631, offsetB: 1655)"
-                          ],
-                          "sons": [
-                            {
-                              "kind": "nkIdent",
-                              "ident": "false"
-                            },
-                            {
-                              "kind": "nkRecList",
-                              "sons": [
-                                {
-                                  "kind": "nkNilLit"
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkPostfix",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "*"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "NoField0"
-                }
-              ]
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkObjectTy",
-              "mid": [
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 4, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## comment eol\", line: 88, col: 4, offsetA: 1707, offsetB: 1721)",
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 4, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## comment nl\", line: 89, col: 4, offsetA: 1726, offsetB: 1739)"
-              ],
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkOfInherit",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "RootObj"
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkPostfix",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "*"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "NoField1"
-                }
-              ]
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkObjectTy",
-              "mid": [
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 4, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## comment nofield1 eol\", line: 92, col: 4, offsetA: 1777, offsetB: 1800)",
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 4, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## comment nl\", line: 93, col: 4, offsetA: 1805, offsetB: 1818)"
-              ],
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkOfInherit",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "RootObj"
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkWhenStmt",
-      "sons": [
-        {
-          "kind": "nkElifBranch",
-          "mid": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# when colon line\", line: 95, col: 24, offsetA: 1844, offsetB: 1861)"
-          ],
-          "sons": [
-            {
-              "kind": "nkCall",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "defined"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "somecond"
-                }
-              ]
-            },
-            {
-              "kind": "nkStmtList",
-              "prefix": [
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# when first line\", line: 96, col: 2, offsetA: 1864, offsetB: 1881)"
-              ],
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkElse",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# comment\", line: 98, col: 0, offsetA: 1892, offsetB: 1901)"
-          ],
-          "mid": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# else colon line\", line: 99, col: 6, offsetA: 1908, offsetB: 1925)"
-          ],
-          "sons": [
-            {
-              "kind": "nkStmtList",
-              "prefix": [
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# else first line\", line: 100, col: 2, offsetA: 1928, offsetB: 1945)"
-              ],
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkIfStmt",
-      "sons": [
-        {
-          "kind": "nkElifBranch",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "true"
-            },
-            {
-              "kind": "nkStmtList",
-              "prefix": [
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# if next line\", line: 103, col: 2, offsetA: 1967, offsetB: 1981)"
-              ],
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkElse",
-          "sons": [
-            {
-              "kind": "nkStmtList",
-              "prefix": [
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# else next line\", line: 106, col: 2, offsetA: 2000, offsetB: 2016)"
-              ],
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkIfStmt",
-      "sons": [
-        {
-          "kind": "nkElifBranch",
-          "mid": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# if colon line\", line: 108, col: 9, offsetA: 2036, offsetB: 2051)"
-          ],
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "true"
-            },
-            {
-              "kind": "nkStmtList",
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkElse",
-          "mid": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# else colon line\", line: 110, col: 6, offsetA: 2068, offsetB: 2085)"
-          ],
-          "sons": [
-            {
-              "kind": "nkStmtList",
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkIfStmt",
-      "sons": [
-        {
-          "kind": "nkElifBranch",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "true"
-            },
-            {
-              "kind": "nkStmtList",
-              "prefix": [
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# if dedented colon line\", line: 113, col: 2, offsetA: 2107, offsetB: 2131)"
-              ],
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkElse",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# before else dedented\", line: 115, col: 0, offsetA: 2142, offsetB: 2164)"
-          ],
-          "mid": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# else colon line\", line: 116, col: 6, offsetA: 2171, offsetB: 2188)"
-          ],
-          "sons": [
-            {
-              "kind": "nkStmtList",
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "mid": [
-        "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# after proc before indented name\", line: 119, col: 13, offsetA: 2213, offsetB: 2246)"
-      ],
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "xxx"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkStmtList",
-          "sons": [
-            {
-              "kind": "nkDiscardStmt",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "mid": [
-        "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# proc eq line\", line: 122, col: 14, offsetA: 2272, offsetB: 2286)"
-      ],
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "xxxx"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkStmtList",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# proc first line\", line: 123, col: 2, offsetA: 2289, offsetB: 2306)"
-          ],
-          "sons": [
-            {
-              "kind": "nkDiscardStmt",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "x"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkStmtList",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## A proc doc comment\", line: 127, col: 2, offsetA: 2331, offsetB: 2352)"
-          ],
-          "sons": [
-            {
-              "kind": "nkIfStmt",
-              "sons": [
-                {
-                  "kind": "nkElifBranch",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "true"
-                    },
-                    {
-                      "kind": "nkStmtList",
-                      "sons": [
-                        {
-                          "kind": "nkInfix",
-                          "sons": [
-                            {
-                              "kind": "nkIdent",
-                              "ident": "-="
-                            },
-                            {
-                              "kind": "nkIdent",
-                              "ident": "numberOfCharsRead"
-                            },
-                            {
-                              "kind": "nkIntLit",
-                              "intVal": 2
-                            }
-                          ],
-                          "postfix": [
-                            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# handle Ctrl+Z as EOF\", line: 129, col: 27, offsetA: 2391, offsetB: 2413)"
-                          ]
-                        },
-                        {
-                          "kind": "nkForStmt",
-                          "sons": [
-                            {
-                              "kind": "nkIdent",
-                              "ident": "i"
-                            },
-                            {
-                              "kind": "nkInfix",
-                              "sons": [
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "..<"
-                                },
-                                {
-                                  "kind": "nkIntLit",
-                                  "intVal": 0
-                                },
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "numberOfCharsRead"
-                                }
-                              ]
-                            },
-                            {
-                              "kind": "nkStmtList",
-                              "sons": [
-                                {
-                                  "kind": "nkDiscardStmt",
-                                  "sons": [
-                                    {
-                                      "kind": "nkEmpty"
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "x"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkStmtList",
-          "sons": [
-            {
-              "kind": "nkDiscardStmt",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkImportStmt",
-      "prefix": [
-        "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## indented doc comment for proc\", line: 136, col: 0, offsetA: 2489, offsetB: 2521)",
-        "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## that is long\", line: 137, col: 0, offsetA: 2522, offsetB: 2537)",
-        "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# before module\", line: 138, col: 0, offsetA: 2538, offsetB: 2553)"
-      ],
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "module",
-          "postfix": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# with a comment\", line: 139, col: 14, offsetA: 2568, offsetB: 2584)"
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkImportStmt",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "module",
-          "postfix": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## with a comment\", line: 140, col: 14, offsetA: 2599, offsetB: 2616)"
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkTryStmt",
-      "mid": [
-        "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# try colon line\", line: 141, col: 5, offsetA: 2622, offsetB: 2638)"
-      ],
-      "sons": [
-        {
-          "kind": "nkStmtList",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# try first line\", line: 142, col: 2, offsetA: 2641, offsetB: 2657)"
-          ],
-          "sons": [
-            {
-              "kind": "nkDiscardStmt",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkExceptBranch",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# try last line\", line: 144, col: 0, offsetA: 2668, offsetB: 2683)"
-          ],
-          "sons": [
-            {
-              "kind": "nkStmtList",
-              "prefix": [
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# except first line\", line: 146, col: 2, offsetA: 2694, offsetB: 2713)"
-              ],
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkFinally",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# except last line\", line: 148, col: 0, offsetA: 2724, offsetB: 2742)"
-          ],
-          "sons": [
-            {
-              "kind": "nkStmtList",
-              "prefix": [
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# finally first line\", line: 150, col: 2, offsetA: 2754, offsetB: 2774)"
-              ],
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkTryStmt",
-      "prefix": [
-        "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# finally last line\", line: 152, col: 0, offsetA: 2785, offsetB: 2804)"
-      ],
-      "sons": [
-        {
-          "kind": "nkStmtList",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# try first dedent line\", line: 154, col: 2, offsetA: 2812, offsetB: 2835)"
-          ],
-          "sons": [
-            {
-              "kind": "nkCall",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "f"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkExceptBranch",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# try last dedent line\", line: 156, col: 0, offsetA: 2842, offsetB: 2864)"
-          ],
-          "sons": [
-            {
-              "kind": "nkStmtList",
-              "prefix": [
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# except dedent first line\", line: 158, col: 2, offsetA: 2875, offsetB: 2901)"
-              ],
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkFinally",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# except dedent last line\", line: 160, col: 0, offsetA: 2912, offsetB: 2937)"
-          ],
-          "sons": [
-            {
-              "kind": "nkStmtList",
-              "prefix": [
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# finally first dedent line\", line: 162, col: 2, offsetA: 2949, offsetB: 2976)"
-              ],
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkForStmt",
-      "prefix": [
-        "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# finally last dedent line\", line: 164, col: 0, offsetA: 2987, offsetB: 3013)"
-      ],
-      "mid": [
-        "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# for colon line\", line: 165, col: 17, offsetA: 3031, offsetB: 3047)"
-      ],
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "i"
-        },
-        {
-          "kind": "nkInfix",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": ".."
-            },
-            {
-              "kind": "nkIntLit",
-              "intVal": 0
-            },
-            {
-              "kind": "nkIntLit",
-              "intVal": 1
-            }
-          ]
-        },
-        {
-          "kind": "nkStmtList",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# for first line\", line: 166, col: 2, offsetA: 3050, offsetB: 3066)"
-          ],
-          "sons": [
-            {
-              "kind": "nkDiscardStmt",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkCaseStmt",
-      "mid": [
-        "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# case line\", line: 168, col: 7, offsetA: 3084, offsetB: 3095)"
-      ],
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "a"
-        },
-        {
-          "kind": "nkOfBranch",
-          "mid": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# of colon line\", line: 169, col: 9, offsetA: 3105, offsetB: 3120)"
-          ],
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "true"
-            },
-            {
-              "kind": "nkStmtList",
-              "prefix": [
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# of first line\", line: 170, col: 2, offsetA: 3123, offsetB: 3138)"
-              ],
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkElse",
-          "mid": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# case else colon line\", line: 172, col: 6, offsetA: 3155, offsetB: 3177)"
-          ],
-          "sons": [
-            {
-              "kind": "nkStmtList",
-              "prefix": [
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# case else first line\", line: 173, col: 2, offsetA: 3180, offsetB: 3202)"
-              ],
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkCall",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "f"
-        },
-        {
-          "kind": "nkDo",
-          "mid": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# do colon line\", line: 176, col: 13, offsetA: 3227, offsetB: 3242)"
-          ],
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkFormalParams",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "int"
-                }
-              ]
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkStmtList",
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkBlockStmt",
-      "mid": [
-        "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# block colon line\", line: 180, col: 7, offsetA: 3271, offsetB: 3289)"
-      ],
-      "sons": [
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkStmtList",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# block first line\", line: 181, col: 2, offsetA: 3292, offsetB: 3310)"
-          ],
-          "sons": [
-            {
-              "kind": "nkDiscardStmt",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            },
-            {
-              "kind": "nkDiscardStmt",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkLetSection",
-      "sons": [
-        {
-          "kind": "nkIdentDefs",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "x"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkLambda",
-              "mid": [
-                "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# lambda eq line\", line: 186, col: 17, offsetA: 3357, offsetB: 3373)"
-              ],
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkFormalParams",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "int"
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkStmtList",
-                  "prefix": [
-                    "(tokType: tkComment, base: base10, spacing: {}, indent: 6, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# lambda first line\", line: 187, col: 6, offsetA: 3380, offsetB: 3399)"
-                  ],
-                  "sons": [
-                    {
-                      "kind": "nkDiscardStmt",
-                      "sons": [
-                        {
-                          "kind": "nkEmpty"
-                        }
-                      ]
-                    },
-                    {
-                      "kind": "nkDiscardStmt",
-                      "sons": [
-                        {
-                          "kind": "nkEmpty"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkWhileStmt",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "false"
-        },
-        {
-          "kind": "nkStmtList",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# while first line\", line: 191, col: 2, offsetA: 3443, offsetB: 3461)"
-          ],
-          "sons": [
-            {
-              "kind": "nkDiscardStmt",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkStaticStmt",
-      "mid": [
-        "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# static colon line\", line: 194, col: 8, offsetA: 3481, offsetB: 3500)"
-      ],
-      "sons": [
-        {
-          "kind": "nkStmtList",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# static first line\", line: 195, col: 2, offsetA: 3503, offsetB: 3522)"
-          ],
-          "sons": [
-            {
-              "kind": "nkDiscardStmt",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkDiscardStmt",
-      "sons": [
-        {
-          "kind": "nkObjConstr",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "Object"
-            },
-            {
-              "kind": "nkExprColonExpr",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "prefix": [
-                    "(tokType: tkComment, base: base10, spacing: {}, indent: 4, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# object eol\", line: 199, col: 4, offsetA: 3554, offsetB: 3566)",
-                    "(tokType: tkComment, base: base10, spacing: {}, indent: 4, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# object first line\", line: 200, col: 4, offsetA: 3571, offsetB: 3590)"
-                  ],
-                  "ident": "field"
-                },
-                {
-                  "kind": "nkIntLit",
-                  "intVal": 0
-                }
-              ],
-              "postfix": [
-                "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# field line\", line: 201, col: 14, offsetA: 3605, offsetB: 3617)"
-              ]
-            },
-            {
-              "kind": "nkExprColonExpr",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "field2"
-                },
-                {
-                  "kind": "nkIntLit",
-                  "intVal": 42
-                }
-              ],
-              "postfix": [
-                "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# field colon line\", line: 202, col: 15, offsetA: 3633, offsetB: 3651)"
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkAsgn",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "a"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "b"
-        }
-      ]
-    },
-    {
-      "kind": "nkCommentStmt",
-      "comment": "## Doc comment after assignment"
-    },
-    {
-      "kind": "nkCommentStmt",
-      "comment": "## needs to be double"
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "ffff"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkStmtList",
-          "sons": [
-            {
-              "kind": "nkCall",
-              "sons": [
-                {
-                  "kind": "nkDotExpr",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "result"
-                    },
-                    {
-                      "kind": "nkIdent",
-                      "ident": "add"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkInfix",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "and",
-          "postfix": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# dedented comment in infix\", line: 215, col: 8, offsetA: 3819, offsetB: 3846)"
-          ]
-        },
-        {
-          "kind": "nkIdent",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## Doc comment after indented statement\", line: 213, col: 0, offsetA: 3749, offsetB: 3788)",
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## needs to be double\", line: 214, col: 0, offsetA: 3789, offsetB: 3810)"
-          ],
-          "ident": "abc"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "def"
-        }
-      ]
-    },
-    {
-      "kind": "nkInfix",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "and",
-          "postfix": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# indented comment in infix\", line: 217, col: 8, offsetA: 3859, offsetB: 3886)"
-          ]
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "abc"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "def"
-        }
-      ]
-    },
-    {
-      "kind": "nkIfStmt",
-      "sons": [
-        {
-          "kind": "nkElifBranch",
-          "sons": [
-            {
-              "kind": "nkInfix",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "and",
-                  "postfix": [
-                    "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# dedented comment in infix\", line: 219, col: 11, offsetA: 3902, offsetB: 3929)"
-                  ]
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "abc"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "def"
-                }
-              ]
-            },
-            {
-              "kind": "nkStmtList",
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkIfStmt",
-      "sons": [
-        {
-          "kind": "nkElifBranch",
-          "sons": [
-            {
-              "kind": "nkInfix",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "and",
-                  "postfix": [
-                    "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# indented comment in infix\", line: 222, col: 11, offsetA: 3956, offsetB: 3983)"
-                  ]
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "abc"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "def"
-                }
-              ]
-            },
-            {
-              "kind": "nkStmtList",
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkCall",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "a"
-        },
-        {
-          "kind": "nkExprEqExpr",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "b"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "c"
-            }
-          ],
-          "postfix": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# comment after keyword parameter\", line: 226, col: 8, offsetA: 4008, offsetB: 4041)"
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkCall",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "a"
-        },
-        {
-          "kind": "nkExprEqExpr",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "b"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "c"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkPragma",
-      "prefix": [
-        "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# dedented comment after keyword parameter\", line: 230, col: 0, offsetA: 4056, offsetB: 4098)"
-      ],
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "pragma",
-          "postfix": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# comment here\", line: 231, col: 9, offsetA: 4108, offsetB: 4122)"
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "a"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "v",
-                  "postfix": [
-                    "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"#[block]#\", line: 234, col: 9, offsetA: 4138, offsetB: 4146)"
-                  ]
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "int"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "abc"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "int"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        }
-      ]
-    },
-    {
-      "kind": "nkLetSection",
-      "sons": [
-        {
-          "kind": "nkIdentDefs",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# let first line indented\", line: 238, col: 2, offsetA: 4174, offsetB: 4199)"
-          ],
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "v"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIntLit",
-              "intVal": 53
-            }
-          ],
-          "postfix": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# after v\", line: 239, col: 9, offsetA: 4209, offsetB: 4218)"
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkVarSection",
-      "sons": [
-        {
-          "kind": "nkIdentDefs",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# var first line indented\", line: 242, col: 2, offsetA: 4226, offsetB: 4251)"
-          ],
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "v"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIntLit",
-              "intVal": 53
-            }
-          ],
-          "postfix": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# after v\", line: 243, col: 9, offsetA: 4261, offsetB: 4270)"
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkDiscardStmt",
-      "sons": [
-        {
-          "kind": "nkIntLit",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# discard eol\", line: 246, col: 2, offsetA: 4282, offsetB: 4295)",
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# discard first line\", line: 247, col: 2, offsetA: 4298, offsetB: 4318)"
-          ],
-          "intVal": 54,
-          "postfix": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# discard value\", line: 248, col: 5, offsetA: 4324, offsetB: 4339)"
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkBlockStmt",
-      "sons": [
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkStmtList",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# also after call\", line: 251, col: 2, offsetA: 4350, offsetB: 4367)",
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# comment between the dots\", line: 252, col: 2, offsetA: 4370, offsetB: 4396)"
-          ],
-          "sons": [
-            {
-              "kind": "nkCall",
-              "sons": [
-                {
-                  "kind": "nkDotExpr",
-                  "sons": [
-                    {
-                      "kind": "nkCall",
-                      "sons": [
-                        {
-                          "kind": "nkDotExpr",
-                          "sons": [
-                            {
-                              "kind": "nkDotExpr",
-                              "sons": [
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "f"
-                                },
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "x"
-                                }
-                              ]
-                            },
-                            {
-                              "kind": "nkIdent",
-                              "ident": "z"
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "kind": "nkIdent",
-                      "ident": "d"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "f"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "bool"
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkStmtList",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## Comment here\", line: 256, col: 2, offsetA: 4431, offsetB: 4446)",
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## another\", line: 257, col: 2, offsetA: 4449, offsetB: 4459)"
-          ],
-          "sons": [
-            {
-              "kind": "nkPar",
-              "sons": [
-                {
-                  "kind": "nkInfix",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "or"
-                    },
-                    {
-                      "kind": "nkIdent",
-                      "ident": "true"
-                    },
-                    {
-                      "kind": "nkIdent",
-                      "ident": "false"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "f"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "bool"
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkStmtList",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## Comment here\", line: 261, col: 2, offsetA: 4498, offsetB: 4513)",
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## another\", line: 262, col: 2, offsetA: 4516, offsetB: 4526)"
-          ],
-          "sons": [
-            {
-              "kind": "nkIfStmt",
-              "sons": [
-                {
-                  "kind": "nkElifBranch",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "true"
-                    },
-                    {
-                      "kind": "nkStmtList",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "false"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkElse",
-                  "sons": [
-                    {
-                      "kind": "nkStmtList",
-                      "prefix": [
-                        "(tokType: tkComment, base: base10, spacing: {}, indent: 4, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## comment\", line: 266, col: 4, offsetA: 4560, offsetB: 4570)",
-                        "(tokType: tkComment, base: base10, spacing: {}, indent: 4, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## comment 2\", line: 267, col: 4, offsetA: 4575, offsetB: 4587)"
-                      ],
-                      "sons": [
-                        {
-                          "kind": "nkIfStmt",
-                          "sons": [
-                            {
-                              "kind": "nkElifBranch",
-                              "sons": [
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "true"
-                                },
-                                {
-                                  "kind": "nkStmtList",
-                                  "prefix": [
-                                    "(tokType: tkComment, base: base10, spacing: {}, indent: 6, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## comment\", line: 269, col: 6, offsetA: 4607, offsetB: 4617)",
-                                    "(tokType: tkComment, base: base10, spacing: {}, indent: 6, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## comment 2\", line: 270, col: 6, offsetA: 4624, offsetB: 4636)"
-                                  ],
-                                  "sons": [
-                                    {
-                                      "kind": "nkPar",
-                                      "sons": [
-                                        {
-                                          "kind": "nkInfix",
-                                          "sons": [
-                                            {
-                                              "kind": "nkIdent",
-                                              "ident": "or"
-                                            },
-                                            {
-                                              "kind": "nkIdent",
-                                              "ident": "true"
-                                            },
-                                            {
-                                              "kind": "nkIdent",
-                                              "ident": "false"
-                                            }
-                                          ]
-                                        }
-                                      ]
-                                    }
-                                  ]
-                                }
-                              ]
-                            },
-                            {
-                              "kind": "nkElse",
-                              "sons": [
-                                {
-                                  "kind": "nkStmtList",
-                                  "sons": [
-                                    {
-                                      "kind": "nkIdent",
-                                      "ident": "false"
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
-  ]
-}
+kind: "nkStmtList"
+sons:
+  - kind: "nkCommentStmt"
+    "comment": "#"
+  - kind: "nkCommentStmt"
+    "comment": "#"
+  - kind: "nkCommentStmt"
+    "comment": "# Some commentary"
+  - kind: "nkCommentStmt"
+    "comment": "## A doc comment"
+  - kind: "nkCommentStmt"
+    "comment": "##"
+  - kind: "nkCommentStmt"
+    "comment": "##"
+  - kind: "nkCommentStmt"
+    "comment": "## More doc comments"
+  - kind: "nkCommentStmt"
+    "comment": "##"
+  - kind: "nkCommentStmt"
+    "comment": "#"
+  - kind: "nkCommentStmt"
+    "comment": "# Comment"
+  - kind: "nkCommentStmt"
+    "comment": "#"
+  - kind: "nkCommentStmt"
+    "comment": "#[ a multiline comment\u000Athis is also part of it\u000Aand this\u000A]#"
+  - kind: "nkCommentStmt"
+    "comment": "##[\u000A  these also come in doc variants\u000A]##"
+  - kind: "nkCommentStmt"
+    "comment": "#[\u000A  #[\u000A    they can be nested\u000A  ]#\u000A]#"
+  - kind: "nkCommand"
+    sons:
+      - kind: "nkIdent"
+        ident: "x"
+      - kind: "nkIntLit"
+        intVal: 324
+        postfix:
+          - "# A comment after"
+  - kind: "nkTemplateDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "x"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        prefix:
+          - "## A template doc comment"
+        sons:
+          - kind: "nkTryStmt"
+            sons:
+              - kind: "nkStmtList"
+                sons:
+                  - kind: "nkDiscardStmt"
+                    sons:
+                      - kind: "nkEmpty"
+              - kind: "nkExceptBranch"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "Exception"
+                  - kind: "nkStmtList"
+                    sons:
+                      - kind: "nkMixinStmt"
+                        sons:
+                          - kind: "nkAccQuoted"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: "$"
+                            postfix:
+                              - "# A comment after mixin"
+                      - kind: "nkCommand"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "echo"
+                          - kind: "nkIntLit"
+                            intVal: 4
+  - kind: "nkTypeSection"
+    sons:
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkPragmaExpr"
+            sons:
+              - kind: "nkPostfix"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "*"
+                  - kind: "nkIdent"
+                    ident: "SingleValueSetting"
+              - kind: "nkPragma"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "pure"
+          - kind: "nkEmpty"
+          - kind: "nkEnumTy"
+            sons:
+              - kind: "nkEmpty"
+              - kind: "nkIdent"
+                prefix:
+                  - "## \\"
+                  - "## settings resulting in a single string value"
+                ident: "arguments"
+                postfix:
+                  - "## experimental: the arguments passed after \'-r\'"
+              - kind: "nkIdent"
+                ident: "backend"
+                postfix:
+                  - "## the backend (eg: c|cpp|objc|js); both `nim doc --backend:js`"
+                  - "## and `nim js` would imply backend=js"
+              - kind: "nkPragmaExpr"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "gc"
+                  - kind: "nkPragma"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "deprecated"
+                postfix:
+                  - "## gc selected"
+              - kind: "nkIdent"
+                ident: "mm"
+                postfix:
+                  - "## memory management selected"
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkPostfix"
+            sons:
+              - kind: "nkIdent"
+                ident: "*"
+              - kind: "nkIdent"
+                ident: "FileSeekPos"
+          - kind: "nkEmpty"
+          - kind: "nkEnumTy"
+            sons:
+              - kind: "nkEmpty"
+              - kind: "nkIdent"
+                ident: "fspEnd"
+                postfix:
+                  - "## Seek relative to end"
+                  - "# text file handling:"
+      - kind: "nkTypeDef"
+        prefix:
+          - "## Position relative to which seek should happen."
+          - "# The values are ordered so that they match with stdio"
+          - "# SEEK_SET, SEEK_CUR and SEEK_END respectively."
+        sons:
+          - kind: "nkIdent"
+            ident: "Object"
+          - kind: "nkEmpty"
+          - kind: "nkObjectTy"
+            mid:
+              - "# comment"
+              - "## more comment"
+            sons:
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkRecList"
+                sons:
+                  - kind: "nkIdentDefs"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "field"
+                      - kind: "nkIdent"
+                        ident: "int"
+                      - kind: "nkEmpty"
+                    postfix:
+                      - "# Field comment"
+                  - kind: "nkIdentDefs"
+                    prefix:
+                      - "# comment between fields"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "field2"
+                      - kind: "nkIdent"
+                        ident: "int"
+                      - kind: "nkEmpty"
+                    postfix:
+                      - "## Field comment again"
+                  - kind: "nkIdentDefs"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "fiiiiiiiiiiiiiiiiiiiiiiiieeeeeeeeeld"
+                      - kind: "nkIdent"
+                        ident: "int"
+                      - kind: "nkEmpty"
+                    postfix:
+                      - "# loooooooooooooooooooong comment past the max line length"
+      - kind: "nkTypeDef"
+        prefix:
+          - "# and here"
+        sons:
+          - kind: "nkIdent"
+            ident: "Inherited"
+          - kind: "nkEmpty"
+          - kind: "nkObjectTy"
+            mid:
+              - "# inherited eol comment"
+              - "# inherited next line indent comments"
+            sons:
+              - kind: "nkEmpty"
+              - kind: "nkOfInherit"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "RootObj"
+              - kind: "nkRecList"
+                sons:
+                  - kind: "nkIdentDefs"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "f"
+                      - kind: "nkIdent"
+                        ident: "int"
+                      - kind: "nkEmpty"
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkIdent"
+            ident: "CaseObject"
+          - kind: "nkEmpty"
+          - kind: "nkObjectTy"
+            mid:
+              - "# caseobj eol"
+            sons:
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkRecList"
+                sons:
+                  - kind: "nkRecCase"
+                    sons:
+                      - kind: "nkIdentDefs"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "k"
+                          - kind: "nkIdent"
+                            ident: "bool"
+                          - kind: "nkEmpty"
+                        postfix:
+                          - "# casetype eol"
+                      - kind: "nkOfBranch"
+                        mid:
+                          - "# of eol"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "true"
+                          - kind: "nkIdent"
+                            ident: "false"
+                          - kind: "nkRecList"
+                            sons:
+                              - kind: "nkIdentDefs"
+                                sons:
+                                  - kind: "nkIdent"
+                                    ident: "v"
+                                  - kind: "nkIdent"
+                                    ident: "string"
+                                  - kind: "nkEmpty"
+                                postfix:
+                                  - "# case field eol"
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkPostfix"
+            sons:
+              - kind: "nkIdent"
+                ident: "*"
+              - kind: "nkIdent"
+                ident: "SomeAlias"
+          - kind: "nkEmpty"
+          - kind: "nkIdent"
+            ident: "int"
+            postfix:
+              - "## alias eol"
+              - "## alias next"
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkPragmaExpr"
+            sons:
+              - kind: "nkIdent"
+                ident: "SomeAlias2"
+              - kind: "nkPragma"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "nodecl"
+          - kind: "nkEmpty"
+          - kind: "nkIdent"
+            ident: "int"
+            postfix:
+              - "## alias2 eol"
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkIdent"
+            ident: "SomeAlias3"
+            postfix:
+              - "# alias after symbol"
+          - kind: "nkGenericParams"
+            sons:
+              - kind: "nkIdentDefs"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "T"
+                  - kind: "nkEmpty"
+                  - kind: "nkEmpty"
+          - kind: "nkIdent"
+            prefix:
+              - "# alias after equals"
+            ident: "int"
+            postfix:
+              - "# alias after type"
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkIdent"
+            ident: "SomeAlias4"
+          - kind: "nkEmpty"
+          - kind: "nkBracketExpr"
+            sons:
+              - kind: "nkIdent"
+                ident: "SomeAlias3"
+              - kind: "nkIdent"
+                ident: "int"
+            postfix:
+              - "## after alias4"
+              - "## more after alias4"
+      - kind: "nkTypeDef"
+        prefix:
+          - "## Some comment before whenobj"
+        sons:
+          - kind: "nkIdent"
+            ident: "WhenObject"
+          - kind: "nkEmpty"
+          - kind: "nkObjectTy"
+            mid:
+              - "# whenobject object line"
+            sons:
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkRecList"
+                sons:
+                  - kind: "nkRecWhen"
+                    sons:
+                      - kind: "nkElifBranch"
+                        mid:
+                          - "# when object false line"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "false"
+                          - kind: "nkRecList"
+                            sons:
+                              - kind: "nkNilLit"
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkPostfix"
+            sons:
+              - kind: "nkIdent"
+                ident: "*"
+              - kind: "nkIdent"
+                ident: "NoField0"
+          - kind: "nkEmpty"
+          - kind: "nkObjectTy"
+            mid:
+              - "## comment eol"
+              - "## comment nl"
+            sons:
+              - kind: "nkEmpty"
+              - kind: "nkOfInherit"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "RootObj"
+              - kind: "nkEmpty"
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkPostfix"
+            sons:
+              - kind: "nkIdent"
+                ident: "*"
+              - kind: "nkIdent"
+                ident: "NoField1"
+          - kind: "nkEmpty"
+          - kind: "nkObjectTy"
+            mid:
+              - "## comment nofield1 eol"
+              - "## comment nl"
+            sons:
+              - kind: "nkEmpty"
+              - kind: "nkOfInherit"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "RootObj"
+              - kind: "nkEmpty"
+  - kind: "nkWhenStmt"
+    sons:
+      - kind: "nkElifBranch"
+        mid:
+          - "# when colon line"
+        sons:
+          - kind: "nkCall"
+            sons:
+              - kind: "nkIdent"
+                ident: "defined"
+              - kind: "nkIdent"
+                ident: "somecond"
+          - kind: "nkStmtList"
+            prefix:
+              - "# when first line"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+      - kind: "nkElse"
+        prefix:
+          - "# comment"
+        mid:
+          - "# else colon line"
+        sons:
+          - kind: "nkStmtList"
+            prefix:
+              - "# else first line"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+  - kind: "nkIfStmt"
+    sons:
+      - kind: "nkElifBranch"
+        sons:
+          - kind: "nkIdent"
+            ident: "true"
+          - kind: "nkStmtList"
+            prefix:
+              - "# if next line"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+      - kind: "nkElse"
+        sons:
+          - kind: "nkStmtList"
+            prefix:
+              - "# else next line"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+  - kind: "nkIfStmt"
+    sons:
+      - kind: "nkElifBranch"
+        mid:
+          - "# if colon line"
+        sons:
+          - kind: "nkIdent"
+            ident: "true"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+      - kind: "nkElse"
+        mid:
+          - "# else colon line"
+        sons:
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+  - kind: "nkIfStmt"
+    sons:
+      - kind: "nkElifBranch"
+        sons:
+          - kind: "nkIdent"
+            ident: "true"
+          - kind: "nkStmtList"
+            prefix:
+              - "# if dedented colon line"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+      - kind: "nkElse"
+        prefix:
+          - "# before else dedented"
+        mid:
+          - "# else colon line"
+        sons:
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    mid:
+      - "# after proc before indented name"
+    sons:
+      - kind: "nkIdent"
+        ident: "xxx"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    mid:
+      - "# proc eq line"
+    sons:
+      - kind: "nkIdent"
+        ident: "xxxx"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        prefix:
+          - "# proc first line"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "x"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        prefix:
+          - "## A proc doc comment"
+        sons:
+          - kind: "nkIfStmt"
+            sons:
+              - kind: "nkElifBranch"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "true"
+                  - kind: "nkStmtList"
+                    sons:
+                      - kind: "nkInfix"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "-="
+                          - kind: "nkIdent"
+                            ident: "numberOfCharsRead"
+                          - kind: "nkIntLit"
+                            intVal: 2
+                        postfix:
+                          - "# handle Ctrl+Z as EOF"
+                      - kind: "nkForStmt"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "i"
+                          - kind: "nkInfix"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: "..<"
+                              - kind: "nkIntLit"
+                                intVal: 0
+                              - kind: "nkIdent"
+                                ident: "numberOfCharsRead"
+                          - kind: "nkStmtList"
+                            sons:
+                              - kind: "nkDiscardStmt"
+                                sons:
+                                  - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "x"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+  - kind: "nkImportStmt"
+    prefix:
+      - "## indented doc comment for proc"
+      - "## that is long"
+      - "# before module"
+    sons:
+      - kind: "nkIdent"
+        ident: "module"
+        postfix:
+          - "# with a comment"
+  - kind: "nkImportStmt"
+    sons:
+      - kind: "nkIdent"
+        ident: "module"
+        postfix:
+          - "## with a comment"
+  - kind: "nkTryStmt"
+    mid:
+      - "# try colon line"
+    sons:
+      - kind: "nkStmtList"
+        prefix:
+          - "# try first line"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+          - kind: "nkCommentStmt"
+            "comment": "# try last line"
+      - kind: "nkExceptBranch"
+        mid:
+          - "# except colon line"
+        sons:
+          - kind: "nkStmtList"
+            prefix:
+              - "# except first line"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+              - kind: "nkCommentStmt"
+                "comment": "# except last line"
+      - kind: "nkFinally"
+        mid:
+          - "# Finally colon line"
+        sons:
+          - kind: "nkStmtList"
+            prefix:
+              - "# finally first line"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+              - kind: "nkCommentStmt"
+                "comment": "# finally last line"
+  - kind: "nkTryStmt"
+    sons:
+      - kind: "nkStmtList"
+        prefix:
+          - "# try first dedent line"
+        sons:
+          - kind: "nkCall"
+            sons:
+              - kind: "nkIdent"
+                ident: "f"
+      - kind: "nkExceptBranch"
+        prefix:
+          - "# try last dedent line"
+        sons:
+          - kind: "nkStmtList"
+            prefix:
+              - "# except dedent first line"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+      - kind: "nkFinally"
+        prefix:
+          - "# except dedent last line"
+        sons:
+          - kind: "nkStmtList"
+            prefix:
+              - "# finally first dedent line"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+  - kind: "nkForStmt"
+    prefix:
+      - "# finally last dedent line"
+    mid:
+      - "# for colon line"
+    sons:
+      - kind: "nkIdent"
+        ident: "i"
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: ".."
+          - kind: "nkIntLit"
+            intVal: 0
+          - kind: "nkIntLit"
+            intVal: 1
+      - kind: "nkStmtList"
+        prefix:
+          - "# for first line"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+  - kind: "nkCaseStmt"
+    mid:
+      - "# case line"
+    sons:
+      - kind: "nkIdent"
+        ident: "a"
+      - kind: "nkOfBranch"
+        mid:
+          - "# of colon line"
+        sons:
+          - kind: "nkIdent"
+            ident: "true"
+          - kind: "nkStmtList"
+            prefix:
+              - "# of first line"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+      - kind: "nkElse"
+        mid:
+          - "# case else colon line"
+        sons:
+          - kind: "nkStmtList"
+            prefix:
+              - "# case else first line"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+  - kind: "nkCall"
+    sons:
+      - kind: "nkIdent"
+        ident: "f"
+      - kind: "nkDo"
+        mid:
+          - "# do colon line"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkEmpty"
+          - kind: "nkEmpty"
+          - kind: "nkFormalParams"
+            sons:
+              - kind: "nkIdent"
+                ident: "int"
+          - kind: "nkEmpty"
+          - kind: "nkEmpty"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+  - kind: "nkBlockStmt"
+    mid:
+      - "# block colon line"
+    sons:
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        prefix:
+          - "# block first line"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+  - kind: "nkLetSection"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "x"
+          - kind: "nkEmpty"
+          - kind: "nkLambda"
+            mid:
+              - "# lambda eq line"
+            sons:
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkFormalParams"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "int"
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkStmtList"
+                prefix:
+                  - "# lambda first line"
+                sons:
+                  - kind: "nkDiscardStmt"
+                    sons:
+                      - kind: "nkEmpty"
+                  - kind: "nkDiscardStmt"
+                    sons:
+                      - kind: "nkEmpty"
+  - kind: "nkWhileStmt"
+    mid:
+      - "# while colon line"
+    sons:
+      - kind: "nkIdent"
+        ident: "false"
+      - kind: "nkStmtList"
+        prefix:
+          - "# while first line"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+  - kind: "nkStaticStmt"
+    mid:
+      - "# static colon line"
+    sons:
+      - kind: "nkStmtList"
+        prefix:
+          - "# static first line"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+  - kind: "nkDiscardStmt"
+    sons:
+      - kind: "nkObjConstr"
+        sons:
+          - kind: "nkIdent"
+            ident: "Object"
+          - kind: "nkExprColonExpr"
+            sons:
+              - kind: "nkIdent"
+                prefix:
+                  - "# object eol"
+                  - "# object first line"
+                ident: "field"
+              - kind: "nkIntLit"
+                intVal: 0
+            postfix:
+              - "# field line"
+          - kind: "nkExprColonExpr"
+            sons:
+              - kind: "nkIdent"
+                ident: "field2"
+              - kind: "nkIntLit"
+                intVal: 42
+            postfix:
+              - "# Field colon next line"
+              - "# field colon line"
+  - kind: "nkAsgn"
+    sons:
+      - kind: "nkIdent"
+        ident: "a"
+      - kind: "nkIdent"
+        ident: "b"
+  - kind: "nkCommentStmt"
+    "comment": "## Doc comment after assignment"
+  - kind: "nkCommentStmt"
+    "comment": "## needs to be double"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "ffff"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkCall"
+            sons:
+              - kind: "nkDotExpr"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "result"
+                  - kind: "nkIdent"
+                    ident: "add"
+  - kind: "nkInfix"
+    sons:
+      - kind: "nkIdent"
+        ident: "and"
+        postfix:
+          - "# dedented comment in infix"
+      - kind: "nkIdent"
+        prefix:
+          - "## Doc comment after indented statement"
+          - "## needs to be double"
+        ident: "abc"
+      - kind: "nkIdent"
+        ident: "def"
+  - kind: "nkInfix"
+    sons:
+      - kind: "nkIdent"
+        ident: "and"
+        postfix:
+          - "# indented comment in infix"
+      - kind: "nkIdent"
+        ident: "abc"
+      - kind: "nkIdent"
+        ident: "def"
+  - kind: "nkIfStmt"
+    sons:
+      - kind: "nkElifBranch"
+        sons:
+          - kind: "nkInfix"
+            sons:
+              - kind: "nkIdent"
+                ident: "and"
+                postfix:
+                  - "# dedented comment in infix"
+              - kind: "nkIdent"
+                ident: "abc"
+              - kind: "nkIdent"
+                ident: "def"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+  - kind: "nkIfStmt"
+    sons:
+      - kind: "nkElifBranch"
+        sons:
+          - kind: "nkInfix"
+            sons:
+              - kind: "nkIdent"
+                ident: "and"
+                postfix:
+                  - "# indented comment in infix"
+              - kind: "nkIdent"
+                ident: "abc"
+              - kind: "nkIdent"
+                ident: "def"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+  - kind: "nkCall"
+    sons:
+      - kind: "nkIdent"
+        ident: "a"
+      - kind: "nkExprEqExpr"
+        sons:
+          - kind: "nkIdent"
+            ident: "b"
+          - kind: "nkIdent"
+            ident: "c"
+        postfix:
+          - "# comment after keyword parameter"
+  - kind: "nkCall"
+    sons:
+      - kind: "nkIdent"
+        ident: "a"
+      - kind: "nkExprEqExpr"
+        sons:
+          - kind: "nkIdent"
+            ident: "b"
+          - kind: "nkIdent"
+            ident: "c"
+  - kind: "nkPragma"
+    prefix:
+      - "# dedented comment after keyword parameter"
+    sons:
+      - kind: "nkIdent"
+        ident: "pragma"
+        postfix:
+          - "# comment here"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "a"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "v"
+                postfix:
+                  - "#[block]#"
+              - kind: "nkIdent"
+                ident: "int"
+              - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "abc"
+              - kind: "nkIdent"
+                ident: "int"
+              - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+  - kind: "nkLetSection"
+    sons:
+      - kind: "nkIdentDefs"
+        prefix:
+          - "# let first line indented"
+        sons:
+          - kind: "nkIdent"
+            ident: "v"
+          - kind: "nkEmpty"
+          - kind: "nkIntLit"
+            intVal: 53
+        postfix:
+          - "# after v"
+  - kind: "nkVarSection"
+    sons:
+      - kind: "nkIdentDefs"
+        prefix:
+          - "# var first line indented"
+        sons:
+          - kind: "nkIdent"
+            ident: "v"
+          - kind: "nkEmpty"
+          - kind: "nkIntLit"
+            intVal: 53
+        postfix:
+          - "# after v"
+  - kind: "nkDiscardStmt"
+    sons:
+      - kind: "nkIntLit"
+        prefix:
+          - "# discard eol"
+          - "# discard first line"
+        intVal: 54
+        postfix:
+          - "# discard value"
+  - kind: "nkBlockStmt"
+    sons:
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        prefix:
+          - "# also after call"
+          - "# comment between the dots"
+        sons:
+          - kind: "nkCall"
+            sons:
+              - kind: "nkDotExpr"
+                sons:
+                  - kind: "nkCall"
+                    sons:
+                      - kind: "nkDotExpr"
+                        sons:
+                          - kind: "nkDotExpr"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: "f"
+                              - kind: "nkIdent"
+                                ident: "x"
+                          - kind: "nkIdent"
+                            ident: "z"
+                  - kind: "nkIdent"
+                    ident: "d"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "f"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkIdent"
+            ident: "bool"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        prefix:
+          - "## Comment here"
+          - "## another"
+        sons:
+          - kind: "nkPar"
+            sons:
+              - kind: "nkInfix"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "or"
+                  - kind: "nkIdent"
+                    ident: "true"
+                  - kind: "nkIdent"
+                    ident: "false"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "f"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkIdent"
+            ident: "bool"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        prefix:
+          - "## Comment here"
+          - "## another"
+        sons:
+          - kind: "nkIfStmt"
+            sons:
+              - kind: "nkElifBranch"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "true"
+                  - kind: "nkStmtList"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "false"
+              - kind: "nkElse"
+                sons:
+                  - kind: "nkStmtList"
+                    prefix:
+                      - "## comment"
+                      - "## comment 2"
+                    sons:
+                      - kind: "nkIfStmt"
+                        sons:
+                          - kind: "nkElifBranch"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: "true"
+                              - kind: "nkStmtList"
+                                prefix:
+                                  - "## comment"
+                                  - "## comment 2"
+                                sons:
+                                  - kind: "nkPar"
+                                    sons:
+                                      - kind: "nkInfix"
+                                        sons:
+                                          - kind: "nkIdent"
+                                            ident: "or"
+                                          - kind: "nkIdent"
+                                            ident: "true"
+                                          - kind: "nkIdent"
+                                            ident: "false"
+                          - kind: "nkElse"
+                            sons:
+                              - kind: "nkStmtList"
+                                sons:
+                                  - kind: "nkIdent"
+                                    ident: "false"
+  - kind: "nkCommand"
+    sons:
+      - kind: "nkIdent"
+        ident: "command"
+      - kind: "nkStrLit"
+        strVal: "a"
+      - kind: "nkStrLit"
+        strVal: "b"
+      - kind: "nkStrLit"
+        strVal: "c"
+        postfix:
+          - "# command eol comment"
+  - kind: "nkCommand"
+    sons:
+      - kind: "nkIdent"
+        ident: "command"
+      - kind: "nkStrLit"
+        strVal: "first arg"
+        postfix:
+          - "# first arg comment"
+      - kind: "nkStrLit"
+        strVal: "second arg"
+        postfix:
+          - "# second arg comment"
+      - kind: "nkStrLit"
+        strVal: "third arg"
+        postfix:
+          - "# third arg comment"

--- a/tests/after/empty.nim.nph.yaml
+++ b/tests/after/empty.nim.nph.yaml
@@ -1,3 +1,1 @@
-{
-  "kind": "nkStmtList"
-}
+kind: "nkStmtList"

--- a/tests/after/exprs.nim
+++ b/tests/after/exprs.nim
@@ -5,16 +5,19 @@ var c3 =
     else:
       0
     )
+
 var c3 =
   row[p] +
-    (if runeA != runeB:
-      1
+    (if runeA != runeB: 1
     else: 0
     )
+
 for a in 0 ..< 1:
   discard
+
 for a in 0 .. 1:
   discard
+
 # needs spaces
 for a in ^1 .. ^2:
   discard
@@ -34,11 +37,12 @@ res.add fff do:
 # we don't what `do` in let but need it in the above commend - this needs
 # more investigation - this is important for templates calls like Result.valueOr
 # which become ugly otherwise
-
 let xxx =
   implicitdo:
     return xxx
+
 let shortInfix = a * b * c + d * e * f + (a + b) * g
+
 let longInfix =
   (
     a30 * a21 * a12 * a03 - a20 * a31 * a12 * a03 - a30 * a11 * a22 * a03 +
@@ -50,9 +54,11 @@ let longInfix =
     a20 * a11 * a02 * a33 + a10 * a21 * a02 * a33 + a20 * a01 * a12 * a33 -
     a00 * a21 * a12 * a33 - a10 * a01 * a22 * a33 + a00 * a11 * a22 * a33
   )
+
 if aaaaaaaaaaaaaaaaaaaa and bbbbbbbbbbbbbbbbbbbbbbb and ccccccccccccccccccccccccc and
     ddddddddddddddddd and fffffffffffffffff:
   discard
+
 if (aaaaaaaaaaaaaaaa and bbbbbbbbbbbbbbbbbbbbbbbbbbbb) or
     (ccccccccccccccccccccccccccc and ddddddddddddddddddddd):
   discard
@@ -63,6 +69,7 @@ elif aaaaaaaaa and
       (dddddddddddddddd or eeeeeeeeeeeeeee or fffffffffffffff or gggggggggggggg)
     ):
   discard
+
 case aaaaaaaaaa
 of aaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbb, ccccccccccccccccccccccc,
     ddddddddddddddddddddddd:

--- a/tests/after/exprs.nim.nph.yaml
+++ b/tests/after/exprs.nim.nph.yaml
@@ -1,2302 +1,1038 @@
-{
-  "kind": "nkStmtList",
-  "sons": [
-    {
-      "kind": "nkVarSection",
-      "sons": [
-        {
-          "kind": "nkIdentDefs",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "c3"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkInfix",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "+"
-                },
-                {
-                  "kind": "nkBracketExpr",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "row"
-                    },
-                    {
-                      "kind": "nkIdent",
-                      "ident": "p"
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkStmtListExpr",
-                  "sons": [
-                    {
-                      "kind": "nkIfStmt",
-                      "sons": [
-                        {
-                          "kind": "nkElifExpr",
-                          "sons": [
-                            {
-                              "kind": "nkInfix",
-                              "sons": [
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "!="
-                                },
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "runeA"
-                                },
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "runeB"
-                                }
-                              ]
-                            },
-                            {
-                              "kind": "nkStmtList",
-                              "sons": [
-                                {
-                                  "kind": "nkIntLit",
-                                  "intVal": 1
-                                }
-                              ]
-                            }
-                          ]
-                        },
-                        {
-                          "kind": "nkElseExpr",
-                          "sons": [
-                            {
-                              "kind": "nkStmtList",
-                              "sons": [
-                                {
-                                  "kind": "nkIntLit",
-                                  "intVal": 0
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkVarSection",
-      "sons": [
-        {
-          "kind": "nkIdentDefs",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "c3"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkInfix",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "+"
-                },
-                {
-                  "kind": "nkBracketExpr",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "row"
-                    },
-                    {
-                      "kind": "nkIdent",
-                      "ident": "p"
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkStmtListExpr",
-                  "sons": [
-                    {
-                      "kind": "nkIfStmt",
-                      "sons": [
-                        {
-                          "kind": "nkElifExpr",
-                          "sons": [
-                            {
-                              "kind": "nkInfix",
-                              "sons": [
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "!="
-                                },
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "runeA"
-                                },
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "runeB"
-                                }
-                              ]
-                            },
-                            {
-                              "kind": "nkStmtList",
-                              "sons": [
-                                {
-                                  "kind": "nkIntLit",
-                                  "intVal": 1
-                                }
-                              ]
-                            }
-                          ]
-                        },
-                        {
-                          "kind": "nkElseExpr",
-                          "sons": [
-                            {
-                              "kind": "nkIntLit",
-                              "intVal": 0
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkForStmt",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "a"
-        },
-        {
-          "kind": "nkInfix",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "..<"
-            },
-            {
-              "kind": "nkIntLit",
-              "intVal": 0
-            },
-            {
-              "kind": "nkIntLit",
-              "intVal": 1
-            }
-          ]
-        },
-        {
-          "kind": "nkStmtList",
-          "sons": [
-            {
-              "kind": "nkDiscardStmt",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkForStmt",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "a"
-        },
-        {
-          "kind": "nkInfix",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": ".."
-            },
-            {
-              "kind": "nkIntLit",
-              "intVal": 0
-            },
-            {
-              "kind": "nkIntLit",
-              "intVal": 1
-            }
-          ]
-        },
-        {
-          "kind": "nkStmtList",
-          "sons": [
-            {
-              "kind": "nkDiscardStmt",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkForStmt",
-      "prefix": [
-        "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# needs spaces\", line: 18, col: 0, offsetA: 201, offsetB: 215)"
-      ],
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "a"
-        },
-        {
-          "kind": "nkInfix",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": ".."
-            },
-            {
-              "kind": "nkPrefix",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "^"
-                },
-                {
-                  "kind": "nkIntLit",
-                  "intVal": 1
-                }
-              ]
-            },
-            {
-              "kind": "nkPrefix",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "^"
-                },
-                {
-                  "kind": "nkIntLit",
-                  "intVal": 2
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkStmtList",
-          "sons": [
-            {
-              "kind": "nkDiscardStmt",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkTemplateDef",
-      "sons": [
-        {
-          "kind": "nkPostfix",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "*"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "ttt"
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "untyped"
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkStmtList",
-          "sons": [
-            {
-              "kind": "nkBracketExpr",
-              "sons": [
-                {
-                  "kind": "nkStmtListExpr",
-                  "sons": [
-                    {
-                      "kind": "nkBlockStmt",
-                      "sons": [
-                        {
-                          "kind": "nkEmpty"
-                        },
-                        {
-                          "kind": "nkStmtList",
-                          "sons": [
-                            {
-                              "kind": "nkIdent",
-                              "ident": "xxx"
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkDiscardStmt",
-      "prefix": [
-        "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# command syntax with colon\", line: 27, col: 0, offsetA: 298, offsetB: 325)"
-      ],
-      "sons": [
-        {
-          "kind": "nkCommand",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "xxxx"
-            },
-            {
-              "kind": "nkStrLit",
-              "strVal": "arg"
-            },
-            {
-              "kind": "nkStmtList",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "yyy"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkCommand",
-      "sons": [
-        {
-          "kind": "nkDotExpr",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "res"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "add"
-            }
-          ]
-        },
-        {
-          "kind": "nkCall",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "fff"
-            },
-            {
-              "kind": "nkStmtList",
-              "sons": [
-                {
-                  "kind": "nkCall",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "yy"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkLetSection",
-      "prefix": [
-        "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# we don\\\'t what `do` in let but need it in the above commend - this needs\", line: 34, col: 0, offsetA: 381, offsetB: 454)",
-        "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# more investigation - this is important for templates calls like Result.valueOr\", line: 35, col: 0, offsetA: 455, offsetB: 535)",
-        "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# which become ugly otherwise\", line: 36, col: 0, offsetA: 536, offsetB: 565)"
-      ],
-      "sons": [
-        {
-          "kind": "nkIdentDefs",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "xxx"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkCall",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "implicitdo"
-                },
-                {
-                  "kind": "nkStmtList",
-                  "sons": [
-                    {
-                      "kind": "nkReturnStmt",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "xxx"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkLetSection",
-      "sons": [
-        {
-          "kind": "nkIdentDefs",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "shortInfix"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkInfix",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "+"
-                },
-                {
-                  "kind": "nkInfix",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "+"
-                    },
-                    {
-                      "kind": "nkInfix",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "*"
-                        },
-                        {
-                          "kind": "nkInfix",
-                          "sons": [
-                            {
-                              "kind": "nkIdent",
-                              "ident": "*"
-                            },
-                            {
-                              "kind": "nkIdent",
-                              "ident": "a"
-                            },
-                            {
-                              "kind": "nkIdent",
-                              "ident": "b"
-                            }
-                          ]
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "c"
-                        }
-                      ]
-                    },
-                    {
-                      "kind": "nkInfix",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "*"
-                        },
-                        {
-                          "kind": "nkInfix",
-                          "sons": [
-                            {
-                              "kind": "nkIdent",
-                              "ident": "*"
-                            },
-                            {
-                              "kind": "nkIdent",
-                              "ident": "d"
-                            },
-                            {
-                              "kind": "nkIdent",
-                              "ident": "e"
-                            }
-                          ]
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "f"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkInfix",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "*"
-                    },
-                    {
-                      "kind": "nkPar",
-                      "sons": [
-                        {
-                          "kind": "nkInfix",
-                          "sons": [
-                            {
-                              "kind": "nkIdent",
-                              "ident": "+"
-                            },
-                            {
-                              "kind": "nkIdent",
-                              "ident": "a"
-                            },
-                            {
-                              "kind": "nkIdent",
-                              "ident": "b"
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "kind": "nkIdent",
-                      "ident": "g"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkLetSection",
-      "sons": [
-        {
-          "kind": "nkIdentDefs",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "longInfix"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkPar",
-              "sons": [
-                {
-                  "kind": "nkInfix",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "+"
-                    },
-                    {
-                      "kind": "nkInfix",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "-"
-                        },
-                        {
-                          "kind": "nkInfix",
-                          "sons": [
-                            {
-                              "kind": "nkIdent",
-                              "ident": "-"
-                            },
-                            {
-                              "kind": "nkInfix",
-                              "sons": [
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "+"
-                                },
-                                {
-                                  "kind": "nkInfix",
-                                  "sons": [
-                                    {
-                                      "kind": "nkIdent",
-                                      "ident": "+"
-                                    },
-                                    {
-                                      "kind": "nkInfix",
-                                      "sons": [
-                                        {
-                                          "kind": "nkIdent",
-                                          "ident": "-"
-                                        },
-                                        {
-                                          "kind": "nkInfix",
-                                          "sons": [
-                                            {
-                                              "kind": "nkIdent",
-                                              "ident": "-"
-                                            },
-                                            {
-                                              "kind": "nkInfix",
-                                              "sons": [
-                                                {
-                                                  "kind": "nkIdent",
-                                                  "ident": "+"
-                                                },
-                                                {
-                                                  "kind": "nkInfix",
-                                                  "sons": [
-                                                    {
-                                                      "kind": "nkIdent",
-                                                      "ident": "+"
-                                                    },
-                                                    {
-                                                      "kind": "nkInfix",
-                                                      "sons": [
-                                                        {
-                                                          "kind": "nkIdent",
-                                                          "ident": "-"
-                                                        },
-                                                        {
-                                                          "kind": "nkInfix",
-                                                          "sons": [
-                                                            {
-                                                              "kind": "nkIdent",
-                                                              "ident": "-"
-                                                            },
-                                                            {
-                                                              "kind": "nkInfix",
-                                                              "sons": [
-                                                                {
-                                                                  "kind": "nkIdent",
-                                                                  "ident": "+"
-                                                                },
-                                                                {
-                                                                  "kind": "nkInfix",
-                                                                  "sons": [
-                                                                    {
-                                                                      "kind": "nkIdent",
-                                                                      "ident": "+"
-                                                                    },
-                                                                    {
-                                                                      "kind": "nkInfix",
-                                                                      "sons": [
-                                                                        {
-                                                                          "kind": "nkIdent",
-                                                                          "ident": "-"
-                                                                        },
-                                                                        {
-                                                                          "kind": "nkInfix",
-                                                                          "sons": [
-                                                                            {
-                                                                              "kind": "nkIdent",
-                                                                              "ident": "-"
-                                                                            },
-                                                                            {
-                                                                              "kind": "nkInfix",
-                                                                              "sons": [
-                                                                                {
-                                                                                  "kind": "nkIdent",
-                                                                                  "ident": "+"
-                                                                                },
-                                                                                {
-                                                                                  "kind": "nkInfix",
-                                                                                  "sons": [
-                                                                                    {
-                                                                                      "kind": "nkIdent",
-                                                                                      "ident": "+"
-                                                                                    },
-                                                                                    {
-                                                                                      "kind": "nkInfix",
-                                                                                      "sons": [
-                                                                                        {
-                                                                                          "kind": "nkIdent",
-                                                                                          "ident": "-"
-                                                                                        },
-                                                                                        {
-                                                                                          "kind": "nkInfix",
-                                                                                          "sons": [
-                                                                                            {
-                                                                                              "kind": "nkIdent",
-                                                                                              "ident": "-"
-                                                                                            },
-                                                                                            {
-                                                                                              "kind": "nkInfix",
-                                                                                              "sons": [
-                                                                                                {
-                                                                                                  "kind": "nkIdent",
-                                                                                                  "ident": "+"
-                                                                                                },
-                                                                                                {
-                                                                                                  "kind": "nkInfix",
-                                                                                                  "sons": [
-                                                                                                    {
-                                                                                                      "kind": "nkIdent",
-                                                                                                      "ident": "+"
-                                                                                                    },
-                                                                                                    {
-                                                                                                      "kind": "nkInfix",
-                                                                                                      "sons": [
-                                                                                                        {
-                                                                                                          "kind": "nkIdent",
-                                                                                                          "ident": "-"
-                                                                                                        },
-                                                                                                        {
-                                                                                                          "kind": "nkInfix",
-                                                                                                          "sons": [
-                                                                                                            {
-                                                                                                              "kind": "nkIdent",
-                                                                                                              "ident": "-"
-                                                                                                            },
-                                                                                                            {
-                                                                                                              "kind": "nkInfix",
-                                                                                                              "sons": [
-                                                                                                                {
-                                                                                                                  "kind": "nkIdent",
-                                                                                                                  "ident": "*"
-                                                                                                                },
-                                                                                                                {
-                                                                                                                  "kind": "nkInfix",
-                                                                                                                  "sons": [
-                                                                                                                    {
-                                                                                                                      "kind": "nkIdent",
-                                                                                                                      "ident": "*"
-                                                                                                                    },
-                                                                                                                    {
-                                                                                                                      "kind": "nkInfix",
-                                                                                                                      "sons": [
-                                                                                                                        {
-                                                                                                                          "kind": "nkIdent",
-                                                                                                                          "ident": "*"
-                                                                                                                        },
-                                                                                                                        {
-                                                                                                                          "kind": "nkIdent",
-                                                                                                                          "ident": "a30"
-                                                                                                                        },
-                                                                                                                        {
-                                                                                                                          "kind": "nkIdent",
-                                                                                                                          "ident": "a21"
-                                                                                                                        }
-                                                                                                                      ]
-                                                                                                                    },
-                                                                                                                    {
-                                                                                                                      "kind": "nkIdent",
-                                                                                                                      "ident": "a12"
-                                                                                                                    }
-                                                                                                                  ]
-                                                                                                                },
-                                                                                                                {
-                                                                                                                  "kind": "nkIdent",
-                                                                                                                  "ident": "a03"
-                                                                                                                }
-                                                                                                              ]
-                                                                                                            },
-                                                                                                            {
-                                                                                                              "kind": "nkInfix",
-                                                                                                              "sons": [
-                                                                                                                {
-                                                                                                                  "kind": "nkIdent",
-                                                                                                                  "ident": "*"
-                                                                                                                },
-                                                                                                                {
-                                                                                                                  "kind": "nkInfix",
-                                                                                                                  "sons": [
-                                                                                                                    {
-                                                                                                                      "kind": "nkIdent",
-                                                                                                                      "ident": "*"
-                                                                                                                    },
-                                                                                                                    {
-                                                                                                                      "kind": "nkInfix",
-                                                                                                                      "sons": [
-                                                                                                                        {
-                                                                                                                          "kind": "nkIdent",
-                                                                                                                          "ident": "*"
-                                                                                                                        },
-                                                                                                                        {
-                                                                                                                          "kind": "nkIdent",
-                                                                                                                          "ident": "a20"
-                                                                                                                        },
-                                                                                                                        {
-                                                                                                                          "kind": "nkIdent",
-                                                                                                                          "ident": "a31"
-                                                                                                                        }
-                                                                                                                      ]
-                                                                                                                    },
-                                                                                                                    {
-                                                                                                                      "kind": "nkIdent",
-                                                                                                                      "ident": "a12"
-                                                                                                                    }
-                                                                                                                  ]
-                                                                                                                },
-                                                                                                                {
-                                                                                                                  "kind": "nkIdent",
-                                                                                                                  "ident": "a03"
-                                                                                                                }
-                                                                                                              ]
-                                                                                                            }
-                                                                                                          ]
-                                                                                                        },
-                                                                                                        {
-                                                                                                          "kind": "nkInfix",
-                                                                                                          "sons": [
-                                                                                                            {
-                                                                                                              "kind": "nkIdent",
-                                                                                                              "ident": "*"
-                                                                                                            },
-                                                                                                            {
-                                                                                                              "kind": "nkInfix",
-                                                                                                              "sons": [
-                                                                                                                {
-                                                                                                                  "kind": "nkIdent",
-                                                                                                                  "ident": "*"
-                                                                                                                },
-                                                                                                                {
-                                                                                                                  "kind": "nkInfix",
-                                                                                                                  "sons": [
-                                                                                                                    {
-                                                                                                                      "kind": "nkIdent",
-                                                                                                                      "ident": "*"
-                                                                                                                    },
-                                                                                                                    {
-                                                                                                                      "kind": "nkIdent",
-                                                                                                                      "ident": "a30"
-                                                                                                                    },
-                                                                                                                    {
-                                                                                                                      "kind": "nkIdent",
-                                                                                                                      "ident": "a11"
-                                                                                                                    }
-                                                                                                                  ]
-                                                                                                                },
-                                                                                                                {
-                                                                                                                  "kind": "nkIdent",
-                                                                                                                  "ident": "a22"
-                                                                                                                }
-                                                                                                              ]
-                                                                                                            },
-                                                                                                            {
-                                                                                                              "kind": "nkIdent",
-                                                                                                              "ident": "a03"
-                                                                                                            }
-                                                                                                          ]
-                                                                                                        }
-                                                                                                      ]
-                                                                                                    },
-                                                                                                    {
-                                                                                                      "kind": "nkInfix",
-                                                                                                      "sons": [
-                                                                                                        {
-                                                                                                          "kind": "nkIdent",
-                                                                                                          "ident": "*"
-                                                                                                        },
-                                                                                                        {
-                                                                                                          "kind": "nkInfix",
-                                                                                                          "sons": [
-                                                                                                            {
-                                                                                                              "kind": "nkIdent",
-                                                                                                              "ident": "*"
-                                                                                                            },
-                                                                                                            {
-                                                                                                              "kind": "nkInfix",
-                                                                                                              "sons": [
-                                                                                                                {
-                                                                                                                  "kind": "nkIdent",
-                                                                                                                  "ident": "*"
-                                                                                                                },
-                                                                                                                {
-                                                                                                                  "kind": "nkIdent",
-                                                                                                                  "ident": "a10"
-                                                                                                                },
-                                                                                                                {
-                                                                                                                  "kind": "nkIdent",
-                                                                                                                  "ident": "a31"
-                                                                                                                }
-                                                                                                              ]
-                                                                                                            },
-                                                                                                            {
-                                                                                                              "kind": "nkIdent",
-                                                                                                              "ident": "a22"
-                                                                                                            }
-                                                                                                          ]
-                                                                                                        },
-                                                                                                        {
-                                                                                                          "kind": "nkIdent",
-                                                                                                          "ident": "a03"
-                                                                                                        }
-                                                                                                      ]
-                                                                                                    }
-                                                                                                  ]
-                                                                                                },
-                                                                                                {
-                                                                                                  "kind": "nkInfix",
-                                                                                                  "sons": [
-                                                                                                    {
-                                                                                                      "kind": "nkIdent",
-                                                                                                      "ident": "*"
-                                                                                                    },
-                                                                                                    {
-                                                                                                      "kind": "nkInfix",
-                                                                                                      "sons": [
-                                                                                                        {
-                                                                                                          "kind": "nkIdent",
-                                                                                                          "ident": "*"
-                                                                                                        },
-                                                                                                        {
-                                                                                                          "kind": "nkInfix",
-                                                                                                          "sons": [
-                                                                                                            {
-                                                                                                              "kind": "nkIdent",
-                                                                                                              "ident": "*"
-                                                                                                            },
-                                                                                                            {
-                                                                                                              "kind": "nkIdent",
-                                                                                                              "ident": "a20"
-                                                                                                            },
-                                                                                                            {
-                                                                                                              "kind": "nkIdent",
-                                                                                                              "ident": "a11"
-                                                                                                            }
-                                                                                                          ]
-                                                                                                        },
-                                                                                                        {
-                                                                                                          "kind": "nkIdent",
-                                                                                                          "ident": "a32"
-                                                                                                        }
-                                                                                                      ]
-                                                                                                    },
-                                                                                                    {
-                                                                                                      "kind": "nkIdent",
-                                                                                                      "ident": "a03"
-                                                                                                    }
-                                                                                                  ]
-                                                                                                }
-                                                                                              ]
-                                                                                            },
-                                                                                            {
-                                                                                              "kind": "nkInfix",
-                                                                                              "sons": [
-                                                                                                {
-                                                                                                  "kind": "nkIdent",
-                                                                                                  "ident": "*"
-                                                                                                },
-                                                                                                {
-                                                                                                  "kind": "nkInfix",
-                                                                                                  "sons": [
-                                                                                                    {
-                                                                                                      "kind": "nkIdent",
-                                                                                                      "ident": "*"
-                                                                                                    },
-                                                                                                    {
-                                                                                                      "kind": "nkInfix",
-                                                                                                      "sons": [
-                                                                                                        {
-                                                                                                          "kind": "nkIdent",
-                                                                                                          "ident": "*"
-                                                                                                        },
-                                                                                                        {
-                                                                                                          "kind": "nkIdent",
-                                                                                                          "ident": "a10"
-                                                                                                        },
-                                                                                                        {
-                                                                                                          "kind": "nkIdent",
-                                                                                                          "ident": "a21"
-                                                                                                        }
-                                                                                                      ]
-                                                                                                    },
-                                                                                                    {
-                                                                                                      "kind": "nkIdent",
-                                                                                                      "ident": "a32"
-                                                                                                    }
-                                                                                                  ]
-                                                                                                },
-                                                                                                {
-                                                                                                  "kind": "nkIdent",
-                                                                                                  "ident": "a03"
-                                                                                                }
-                                                                                              ]
-                                                                                            }
-                                                                                          ]
-                                                                                        },
-                                                                                        {
-                                                                                          "kind": "nkInfix",
-                                                                                          "sons": [
-                                                                                            {
-                                                                                              "kind": "nkIdent",
-                                                                                              "ident": "*"
-                                                                                            },
-                                                                                            {
-                                                                                              "kind": "nkInfix",
-                                                                                              "sons": [
-                                                                                                {
-                                                                                                  "kind": "nkIdent",
-                                                                                                  "ident": "*"
-                                                                                                },
-                                                                                                {
-                                                                                                  "kind": "nkInfix",
-                                                                                                  "sons": [
-                                                                                                    {
-                                                                                                      "kind": "nkIdent",
-                                                                                                      "ident": "*"
-                                                                                                    },
-                                                                                                    {
-                                                                                                      "kind": "nkIdent",
-                                                                                                      "ident": "a30"
-                                                                                                    },
-                                                                                                    {
-                                                                                                      "kind": "nkIdent",
-                                                                                                      "ident": "a21"
-                                                                                                    }
-                                                                                                  ]
-                                                                                                },
-                                                                                                {
-                                                                                                  "kind": "nkIdent",
-                                                                                                  "ident": "a02"
-                                                                                                }
-                                                                                              ]
-                                                                                            },
-                                                                                            {
-                                                                                              "kind": "nkIdent",
-                                                                                              "ident": "a13"
-                                                                                            }
-                                                                                          ]
-                                                                                        }
-                                                                                      ]
-                                                                                    },
-                                                                                    {
-                                                                                      "kind": "nkInfix",
-                                                                                      "sons": [
-                                                                                        {
-                                                                                          "kind": "nkIdent",
-                                                                                          "ident": "*"
-                                                                                        },
-                                                                                        {
-                                                                                          "kind": "nkInfix",
-                                                                                          "sons": [
-                                                                                            {
-                                                                                              "kind": "nkIdent",
-                                                                                              "ident": "*"
-                                                                                            },
-                                                                                            {
-                                                                                              "kind": "nkInfix",
-                                                                                              "sons": [
-                                                                                                {
-                                                                                                  "kind": "nkIdent",
-                                                                                                  "ident": "*"
-                                                                                                },
-                                                                                                {
-                                                                                                  "kind": "nkIdent",
-                                                                                                  "ident": "a20"
-                                                                                                },
-                                                                                                {
-                                                                                                  "kind": "nkIdent",
-                                                                                                  "ident": "a31"
-                                                                                                }
-                                                                                              ]
-                                                                                            },
-                                                                                            {
-                                                                                              "kind": "nkIdent",
-                                                                                              "ident": "a02"
-                                                                                            }
-                                                                                          ]
-                                                                                        },
-                                                                                        {
-                                                                                          "kind": "nkIdent",
-                                                                                          "ident": "a13"
-                                                                                        }
-                                                                                      ]
-                                                                                    }
-                                                                                  ]
-                                                                                },
-                                                                                {
-                                                                                  "kind": "nkInfix",
-                                                                                  "sons": [
-                                                                                    {
-                                                                                      "kind": "nkIdent",
-                                                                                      "ident": "*"
-                                                                                    },
-                                                                                    {
-                                                                                      "kind": "nkInfix",
-                                                                                      "sons": [
-                                                                                        {
-                                                                                          "kind": "nkIdent",
-                                                                                          "ident": "*"
-                                                                                        },
-                                                                                        {
-                                                                                          "kind": "nkInfix",
-                                                                                          "sons": [
-                                                                                            {
-                                                                                              "kind": "nkIdent",
-                                                                                              "ident": "*"
-                                                                                            },
-                                                                                            {
-                                                                                              "kind": "nkIdent",
-                                                                                              "ident": "a30"
-                                                                                            },
-                                                                                            {
-                                                                                              "kind": "nkIdent",
-                                                                                              "ident": "a01"
-                                                                                            }
-                                                                                          ]
-                                                                                        },
-                                                                                        {
-                                                                                          "kind": "nkIdent",
-                                                                                          "ident": "a22"
-                                                                                        }
-                                                                                      ]
-                                                                                    },
-                                                                                    {
-                                                                                      "kind": "nkIdent",
-                                                                                      "ident": "a13"
-                                                                                    }
-                                                                                  ]
-                                                                                }
-                                                                              ]
-                                                                            },
-                                                                            {
-                                                                              "kind": "nkInfix",
-                                                                              "sons": [
-                                                                                {
-                                                                                  "kind": "nkIdent",
-                                                                                  "ident": "*"
-                                                                                },
-                                                                                {
-                                                                                  "kind": "nkInfix",
-                                                                                  "sons": [
-                                                                                    {
-                                                                                      "kind": "nkIdent",
-                                                                                      "ident": "*"
-                                                                                    },
-                                                                                    {
-                                                                                      "kind": "nkInfix",
-                                                                                      "sons": [
-                                                                                        {
-                                                                                          "kind": "nkIdent",
-                                                                                          "ident": "*"
-                                                                                        },
-                                                                                        {
-                                                                                          "kind": "nkIdent",
-                                                                                          "ident": "a00"
-                                                                                        },
-                                                                                        {
-                                                                                          "kind": "nkIdent",
-                                                                                          "ident": "a31"
-                                                                                        }
-                                                                                      ]
-                                                                                    },
-                                                                                    {
-                                                                                      "kind": "nkIdent",
-                                                                                      "ident": "a22"
-                                                                                    }
-                                                                                  ]
-                                                                                },
-                                                                                {
-                                                                                  "kind": "nkIdent",
-                                                                                  "ident": "a13"
-                                                                                }
-                                                                              ]
-                                                                            }
-                                                                          ]
-                                                                        },
-                                                                        {
-                                                                          "kind": "nkInfix",
-                                                                          "sons": [
-                                                                            {
-                                                                              "kind": "nkIdent",
-                                                                              "ident": "*"
-                                                                            },
-                                                                            {
-                                                                              "kind": "nkInfix",
-                                                                              "sons": [
-                                                                                {
-                                                                                  "kind": "nkIdent",
-                                                                                  "ident": "*"
-                                                                                },
-                                                                                {
-                                                                                  "kind": "nkInfix",
-                                                                                  "sons": [
-                                                                                    {
-                                                                                      "kind": "nkIdent",
-                                                                                      "ident": "*"
-                                                                                    },
-                                                                                    {
-                                                                                      "kind": "nkIdent",
-                                                                                      "ident": "a20"
-                                                                                    },
-                                                                                    {
-                                                                                      "kind": "nkIdent",
-                                                                                      "ident": "a01"
-                                                                                    }
-                                                                                  ]
-                                                                                },
-                                                                                {
-                                                                                  "kind": "nkIdent",
-                                                                                  "ident": "a32"
-                                                                                }
-                                                                              ]
-                                                                            },
-                                                                            {
-                                                                              "kind": "nkIdent",
-                                                                              "ident": "a13"
-                                                                            }
-                                                                          ]
-                                                                        }
-                                                                      ]
-                                                                    },
-                                                                    {
-                                                                      "kind": "nkInfix",
-                                                                      "sons": [
-                                                                        {
-                                                                          "kind": "nkIdent",
-                                                                          "ident": "*"
-                                                                        },
-                                                                        {
-                                                                          "kind": "nkInfix",
-                                                                          "sons": [
-                                                                            {
-                                                                              "kind": "nkIdent",
-                                                                              "ident": "*"
-                                                                            },
-                                                                            {
-                                                                              "kind": "nkInfix",
-                                                                              "sons": [
-                                                                                {
-                                                                                  "kind": "nkIdent",
-                                                                                  "ident": "*"
-                                                                                },
-                                                                                {
-                                                                                  "kind": "nkIdent",
-                                                                                  "ident": "a00"
-                                                                                },
-                                                                                {
-                                                                                  "kind": "nkIdent",
-                                                                                  "ident": "a21"
-                                                                                }
-                                                                              ]
-                                                                            },
-                                                                            {
-                                                                              "kind": "nkIdent",
-                                                                              "ident": "a32"
-                                                                            }
-                                                                          ]
-                                                                        },
-                                                                        {
-                                                                          "kind": "nkIdent",
-                                                                          "ident": "a13"
-                                                                        }
-                                                                      ]
-                                                                    }
-                                                                  ]
-                                                                },
-                                                                {
-                                                                  "kind": "nkInfix",
-                                                                  "sons": [
-                                                                    {
-                                                                      "kind": "nkIdent",
-                                                                      "ident": "*"
-                                                                    },
-                                                                    {
-                                                                      "kind": "nkInfix",
-                                                                      "sons": [
-                                                                        {
-                                                                          "kind": "nkIdent",
-                                                                          "ident": "*"
-                                                                        },
-                                                                        {
-                                                                          "kind": "nkInfix",
-                                                                          "sons": [
-                                                                            {
-                                                                              "kind": "nkIdent",
-                                                                              "ident": "*"
-                                                                            },
-                                                                            {
-                                                                              "kind": "nkIdent",
-                                                                              "ident": "a30"
-                                                                            },
-                                                                            {
-                                                                              "kind": "nkIdent",
-                                                                              "ident": "a11"
-                                                                            }
-                                                                          ]
-                                                                        },
-                                                                        {
-                                                                          "kind": "nkIdent",
-                                                                          "ident": "a02"
-                                                                        }
-                                                                      ]
-                                                                    },
-                                                                    {
-                                                                      "kind": "nkIdent",
-                                                                      "ident": "a23"
-                                                                    }
-                                                                  ]
-                                                                }
-                                                              ]
-                                                            },
-                                                            {
-                                                              "kind": "nkInfix",
-                                                              "sons": [
-                                                                {
-                                                                  "kind": "nkIdent",
-                                                                  "ident": "*"
-                                                                },
-                                                                {
-                                                                  "kind": "nkInfix",
-                                                                  "sons": [
-                                                                    {
-                                                                      "kind": "nkIdent",
-                                                                      "ident": "*"
-                                                                    },
-                                                                    {
-                                                                      "kind": "nkInfix",
-                                                                      "sons": [
-                                                                        {
-                                                                          "kind": "nkIdent",
-                                                                          "ident": "*"
-                                                                        },
-                                                                        {
-                                                                          "kind": "nkIdent",
-                                                                          "ident": "a10"
-                                                                        },
-                                                                        {
-                                                                          "kind": "nkIdent",
-                                                                          "ident": "a31"
-                                                                        }
-                                                                      ]
-                                                                    },
-                                                                    {
-                                                                      "kind": "nkIdent",
-                                                                      "ident": "a02"
-                                                                    }
-                                                                  ]
-                                                                },
-                                                                {
-                                                                  "kind": "nkIdent",
-                                                                  "ident": "a23"
-                                                                }
-                                                              ]
-                                                            }
-                                                          ]
-                                                        },
-                                                        {
-                                                          "kind": "nkInfix",
-                                                          "sons": [
-                                                            {
-                                                              "kind": "nkIdent",
-                                                              "ident": "*"
-                                                            },
-                                                            {
-                                                              "kind": "nkInfix",
-                                                              "sons": [
-                                                                {
-                                                                  "kind": "nkIdent",
-                                                                  "ident": "*"
-                                                                },
-                                                                {
-                                                                  "kind": "nkInfix",
-                                                                  "sons": [
-                                                                    {
-                                                                      "kind": "nkIdent",
-                                                                      "ident": "*"
-                                                                    },
-                                                                    {
-                                                                      "kind": "nkIdent",
-                                                                      "ident": "a30"
-                                                                    },
-                                                                    {
-                                                                      "kind": "nkIdent",
-                                                                      "ident": "a01"
-                                                                    }
-                                                                  ]
-                                                                },
-                                                                {
-                                                                  "kind": "nkIdent",
-                                                                  "ident": "a12"
-                                                                }
-                                                              ]
-                                                            },
-                                                            {
-                                                              "kind": "nkIdent",
-                                                              "ident": "a23"
-                                                            }
-                                                          ]
-                                                        }
-                                                      ]
-                                                    },
-                                                    {
-                                                      "kind": "nkInfix",
-                                                      "sons": [
-                                                        {
-                                                          "kind": "nkIdent",
-                                                          "ident": "*"
-                                                        },
-                                                        {
-                                                          "kind": "nkInfix",
-                                                          "sons": [
-                                                            {
-                                                              "kind": "nkIdent",
-                                                              "ident": "*"
-                                                            },
-                                                            {
-                                                              "kind": "nkInfix",
-                                                              "sons": [
-                                                                {
-                                                                  "kind": "nkIdent",
-                                                                  "ident": "*"
-                                                                },
-                                                                {
-                                                                  "kind": "nkIdent",
-                                                                  "ident": "a00"
-                                                                },
-                                                                {
-                                                                  "kind": "nkIdent",
-                                                                  "ident": "a31"
-                                                                }
-                                                              ]
-                                                            },
-                                                            {
-                                                              "kind": "nkIdent",
-                                                              "ident": "a12"
-                                                            }
-                                                          ]
-                                                        },
-                                                        {
-                                                          "kind": "nkIdent",
-                                                          "ident": "a23"
-                                                        }
-                                                      ]
-                                                    }
-                                                  ]
-                                                },
-                                                {
-                                                  "kind": "nkInfix",
-                                                  "sons": [
-                                                    {
-                                                      "kind": "nkIdent",
-                                                      "ident": "*"
-                                                    },
-                                                    {
-                                                      "kind": "nkInfix",
-                                                      "sons": [
-                                                        {
-                                                          "kind": "nkIdent",
-                                                          "ident": "*"
-                                                        },
-                                                        {
-                                                          "kind": "nkInfix",
-                                                          "sons": [
-                                                            {
-                                                              "kind": "nkIdent",
-                                                              "ident": "*"
-                                                            },
-                                                            {
-                                                              "kind": "nkIdent",
-                                                              "ident": "a10"
-                                                            },
-                                                            {
-                                                              "kind": "nkIdent",
-                                                              "ident": "a01"
-                                                            }
-                                                          ]
-                                                        },
-                                                        {
-                                                          "kind": "nkIdent",
-                                                          "ident": "a32"
-                                                        }
-                                                      ]
-                                                    },
-                                                    {
-                                                      "kind": "nkIdent",
-                                                      "ident": "a23"
-                                                    }
-                                                  ]
-                                                }
-                                              ]
-                                            },
-                                            {
-                                              "kind": "nkInfix",
-                                              "sons": [
-                                                {
-                                                  "kind": "nkIdent",
-                                                  "ident": "*"
-                                                },
-                                                {
-                                                  "kind": "nkInfix",
-                                                  "sons": [
-                                                    {
-                                                      "kind": "nkIdent",
-                                                      "ident": "*"
-                                                    },
-                                                    {
-                                                      "kind": "nkInfix",
-                                                      "sons": [
-                                                        {
-                                                          "kind": "nkIdent",
-                                                          "ident": "*"
-                                                        },
-                                                        {
-                                                          "kind": "nkIdent",
-                                                          "ident": "a00"
-                                                        },
-                                                        {
-                                                          "kind": "nkIdent",
-                                                          "ident": "a11"
-                                                        }
-                                                      ]
-                                                    },
-                                                    {
-                                                      "kind": "nkIdent",
-                                                      "ident": "a32"
-                                                    }
-                                                  ]
-                                                },
-                                                {
-                                                  "kind": "nkIdent",
-                                                  "ident": "a23"
-                                                }
-                                              ]
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "kind": "nkInfix",
-                                          "sons": [
-                                            {
-                                              "kind": "nkIdent",
-                                              "ident": "*"
-                                            },
-                                            {
-                                              "kind": "nkInfix",
-                                              "sons": [
-                                                {
-                                                  "kind": "nkIdent",
-                                                  "ident": "*"
-                                                },
-                                                {
-                                                  "kind": "nkInfix",
-                                                  "sons": [
-                                                    {
-                                                      "kind": "nkIdent",
-                                                      "ident": "*"
-                                                    },
-                                                    {
-                                                      "kind": "nkIdent",
-                                                      "ident": "a20"
-                                                    },
-                                                    {
-                                                      "kind": "nkIdent",
-                                                      "ident": "a11"
-                                                    }
-                                                  ]
-                                                },
-                                                {
-                                                  "kind": "nkIdent",
-                                                  "ident": "a02"
-                                                }
-                                              ]
-                                            },
-                                            {
-                                              "kind": "nkIdent",
-                                              "ident": "a33"
-                                            }
-                                          ]
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "kind": "nkInfix",
-                                      "sons": [
-                                        {
-                                          "kind": "nkIdent",
-                                          "ident": "*"
-                                        },
-                                        {
-                                          "kind": "nkInfix",
-                                          "sons": [
-                                            {
-                                              "kind": "nkIdent",
-                                              "ident": "*"
-                                            },
-                                            {
-                                              "kind": "nkInfix",
-                                              "sons": [
-                                                {
-                                                  "kind": "nkIdent",
-                                                  "ident": "*"
-                                                },
-                                                {
-                                                  "kind": "nkIdent",
-                                                  "ident": "a10"
-                                                },
-                                                {
-                                                  "kind": "nkIdent",
-                                                  "ident": "a21"
-                                                }
-                                              ]
-                                            },
-                                            {
-                                              "kind": "nkIdent",
-                                              "ident": "a02"
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "kind": "nkIdent",
-                                          "ident": "a33"
-                                        }
-                                      ]
-                                    }
-                                  ]
-                                },
-                                {
-                                  "kind": "nkInfix",
-                                  "sons": [
-                                    {
-                                      "kind": "nkIdent",
-                                      "ident": "*"
-                                    },
-                                    {
-                                      "kind": "nkInfix",
-                                      "sons": [
-                                        {
-                                          "kind": "nkIdent",
-                                          "ident": "*"
-                                        },
-                                        {
-                                          "kind": "nkInfix",
-                                          "sons": [
-                                            {
-                                              "kind": "nkIdent",
-                                              "ident": "*"
-                                            },
-                                            {
-                                              "kind": "nkIdent",
-                                              "ident": "a20"
-                                            },
-                                            {
-                                              "kind": "nkIdent",
-                                              "ident": "a01"
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "kind": "nkIdent",
-                                          "ident": "a12"
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "kind": "nkIdent",
-                                      "ident": "a33"
-                                    }
-                                  ]
-                                }
-                              ]
-                            },
-                            {
-                              "kind": "nkInfix",
-                              "sons": [
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "*"
-                                },
-                                {
-                                  "kind": "nkInfix",
-                                  "sons": [
-                                    {
-                                      "kind": "nkIdent",
-                                      "ident": "*"
-                                    },
-                                    {
-                                      "kind": "nkInfix",
-                                      "sons": [
-                                        {
-                                          "kind": "nkIdent",
-                                          "ident": "*"
-                                        },
-                                        {
-                                          "kind": "nkIdent",
-                                          "ident": "a00"
-                                        },
-                                        {
-                                          "kind": "nkIdent",
-                                          "ident": "a21"
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "kind": "nkIdent",
-                                      "ident": "a12"
-                                    }
-                                  ]
-                                },
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "a33"
-                                }
-                              ]
-                            }
-                          ]
-                        },
-                        {
-                          "kind": "nkInfix",
-                          "sons": [
-                            {
-                              "kind": "nkIdent",
-                              "ident": "*"
-                            },
-                            {
-                              "kind": "nkInfix",
-                              "sons": [
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "*"
-                                },
-                                {
-                                  "kind": "nkInfix",
-                                  "sons": [
-                                    {
-                                      "kind": "nkIdent",
-                                      "ident": "*"
-                                    },
-                                    {
-                                      "kind": "nkIdent",
-                                      "ident": "a10"
-                                    },
-                                    {
-                                      "kind": "nkIdent",
-                                      "ident": "a01"
-                                    }
-                                  ]
-                                },
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "a22"
-                                }
-                              ]
-                            },
-                            {
-                              "kind": "nkIdent",
-                              "ident": "a33"
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "kind": "nkInfix",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "*"
-                        },
-                        {
-                          "kind": "nkInfix",
-                          "sons": [
-                            {
-                              "kind": "nkIdent",
-                              "ident": "*"
-                            },
-                            {
-                              "kind": "nkInfix",
-                              "sons": [
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "*"
-                                },
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "a00"
-                                },
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "a11"
-                                }
-                              ]
-                            },
-                            {
-                              "kind": "nkIdent",
-                              "ident": "a22"
-                            }
-                          ]
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "a33"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkIfStmt",
-      "sons": [
-        {
-          "kind": "nkElifBranch",
-          "sons": [
-            {
-              "kind": "nkInfix",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "and"
-                },
-                {
-                  "kind": "nkInfix",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "and"
-                    },
-                    {
-                      "kind": "nkInfix",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "and"
-                        },
-                        {
-                          "kind": "nkInfix",
-                          "sons": [
-                            {
-                              "kind": "nkIdent",
-                              "ident": "and"
-                            },
-                            {
-                              "kind": "nkIdent",
-                              "ident": "aaaaaaaaaaaaaaaaaaaa"
-                            },
-                            {
-                              "kind": "nkIdent",
-                              "ident": "bbbbbbbbbbbbbbbbbbbbbbb"
-                            }
-                          ]
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "ccccccccccccccccccccccccc"
-                        }
-                      ]
-                    },
-                    {
-                      "kind": "nkIdent",
-                      "ident": "ddddddddddddddddd"
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "fffffffffffffffff"
-                }
-              ]
-            },
-            {
-              "kind": "nkStmtList",
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkIfStmt",
-      "sons": [
-        {
-          "kind": "nkElifBranch",
-          "sons": [
-            {
-              "kind": "nkInfix",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "or"
-                },
-                {
-                  "kind": "nkPar",
-                  "sons": [
-                    {
-                      "kind": "nkInfix",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "and"
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "aaaaaaaaaaaaaaaa"
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "bbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkPar",
-                  "sons": [
-                    {
-                      "kind": "nkInfix",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "and"
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "ccccccccccccccccccccccccccc"
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "ddddddddddddddddddddd"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "kind": "nkStmtList",
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkElifBranch",
-          "sons": [
-            {
-              "kind": "nkInfix",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "and"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "aaaaaaaaa"
-                },
-                {
-                  "kind": "nkPar",
-                  "sons": [
-                    {
-                      "kind": "nkInfix",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "or"
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "bbbbbbbbbb"
-                        },
-                        {
-                          "kind": "nkInfix",
-                          "sons": [
-                            {
-                              "kind": "nkIdent",
-                              "ident": "and"
-                            },
-                            {
-                              "kind": "nkIdent",
-                              "ident": "cccccccccccc"
-                            },
-                            {
-                              "kind": "nkPar",
-                              "sons": [
-                                {
-                                  "kind": "nkInfix",
-                                  "sons": [
-                                    {
-                                      "kind": "nkIdent",
-                                      "ident": "or"
-                                    },
-                                    {
-                                      "kind": "nkInfix",
-                                      "sons": [
-                                        {
-                                          "kind": "nkIdent",
-                                          "ident": "or"
-                                        },
-                                        {
-                                          "kind": "nkInfix",
-                                          "sons": [
-                                            {
-                                              "kind": "nkIdent",
-                                              "ident": "or"
-                                            },
-                                            {
-                                              "kind": "nkIdent",
-                                              "ident": "dddddddddddddddd"
-                                            },
-                                            {
-                                              "kind": "nkIdent",
-                                              "ident": "eeeeeeeeeeeeeee"
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "kind": "nkIdent",
-                                          "ident": "fffffffffffffff"
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "kind": "nkIdent",
-                                      "ident": "gggggggggggggg"
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "kind": "nkStmtList",
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkCaseStmt",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "aaaaaaaaaa"
-        },
-        {
-          "kind": "nkOfBranch",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "bbbbbbbbbbbbbbbbbbbbbbbbbb"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "ccccccccccccccccccccccc"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "ddddddddddddddddddddddd"
-            },
-            {
-              "kind": "nkStmtList",
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkOfBranch",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "aaaa"
-            },
-            {
-              "kind": "nkStmtList",
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkOfBranch",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "bbbbbbbbbbbbbbbbbbbbbbbbbb"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "ccccccccccccccccccccccc"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "dddddddddddddddddddddd"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "bbbbbbbbbbbbbbbbbbbbbbbbbb"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "ccccccccccccccccccccccc"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "dddddddddddddddddddddd"
-            },
-            {
-              "kind": "nkStmtList",
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkElse",
-          "sons": [
-            {
-              "kind": "nkStmtList",
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
-  ]
-}
+kind: "nkStmtList"
+sons:
+  - kind: "nkVarSection"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "c3"
+          - kind: "nkEmpty"
+          - kind: "nkInfix"
+            sons:
+              - kind: "nkIdent"
+                ident: "+"
+              - kind: "nkBracketExpr"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "row"
+                  - kind: "nkIdent"
+                    ident: "p"
+              - kind: "nkStmtListExpr"
+                sons:
+                  - kind: "nkIfStmt"
+                    sons:
+                      - kind: "nkElifExpr"
+                        sons:
+                          - kind: "nkInfix"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: "!="
+                              - kind: "nkIdent"
+                                ident: "runeA"
+                              - kind: "nkIdent"
+                                ident: "runeB"
+                          - kind: "nkStmtList"
+                            sons:
+                              - kind: "nkIntLit"
+                                intVal: 1
+                      - kind: "nkElseExpr"
+                        sons:
+                          - kind: "nkStmtList"
+                            sons:
+                              - kind: "nkIntLit"
+                                intVal: 0
+  - kind: "nkVarSection"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "c3"
+          - kind: "nkEmpty"
+          - kind: "nkInfix"
+            sons:
+              - kind: "nkIdent"
+                ident: "+"
+              - kind: "nkBracketExpr"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "row"
+                  - kind: "nkIdent"
+                    ident: "p"
+              - kind: "nkStmtListExpr"
+                sons:
+                  - kind: "nkIfStmt"
+                    sons:
+                      - kind: "nkElifExpr"
+                        sons:
+                          - kind: "nkInfix"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: "!="
+                              - kind: "nkIdent"
+                                ident: "runeA"
+                              - kind: "nkIdent"
+                                ident: "runeB"
+                          - kind: "nkIntLit"
+                            intVal: 1
+                      - kind: "nkElseExpr"
+                        sons:
+                          - kind: "nkIntLit"
+                            intVal: 0
+  - kind: "nkForStmt"
+    sons:
+      - kind: "nkIdent"
+        ident: "a"
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: "..<"
+          - kind: "nkIntLit"
+            intVal: 0
+          - kind: "nkIntLit"
+            intVal: 1
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+  - kind: "nkForStmt"
+    sons:
+      - kind: "nkIdent"
+        ident: "a"
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: ".."
+          - kind: "nkIntLit"
+            intVal: 0
+          - kind: "nkIntLit"
+            intVal: 1
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+  - kind: "nkForStmt"
+    prefix:
+      - "# needs spaces"
+    sons:
+      - kind: "nkIdent"
+        ident: "a"
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: ".."
+          - kind: "nkPrefix"
+            sons:
+              - kind: "nkIdent"
+                ident: "^"
+              - kind: "nkIntLit"
+                intVal: 1
+          - kind: "nkPrefix"
+            sons:
+              - kind: "nkIdent"
+                ident: "^"
+              - kind: "nkIntLit"
+                intVal: 2
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+  - kind: "nkTemplateDef"
+    sons:
+      - kind: "nkPostfix"
+        sons:
+          - kind: "nkIdent"
+            ident: "*"
+          - kind: "nkIdent"
+            ident: "ttt"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkIdent"
+            ident: "untyped"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkBracketExpr"
+            sons:
+              - kind: "nkStmtListExpr"
+                sons:
+                  - kind: "nkBlockStmt"
+                    sons:
+                      - kind: "nkEmpty"
+                      - kind: "nkStmtList"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "xxx"
+  - kind: "nkDiscardStmt"
+    prefix:
+      - "# command syntax with colon"
+    sons:
+      - kind: "nkCommand"
+        sons:
+          - kind: "nkIdent"
+            ident: "xxxx"
+          - kind: "nkStrLit"
+            strVal: "arg"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkIdent"
+                ident: "yyy"
+  - kind: "nkCommand"
+    sons:
+      - kind: "nkDotExpr"
+        sons:
+          - kind: "nkIdent"
+            ident: "res"
+          - kind: "nkIdent"
+            ident: "add"
+      - kind: "nkCall"
+        sons:
+          - kind: "nkIdent"
+            ident: "fff"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkCall"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "yy"
+  - kind: "nkLetSection"
+    prefix:
+      - "# we don\'t what `do` in let but need it in the above commend - this needs"
+      - "# more investigation - this is important for templates calls like Result.valueOr"
+      - "# which become ugly otherwise"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "xxx"
+          - kind: "nkEmpty"
+          - kind: "nkCall"
+            sons:
+              - kind: "nkIdent"
+                ident: "implicitdo"
+              - kind: "nkStmtList"
+                sons:
+                  - kind: "nkReturnStmt"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "xxx"
+  - kind: "nkLetSection"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "shortInfix"
+          - kind: "nkEmpty"
+          - kind: "nkInfix"
+            sons:
+              - kind: "nkIdent"
+                ident: "+"
+              - kind: "nkInfix"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "+"
+                  - kind: "nkInfix"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "*"
+                      - kind: "nkInfix"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "*"
+                          - kind: "nkIdent"
+                            ident: "a"
+                          - kind: "nkIdent"
+                            ident: "b"
+                      - kind: "nkIdent"
+                        ident: "c"
+                  - kind: "nkInfix"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "*"
+                      - kind: "nkInfix"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "*"
+                          - kind: "nkIdent"
+                            ident: "d"
+                          - kind: "nkIdent"
+                            ident: "e"
+                      - kind: "nkIdent"
+                        ident: "f"
+              - kind: "nkInfix"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "*"
+                  - kind: "nkPar"
+                    sons:
+                      - kind: "nkInfix"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "+"
+                          - kind: "nkIdent"
+                            ident: "a"
+                          - kind: "nkIdent"
+                            ident: "b"
+                  - kind: "nkIdent"
+                    ident: "g"
+  - kind: "nkLetSection"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "longInfix"
+          - kind: "nkEmpty"
+          - kind: "nkPar"
+            sons:
+              - kind: "nkInfix"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "+"
+                  - kind: "nkInfix"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "-"
+                      - kind: "nkInfix"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "-"
+                          - kind: "nkInfix"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: "+"
+                              - kind: "nkInfix"
+                                sons:
+                                  - kind: "nkIdent"
+                                    ident: "+"
+                                  - kind: "nkInfix"
+                                    sons:
+                                      - kind: "nkIdent"
+                                        ident: "-"
+                                      - kind: "nkInfix"
+                                        sons:
+                                          - kind: "nkIdent"
+                                            ident: "-"
+                                          - kind: "nkInfix"
+                                            sons:
+                                              - kind: "nkIdent"
+                                                ident: "+"
+                                              - kind: "nkInfix"
+                                                sons:
+                                                  - kind: "nkIdent"
+                                                    ident: "+"
+                                                  - kind: "nkInfix"
+                                                    sons:
+                                                      - kind: "nkIdent"
+                                                        ident: "-"
+                                                      - kind: "nkInfix"
+                                                        sons:
+                                                          - kind: "nkIdent"
+                                                            ident: "-"
+                                                          - kind: "nkInfix"
+                                                            sons:
+                                                              - kind: "nkIdent"
+                                                                ident: "+"
+                                                              - kind: "nkInfix"
+                                                                sons:
+                                                                  - kind: "nkIdent"
+                                                                    ident: "+"
+                                                                  - kind: "nkInfix"
+                                                                    sons:
+                                                                      - kind: "nkIdent"
+                                                                        ident: "-"
+                                                                      - kind: "nkInfix"
+                                                                        sons:
+                                                                          - kind: "nkIdent"
+                                                                            ident: "-"
+                                                                          - kind: "nkInfix"
+                                                                            sons:
+                                                                              - kind: "nkIdent"
+                                                                                ident: "+"
+                                                                              - kind: "nkInfix"
+                                                                                sons:
+                                                                                  - kind: "nkIdent"
+                                                                                    ident: "+"
+                                                                                  - kind: "nkInfix"
+                                                                                    sons:
+                                                                                      - kind: "nkIdent"
+                                                                                        ident: "-"
+                                                                                      - kind: "nkInfix"
+                                                                                        sons:
+                                                                                          - kind: "nkIdent"
+                                                                                            ident: "-"
+                                                                                          - kind: "nkInfix"
+                                                                                            sons:
+                                                                                              - kind: "nkIdent"
+                                                                                                ident: "+"
+                                                                                              - kind: "nkInfix"
+                                                                                                sons:
+                                                                                                  - kind: "nkIdent"
+                                                                                                    ident: "+"
+                                                                                                  - kind: "nkInfix"
+                                                                                                    sons:
+                                                                                                      - kind: "nkIdent"
+                                                                                                        ident: "-"
+                                                                                                      - kind: "nkInfix"
+                                                                                                        sons:
+                                                                                                          - kind: "nkIdent"
+                                                                                                            ident: "-"
+                                                                                                          - kind: "nkInfix"
+                                                                                                            sons:
+                                                                                                              - kind: "nkIdent"
+                                                                                                                ident: "*"
+                                                                                                              - kind: "nkInfix"
+                                                                                                                sons:
+                                                                                                                  - kind: "nkIdent"
+                                                                                                                    ident: "*"
+                                                                                                                  - kind: "nkInfix"
+                                                                                                                    sons:
+                                                                                                                      - kind: "nkIdent"
+                                                                                                                        ident: "*"
+                                                                                                                      - kind: "nkIdent"
+                                                                                                                        ident: "a30"
+                                                                                                                      - kind: "nkIdent"
+                                                                                                                        ident: "a21"
+                                                                                                                  - kind: "nkIdent"
+                                                                                                                    ident: "a12"
+                                                                                                              - kind: "nkIdent"
+                                                                                                                ident: "a03"
+                                                                                                          - kind: "nkInfix"
+                                                                                                            sons:
+                                                                                                              - kind: "nkIdent"
+                                                                                                                ident: "*"
+                                                                                                              - kind: "nkInfix"
+                                                                                                                sons:
+                                                                                                                  - kind: "nkIdent"
+                                                                                                                    ident: "*"
+                                                                                                                  - kind: "nkInfix"
+                                                                                                                    sons:
+                                                                                                                      - kind: "nkIdent"
+                                                                                                                        ident: "*"
+                                                                                                                      - kind: "nkIdent"
+                                                                                                                        ident: "a20"
+                                                                                                                      - kind: "nkIdent"
+                                                                                                                        ident: "a31"
+                                                                                                                  - kind: "nkIdent"
+                                                                                                                    ident: "a12"
+                                                                                                              - kind: "nkIdent"
+                                                                                                                ident: "a03"
+                                                                                                      - kind: "nkInfix"
+                                                                                                        sons:
+                                                                                                          - kind: "nkIdent"
+                                                                                                            ident: "*"
+                                                                                                          - kind: "nkInfix"
+                                                                                                            sons:
+                                                                                                              - kind: "nkIdent"
+                                                                                                                ident: "*"
+                                                                                                              - kind: "nkInfix"
+                                                                                                                sons:
+                                                                                                                  - kind: "nkIdent"
+                                                                                                                    ident: "*"
+                                                                                                                  - kind: "nkIdent"
+                                                                                                                    ident: "a30"
+                                                                                                                  - kind: "nkIdent"
+                                                                                                                    ident: "a11"
+                                                                                                              - kind: "nkIdent"
+                                                                                                                ident: "a22"
+                                                                                                          - kind: "nkIdent"
+                                                                                                            ident: "a03"
+                                                                                                  - kind: "nkInfix"
+                                                                                                    sons:
+                                                                                                      - kind: "nkIdent"
+                                                                                                        ident: "*"
+                                                                                                      - kind: "nkInfix"
+                                                                                                        sons:
+                                                                                                          - kind: "nkIdent"
+                                                                                                            ident: "*"
+                                                                                                          - kind: "nkInfix"
+                                                                                                            sons:
+                                                                                                              - kind: "nkIdent"
+                                                                                                                ident: "*"
+                                                                                                              - kind: "nkIdent"
+                                                                                                                ident: "a10"
+                                                                                                              - kind: "nkIdent"
+                                                                                                                ident: "a31"
+                                                                                                          - kind: "nkIdent"
+                                                                                                            ident: "a22"
+                                                                                                      - kind: "nkIdent"
+                                                                                                        ident: "a03"
+                                                                                              - kind: "nkInfix"
+                                                                                                sons:
+                                                                                                  - kind: "nkIdent"
+                                                                                                    ident: "*"
+                                                                                                  - kind: "nkInfix"
+                                                                                                    sons:
+                                                                                                      - kind: "nkIdent"
+                                                                                                        ident: "*"
+                                                                                                      - kind: "nkInfix"
+                                                                                                        sons:
+                                                                                                          - kind: "nkIdent"
+                                                                                                            ident: "*"
+                                                                                                          - kind: "nkIdent"
+                                                                                                            ident: "a20"
+                                                                                                          - kind: "nkIdent"
+                                                                                                            ident: "a11"
+                                                                                                      - kind: "nkIdent"
+                                                                                                        ident: "a32"
+                                                                                                  - kind: "nkIdent"
+                                                                                                    ident: "a03"
+                                                                                          - kind: "nkInfix"
+                                                                                            sons:
+                                                                                              - kind: "nkIdent"
+                                                                                                ident: "*"
+                                                                                              - kind: "nkInfix"
+                                                                                                sons:
+                                                                                                  - kind: "nkIdent"
+                                                                                                    ident: "*"
+                                                                                                  - kind: "nkInfix"
+                                                                                                    sons:
+                                                                                                      - kind: "nkIdent"
+                                                                                                        ident: "*"
+                                                                                                      - kind: "nkIdent"
+                                                                                                        ident: "a10"
+                                                                                                      - kind: "nkIdent"
+                                                                                                        ident: "a21"
+                                                                                                  - kind: "nkIdent"
+                                                                                                    ident: "a32"
+                                                                                              - kind: "nkIdent"
+                                                                                                ident: "a03"
+                                                                                      - kind: "nkInfix"
+                                                                                        sons:
+                                                                                          - kind: "nkIdent"
+                                                                                            ident: "*"
+                                                                                          - kind: "nkInfix"
+                                                                                            sons:
+                                                                                              - kind: "nkIdent"
+                                                                                                ident: "*"
+                                                                                              - kind: "nkInfix"
+                                                                                                sons:
+                                                                                                  - kind: "nkIdent"
+                                                                                                    ident: "*"
+                                                                                                  - kind: "nkIdent"
+                                                                                                    ident: "a30"
+                                                                                                  - kind: "nkIdent"
+                                                                                                    ident: "a21"
+                                                                                              - kind: "nkIdent"
+                                                                                                ident: "a02"
+                                                                                          - kind: "nkIdent"
+                                                                                            ident: "a13"
+                                                                                  - kind: "nkInfix"
+                                                                                    sons:
+                                                                                      - kind: "nkIdent"
+                                                                                        ident: "*"
+                                                                                      - kind: "nkInfix"
+                                                                                        sons:
+                                                                                          - kind: "nkIdent"
+                                                                                            ident: "*"
+                                                                                          - kind: "nkInfix"
+                                                                                            sons:
+                                                                                              - kind: "nkIdent"
+                                                                                                ident: "*"
+                                                                                              - kind: "nkIdent"
+                                                                                                ident: "a20"
+                                                                                              - kind: "nkIdent"
+                                                                                                ident: "a31"
+                                                                                          - kind: "nkIdent"
+                                                                                            ident: "a02"
+                                                                                      - kind: "nkIdent"
+                                                                                        ident: "a13"
+                                                                              - kind: "nkInfix"
+                                                                                sons:
+                                                                                  - kind: "nkIdent"
+                                                                                    ident: "*"
+                                                                                  - kind: "nkInfix"
+                                                                                    sons:
+                                                                                      - kind: "nkIdent"
+                                                                                        ident: "*"
+                                                                                      - kind: "nkInfix"
+                                                                                        sons:
+                                                                                          - kind: "nkIdent"
+                                                                                            ident: "*"
+                                                                                          - kind: "nkIdent"
+                                                                                            ident: "a30"
+                                                                                          - kind: "nkIdent"
+                                                                                            ident: "a01"
+                                                                                      - kind: "nkIdent"
+                                                                                        ident: "a22"
+                                                                                  - kind: "nkIdent"
+                                                                                    ident: "a13"
+                                                                          - kind: "nkInfix"
+                                                                            sons:
+                                                                              - kind: "nkIdent"
+                                                                                ident: "*"
+                                                                              - kind: "nkInfix"
+                                                                                sons:
+                                                                                  - kind: "nkIdent"
+                                                                                    ident: "*"
+                                                                                  - kind: "nkInfix"
+                                                                                    sons:
+                                                                                      - kind: "nkIdent"
+                                                                                        ident: "*"
+                                                                                      - kind: "nkIdent"
+                                                                                        ident: "a00"
+                                                                                      - kind: "nkIdent"
+                                                                                        ident: "a31"
+                                                                                  - kind: "nkIdent"
+                                                                                    ident: "a22"
+                                                                              - kind: "nkIdent"
+                                                                                ident: "a13"
+                                                                      - kind: "nkInfix"
+                                                                        sons:
+                                                                          - kind: "nkIdent"
+                                                                            ident: "*"
+                                                                          - kind: "nkInfix"
+                                                                            sons:
+                                                                              - kind: "nkIdent"
+                                                                                ident: "*"
+                                                                              - kind: "nkInfix"
+                                                                                sons:
+                                                                                  - kind: "nkIdent"
+                                                                                    ident: "*"
+                                                                                  - kind: "nkIdent"
+                                                                                    ident: "a20"
+                                                                                  - kind: "nkIdent"
+                                                                                    ident: "a01"
+                                                                              - kind: "nkIdent"
+                                                                                ident: "a32"
+                                                                          - kind: "nkIdent"
+                                                                            ident: "a13"
+                                                                  - kind: "nkInfix"
+                                                                    sons:
+                                                                      - kind: "nkIdent"
+                                                                        ident: "*"
+                                                                      - kind: "nkInfix"
+                                                                        sons:
+                                                                          - kind: "nkIdent"
+                                                                            ident: "*"
+                                                                          - kind: "nkInfix"
+                                                                            sons:
+                                                                              - kind: "nkIdent"
+                                                                                ident: "*"
+                                                                              - kind: "nkIdent"
+                                                                                ident: "a00"
+                                                                              - kind: "nkIdent"
+                                                                                ident: "a21"
+                                                                          - kind: "nkIdent"
+                                                                            ident: "a32"
+                                                                      - kind: "nkIdent"
+                                                                        ident: "a13"
+                                                              - kind: "nkInfix"
+                                                                sons:
+                                                                  - kind: "nkIdent"
+                                                                    ident: "*"
+                                                                  - kind: "nkInfix"
+                                                                    sons:
+                                                                      - kind: "nkIdent"
+                                                                        ident: "*"
+                                                                      - kind: "nkInfix"
+                                                                        sons:
+                                                                          - kind: "nkIdent"
+                                                                            ident: "*"
+                                                                          - kind: "nkIdent"
+                                                                            ident: "a30"
+                                                                          - kind: "nkIdent"
+                                                                            ident: "a11"
+                                                                      - kind: "nkIdent"
+                                                                        ident: "a02"
+                                                                  - kind: "nkIdent"
+                                                                    ident: "a23"
+                                                          - kind: "nkInfix"
+                                                            sons:
+                                                              - kind: "nkIdent"
+                                                                ident: "*"
+                                                              - kind: "nkInfix"
+                                                                sons:
+                                                                  - kind: "nkIdent"
+                                                                    ident: "*"
+                                                                  - kind: "nkInfix"
+                                                                    sons:
+                                                                      - kind: "nkIdent"
+                                                                        ident: "*"
+                                                                      - kind: "nkIdent"
+                                                                        ident: "a10"
+                                                                      - kind: "nkIdent"
+                                                                        ident: "a31"
+                                                                  - kind: "nkIdent"
+                                                                    ident: "a02"
+                                                              - kind: "nkIdent"
+                                                                ident: "a23"
+                                                      - kind: "nkInfix"
+                                                        sons:
+                                                          - kind: "nkIdent"
+                                                            ident: "*"
+                                                          - kind: "nkInfix"
+                                                            sons:
+                                                              - kind: "nkIdent"
+                                                                ident: "*"
+                                                              - kind: "nkInfix"
+                                                                sons:
+                                                                  - kind: "nkIdent"
+                                                                    ident: "*"
+                                                                  - kind: "nkIdent"
+                                                                    ident: "a30"
+                                                                  - kind: "nkIdent"
+                                                                    ident: "a01"
+                                                              - kind: "nkIdent"
+                                                                ident: "a12"
+                                                          - kind: "nkIdent"
+                                                            ident: "a23"
+                                                  - kind: "nkInfix"
+                                                    sons:
+                                                      - kind: "nkIdent"
+                                                        ident: "*"
+                                                      - kind: "nkInfix"
+                                                        sons:
+                                                          - kind: "nkIdent"
+                                                            ident: "*"
+                                                          - kind: "nkInfix"
+                                                            sons:
+                                                              - kind: "nkIdent"
+                                                                ident: "*"
+                                                              - kind: "nkIdent"
+                                                                ident: "a00"
+                                                              - kind: "nkIdent"
+                                                                ident: "a31"
+                                                          - kind: "nkIdent"
+                                                            ident: "a12"
+                                                      - kind: "nkIdent"
+                                                        ident: "a23"
+                                              - kind: "nkInfix"
+                                                sons:
+                                                  - kind: "nkIdent"
+                                                    ident: "*"
+                                                  - kind: "nkInfix"
+                                                    sons:
+                                                      - kind: "nkIdent"
+                                                        ident: "*"
+                                                      - kind: "nkInfix"
+                                                        sons:
+                                                          - kind: "nkIdent"
+                                                            ident: "*"
+                                                          - kind: "nkIdent"
+                                                            ident: "a10"
+                                                          - kind: "nkIdent"
+                                                            ident: "a01"
+                                                      - kind: "nkIdent"
+                                                        ident: "a32"
+                                                  - kind: "nkIdent"
+                                                    ident: "a23"
+                                          - kind: "nkInfix"
+                                            sons:
+                                              - kind: "nkIdent"
+                                                ident: "*"
+                                              - kind: "nkInfix"
+                                                sons:
+                                                  - kind: "nkIdent"
+                                                    ident: "*"
+                                                  - kind: "nkInfix"
+                                                    sons:
+                                                      - kind: "nkIdent"
+                                                        ident: "*"
+                                                      - kind: "nkIdent"
+                                                        ident: "a00"
+                                                      - kind: "nkIdent"
+                                                        ident: "a11"
+                                                  - kind: "nkIdent"
+                                                    ident: "a32"
+                                              - kind: "nkIdent"
+                                                ident: "a23"
+                                      - kind: "nkInfix"
+                                        sons:
+                                          - kind: "nkIdent"
+                                            ident: "*"
+                                          - kind: "nkInfix"
+                                            sons:
+                                              - kind: "nkIdent"
+                                                ident: "*"
+                                              - kind: "nkInfix"
+                                                sons:
+                                                  - kind: "nkIdent"
+                                                    ident: "*"
+                                                  - kind: "nkIdent"
+                                                    ident: "a20"
+                                                  - kind: "nkIdent"
+                                                    ident: "a11"
+                                              - kind: "nkIdent"
+                                                ident: "a02"
+                                          - kind: "nkIdent"
+                                            ident: "a33"
+                                  - kind: "nkInfix"
+                                    sons:
+                                      - kind: "nkIdent"
+                                        ident: "*"
+                                      - kind: "nkInfix"
+                                        sons:
+                                          - kind: "nkIdent"
+                                            ident: "*"
+                                          - kind: "nkInfix"
+                                            sons:
+                                              - kind: "nkIdent"
+                                                ident: "*"
+                                              - kind: "nkIdent"
+                                                ident: "a10"
+                                              - kind: "nkIdent"
+                                                ident: "a21"
+                                          - kind: "nkIdent"
+                                            ident: "a02"
+                                      - kind: "nkIdent"
+                                        ident: "a33"
+                              - kind: "nkInfix"
+                                sons:
+                                  - kind: "nkIdent"
+                                    ident: "*"
+                                  - kind: "nkInfix"
+                                    sons:
+                                      - kind: "nkIdent"
+                                        ident: "*"
+                                      - kind: "nkInfix"
+                                        sons:
+                                          - kind: "nkIdent"
+                                            ident: "*"
+                                          - kind: "nkIdent"
+                                            ident: "a20"
+                                          - kind: "nkIdent"
+                                            ident: "a01"
+                                      - kind: "nkIdent"
+                                        ident: "a12"
+                                  - kind: "nkIdent"
+                                    ident: "a33"
+                          - kind: "nkInfix"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: "*"
+                              - kind: "nkInfix"
+                                sons:
+                                  - kind: "nkIdent"
+                                    ident: "*"
+                                  - kind: "nkInfix"
+                                    sons:
+                                      - kind: "nkIdent"
+                                        ident: "*"
+                                      - kind: "nkIdent"
+                                        ident: "a00"
+                                      - kind: "nkIdent"
+                                        ident: "a21"
+                                  - kind: "nkIdent"
+                                    ident: "a12"
+                              - kind: "nkIdent"
+                                ident: "a33"
+                      - kind: "nkInfix"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "*"
+                          - kind: "nkInfix"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: "*"
+                              - kind: "nkInfix"
+                                sons:
+                                  - kind: "nkIdent"
+                                    ident: "*"
+                                  - kind: "nkIdent"
+                                    ident: "a10"
+                                  - kind: "nkIdent"
+                                    ident: "a01"
+                              - kind: "nkIdent"
+                                ident: "a22"
+                          - kind: "nkIdent"
+                            ident: "a33"
+                  - kind: "nkInfix"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "*"
+                      - kind: "nkInfix"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "*"
+                          - kind: "nkInfix"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: "*"
+                              - kind: "nkIdent"
+                                ident: "a00"
+                              - kind: "nkIdent"
+                                ident: "a11"
+                          - kind: "nkIdent"
+                            ident: "a22"
+                      - kind: "nkIdent"
+                        ident: "a33"
+  - kind: "nkIfStmt"
+    sons:
+      - kind: "nkElifBranch"
+        sons:
+          - kind: "nkInfix"
+            sons:
+              - kind: "nkIdent"
+                ident: "and"
+              - kind: "nkInfix"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "and"
+                  - kind: "nkInfix"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "and"
+                      - kind: "nkInfix"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "and"
+                          - kind: "nkIdent"
+                            ident: "aaaaaaaaaaaaaaaaaaaa"
+                          - kind: "nkIdent"
+                            ident: "bbbbbbbbbbbbbbbbbbbbbbb"
+                      - kind: "nkIdent"
+                        ident: "ccccccccccccccccccccccccc"
+                  - kind: "nkIdent"
+                    ident: "ddddddddddddddddd"
+              - kind: "nkIdent"
+                ident: "fffffffffffffffff"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+  - kind: "nkIfStmt"
+    sons:
+      - kind: "nkElifBranch"
+        sons:
+          - kind: "nkInfix"
+            sons:
+              - kind: "nkIdent"
+                ident: "or"
+              - kind: "nkPar"
+                sons:
+                  - kind: "nkInfix"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "and"
+                      - kind: "nkIdent"
+                        ident: "aaaaaaaaaaaaaaaa"
+                      - kind: "nkIdent"
+                        ident: "bbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+              - kind: "nkPar"
+                sons:
+                  - kind: "nkInfix"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "and"
+                      - kind: "nkIdent"
+                        ident: "ccccccccccccccccccccccccccc"
+                      - kind: "nkIdent"
+                        ident: "ddddddddddddddddddddd"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+      - kind: "nkElifBranch"
+        sons:
+          - kind: "nkInfix"
+            sons:
+              - kind: "nkIdent"
+                ident: "and"
+              - kind: "nkIdent"
+                ident: "aaaaaaaaa"
+              - kind: "nkPar"
+                sons:
+                  - kind: "nkInfix"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "or"
+                      - kind: "nkIdent"
+                        ident: "bbbbbbbbbb"
+                      - kind: "nkInfix"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "and"
+                          - kind: "nkIdent"
+                            ident: "cccccccccccc"
+                          - kind: "nkPar"
+                            sons:
+                              - kind: "nkInfix"
+                                sons:
+                                  - kind: "nkIdent"
+                                    ident: "or"
+                                  - kind: "nkInfix"
+                                    sons:
+                                      - kind: "nkIdent"
+                                        ident: "or"
+                                      - kind: "nkInfix"
+                                        sons:
+                                          - kind: "nkIdent"
+                                            ident: "or"
+                                          - kind: "nkIdent"
+                                            ident: "dddddddddddddddd"
+                                          - kind: "nkIdent"
+                                            ident: "eeeeeeeeeeeeeee"
+                                      - kind: "nkIdent"
+                                        ident: "fffffffffffffff"
+                                  - kind: "nkIdent"
+                                    ident: "gggggggggggggg"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+  - kind: "nkCaseStmt"
+    sons:
+      - kind: "nkIdent"
+        ident: "aaaaaaaaaa"
+      - kind: "nkOfBranch"
+        sons:
+          - kind: "nkIdent"
+            ident: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+          - kind: "nkIdent"
+            ident: "bbbbbbbbbbbbbbbbbbbbbbbbbb"
+          - kind: "nkIdent"
+            ident: "ccccccccccccccccccccccc"
+          - kind: "nkIdent"
+            ident: "ddddddddddddddddddddddd"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+      - kind: "nkOfBranch"
+        sons:
+          - kind: "nkIdent"
+            ident: "aaaa"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+      - kind: "nkOfBranch"
+        sons:
+          - kind: "nkIdent"
+            ident: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+          - kind: "nkIdent"
+            ident: "bbbbbbbbbbbbbbbbbbbbbbbbbb"
+          - kind: "nkIdent"
+            ident: "ccccccccccccccccccccccc"
+          - kind: "nkIdent"
+            ident: "dddddddddddddddddddddd"
+          - kind: "nkIdent"
+            ident: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+          - kind: "nkIdent"
+            ident: "bbbbbbbbbbbbbbbbbbbbbbbbbb"
+          - kind: "nkIdent"
+            ident: "ccccccccccccccccccccccc"
+          - kind: "nkIdent"
+            ident: "dddddddddddddddddddddd"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+      - kind: "nkElse"
+        sons:
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"

--- a/tests/after/import.nim
+++ b/tests/after/import.nim
@@ -7,17 +7,20 @@ import
   ccccccccccccc as dddddddddddddd,
   eeeeeeeeeeeee as fffffffffffffff,
   gggggggggggggggggg as hhhhhhhhhhhhhhhh
+
 import
   "."/
     [
       tables, sets, long, modules, even, more, more, a_really_long_module_here, more,
       more, more, more, more
     ]
+
 import tables, sets
 
 from tables import Xxx, yyy
 
 export a, b, c
+
 export
   aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccc,
   dddddddddddddddddd
@@ -32,8 +35,9 @@ import
   "ccccccccccccccccccccccccc"/dddddddddddddddddddddd
 
 from a import a, b, c
+
 from aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa import
   aaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbb, cccccccccccccccc, ddddddddddddddd,
   eeeeeeeeeeeeeeeeeeeeeee, ffffffffffffff
 
-{.push, raises: [].}
+{.push raises: [].}

--- a/tests/after/import.nim.nph.yaml
+++ b/tests/after/import.nim.nph.yaml
@@ -1,449 +1,209 @@
-{
-  "kind": "nkStmtList",
-  "sons": [
-    {
-      "kind": "nkImportStmt",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "tables"
-        }
-      ]
-    },
-    {
-      "kind": "nkImportStmt",
-      "sons": [
-        {
-          "kind": "nkInfix",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "/"
-            },
-            {
-              "kind": "nkStrLit",
-              "strVal": "."
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "tables"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkImportStmt",
-      "sons": [
-        {
-          "kind": "nkInfix",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "/"
-            },
-            {
-              "kind": "nkStrLit",
-              "strVal": "."
-            },
-            {
-              "kind": "nkBracket",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "tables"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "sets"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkImportStmt",
-      "sons": [
-        {
-          "kind": "nkInfix",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "as"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "sets"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "dummies"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkImportStmt",
-      "sons": [
-        {
-          "kind": "nkInfix",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "as"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "aaaaaaaaaaaaaa"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "bbbbbbbbbbbbbb"
-            }
-          ]
-        },
-        {
-          "kind": "nkInfix",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "as"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "ccccccccccccc"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "dddddddddddddd"
-            }
-          ]
-        },
-        {
-          "kind": "nkInfix",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "as"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "eeeeeeeeeeeee"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "fffffffffffffff"
-            }
-          ]
-        },
-        {
-          "kind": "nkInfix",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "as"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "gggggggggggggggggg"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "hhhhhhhhhhhhhhhh"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkImportStmt",
-      "sons": [
-        {
-          "kind": "nkInfix",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "/"
-            },
-            {
-              "kind": "nkStrLit",
-              "strVal": "."
-            },
-            {
-              "kind": "nkBracket",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "tables"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "sets"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "long"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "modules"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "even"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "more"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "more"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "a_really_long_module_here"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "more"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "more"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "more"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "more"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "more"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkImportStmt",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "tables"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "sets"
-        }
-      ]
-    },
-    {
-      "kind": "nkFromStmt",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "tables"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "Xxx"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "yyy"
-        }
-      ]
-    },
-    {
-      "kind": "nkExportStmt",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "a"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "b"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "c"
-        }
-      ]
-    },
-    {
-      "kind": "nkExportStmt",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "bbbbbbbbbbbbbbbbbbbbbbbb"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "cccccccccccccccccccc"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "dddddddddddddddddd"
-        }
-      ]
-    },
-    {
-      "kind": "nkIncludeStmt",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "a"
-        }
-      ]
-    },
-    {
-      "kind": "nkIncludeStmt",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "aaaaaaaaaaaaaaaaaaaa"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "bbbbbbbbbbbbbbbbbbbbbbbbbbb"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "ccccccccccccccccccccccccc"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "dddddddddddddddddd"
-        }
-      ]
-    },
-    {
-      "kind": "nkImportStmt",
-      "sons": [
-        {
-          "kind": "nkInfix",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "/"
-            },
-            {
-              "kind": "nkStrLit",
-              "strVal": "a"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-            }
-          ]
-        },
-        {
-          "kind": "nkInfix",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "/"
-            },
-            {
-              "kind": "nkStrLit",
-              "strVal": "ccccccccccccccccccccccccc"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "dddddddddddddddddddddd"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkFromStmt",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "a"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "a"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "b"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "c"
-        }
-      ]
-    },
-    {
-      "kind": "nkFromStmt",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "aaaaaaaaaaaaaaaaaaaaaa"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "bbbbbbbbbbbbbbb"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "cccccccccccccccc"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "ddddddddddddddd"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "eeeeeeeeeeeeeeeeeeeeeee"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "ffffffffffffff"
-        }
-      ]
-    },
-    {
-      "kind": "nkPragma",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "push"
-        },
-        {
-          "kind": "nkExprColonExpr",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "raises"
-            },
-            {
-              "kind": "nkBracket"
-            }
-          ]
-        }
-      ]
-    }
-  ]
-}
+kind: "nkStmtList"
+sons:
+  - kind: "nkImportStmt"
+    sons:
+      - kind: "nkIdent"
+        ident: "tables"
+  - kind: "nkImportStmt"
+    sons:
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: "/"
+          - kind: "nkStrLit"
+            strVal: "."
+          - kind: "nkIdent"
+            ident: "tables"
+  - kind: "nkImportStmt"
+    sons:
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: "/"
+          - kind: "nkStrLit"
+            strVal: "."
+          - kind: "nkBracket"
+            sons:
+              - kind: "nkIdent"
+                ident: "tables"
+              - kind: "nkIdent"
+                ident: "sets"
+  - kind: "nkImportStmt"
+    sons:
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: "as"
+          - kind: "nkIdent"
+            ident: "sets"
+          - kind: "nkIdent"
+            ident: "dummies"
+  - kind: "nkImportStmt"
+    sons:
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: "as"
+          - kind: "nkIdent"
+            ident: "aaaaaaaaaaaaaa"
+          - kind: "nkIdent"
+            ident: "bbbbbbbbbbbbbb"
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: "as"
+          - kind: "nkIdent"
+            ident: "ccccccccccccc"
+          - kind: "nkIdent"
+            ident: "dddddddddddddd"
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: "as"
+          - kind: "nkIdent"
+            ident: "eeeeeeeeeeeee"
+          - kind: "nkIdent"
+            ident: "fffffffffffffff"
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: "as"
+          - kind: "nkIdent"
+            ident: "gggggggggggggggggg"
+          - kind: "nkIdent"
+            ident: "hhhhhhhhhhhhhhhh"
+  - kind: "nkImportStmt"
+    sons:
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: "/"
+          - kind: "nkStrLit"
+            strVal: "."
+          - kind: "nkBracket"
+            sons:
+              - kind: "nkIdent"
+                ident: "tables"
+              - kind: "nkIdent"
+                ident: "sets"
+              - kind: "nkIdent"
+                ident: "long"
+              - kind: "nkIdent"
+                ident: "modules"
+              - kind: "nkIdent"
+                ident: "even"
+              - kind: "nkIdent"
+                ident: "more"
+              - kind: "nkIdent"
+                ident: "more"
+              - kind: "nkIdent"
+                ident: "a_really_long_module_here"
+              - kind: "nkIdent"
+                ident: "more"
+              - kind: "nkIdent"
+                ident: "more"
+              - kind: "nkIdent"
+                ident: "more"
+              - kind: "nkIdent"
+                ident: "more"
+              - kind: "nkIdent"
+                ident: "more"
+  - kind: "nkImportStmt"
+    sons:
+      - kind: "nkIdent"
+        ident: "tables"
+      - kind: "nkIdent"
+        ident: "sets"
+  - kind: "nkFromStmt"
+    sons:
+      - kind: "nkIdent"
+        ident: "tables"
+      - kind: "nkIdent"
+        ident: "Xxx"
+      - kind: "nkIdent"
+        ident: "yyy"
+  - kind: "nkExportStmt"
+    sons:
+      - kind: "nkIdent"
+        ident: "a"
+      - kind: "nkIdent"
+        ident: "b"
+      - kind: "nkIdent"
+        ident: "c"
+  - kind: "nkExportStmt"
+    sons:
+      - kind: "nkIdent"
+        ident: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      - kind: "nkIdent"
+        ident: "bbbbbbbbbbbbbbbbbbbbbbbb"
+      - kind: "nkIdent"
+        ident: "cccccccccccccccccccc"
+      - kind: "nkIdent"
+        ident: "dddddddddddddddddd"
+  - kind: "nkIncludeStmt"
+    sons:
+      - kind: "nkIdent"
+        ident: "a"
+  - kind: "nkIncludeStmt"
+    sons:
+      - kind: "nkIdent"
+        ident: "aaaaaaaaaaaaaaaaaaaa"
+      - kind: "nkIdent"
+        ident: "bbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      - kind: "nkIdent"
+        ident: "ccccccccccccccccccccccccc"
+      - kind: "nkIdent"
+        ident: "dddddddddddddddddd"
+  - kind: "nkImportStmt"
+    sons:
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: "/"
+          - kind: "nkStrLit"
+            strVal: "a"
+          - kind: "nkIdent"
+            ident: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: "/"
+          - kind: "nkStrLit"
+            strVal: "ccccccccccccccccccccccccc"
+          - kind: "nkIdent"
+            ident: "dddddddddddddddddddddd"
+  - kind: "nkFromStmt"
+    sons:
+      - kind: "nkIdent"
+        ident: "a"
+      - kind: "nkIdent"
+        ident: "a"
+      - kind: "nkIdent"
+        ident: "b"
+      - kind: "nkIdent"
+        ident: "c"
+  - kind: "nkFromStmt"
+    sons:
+      - kind: "nkIdent"
+        ident: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      - kind: "nkIdent"
+        ident: "aaaaaaaaaaaaaaaaaaaaaa"
+      - kind: "nkIdent"
+        ident: "bbbbbbbbbbbbbbb"
+      - kind: "nkIdent"
+        ident: "cccccccccccccccc"
+      - kind: "nkIdent"
+        ident: "ddddddddddddddd"
+      - kind: "nkIdent"
+        ident: "eeeeeeeeeeeeeeeeeeeeeee"
+      - kind: "nkIdent"
+        ident: "ffffffffffffff"
+  - kind: "nkPragma"
+    sons:
+      - kind: "nkIdent"
+        ident: "push"
+      - kind: "nkExprColonExpr"
+        sons:
+          - kind: "nkIdent"
+            ident: "raises"
+          - kind: "nkBracket"

--- a/tests/after/procs.nim
+++ b/tests/after/procs.nim
@@ -38,21 +38,16 @@ proc aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
   discard
 
 proc aaa*(v: int)
-
 proc aaa[A, B, C](v: int)
-
 proc aaaa*[A, B, C](v: int)
-
 proc aaaaa[A, B, C](
   aaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbb, cccccccccccccccc,
   ddddddddddddddddddd: int;
 )
-
 proc aaaa*[
   Aaaaaaaaaaaaaaaaaaaaaaaa, Bbbbbbbbbbbbbbbbbbbbbbbbbb, Cccccccccccccccccccccc,
   Dddddddddddddddddddddd
 ](v: int)
-
 proc aaaaaaaaa*[
   Aaaaaaaaaaaaaaaaaaaaaaaa, Bbbbbbbbbbbbbbbbbbbbbbbbbb, Cccccccccccccccccccccc,
   Dddddddddddddddddddddd
@@ -62,20 +57,19 @@ proc aaaaaaaaa*[
 )
 
 proc aaaaaaaa[T: Aaaa](v: int)
-
 proc aaaaaaaa[
   Tttttttttttttttttttttttttttttttttttttttttt: Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 ](v: int)
-
 proc aaaaaaaa[T: Aaaa; S: static int](v: int)
-
 proc aaaaaaaa[
-  T: Aaaaaaaaaaaaaaaaaaaaaaaa | Bbbbbbbbbbbbbbbbbbbbbbbbbbbb | Cccccccccccccccccccccccccc
+  T:
+    Aaaaaaaaaaaaaaaaaaaaaaaa | Bbbbbbbbbbbbbbbbbbbbbbbbbbbb | Cccccccccccccccccccccccccc
 ](v: int)
 
 proc aaaaaaaaaaa(
-  v: Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa | Bbbbbbbbbbbbbbbbbbbbbbbbbbbbb |
-    Cccccccccccccccccccccccccc;
+  v:
+    Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa | Bbbbbbbbbbbbbbbbbbbbbbbbbbbbb |
+      Cccccccccccccccccccccccccc;
 )
 
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 42 + 33 +
@@ -85,9 +79,11 @@ functionCall(
   aaaaaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaaa,
   aaaaaaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaa
 )
+
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(
   aaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaaaaa
 )
+
 aasdcsaa(
   aaaaaaaaaa = bbbbbbbbbbb,
   ccccccccccc = ddddddddddddd,

--- a/tests/after/procs.nim.nph.yaml
+++ b/tests/after/procs.nim.nph.yaml
@@ -1,1956 +1,818 @@
-{
-  "kind": "nkStmtList",
-  "sons": [
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "a"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkStmtList",
-          "sons": [
-            {
-              "kind": "nkDiscardStmt",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "a"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "v"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "int"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkStmtList",
-          "sons": [
-            {
-              "kind": "nkDiscardStmt",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "a"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "aaaaaaaaaaaaaaaaaaaaaaa"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "bbbbbbbbbbbbbbbbbbbbbb"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "ccccccccccccccccccccccccccc"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "vvvvvvvvvvvvvvvvvvvvvv"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "string"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkStmtList",
-          "sons": [
-            {
-              "kind": "nkDiscardStmt",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "a"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "aaaaaaaaaaaaaaaaaaaaaaa"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "int"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "bbbbbbbbbbbbbbbbbbbbbb"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "int"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "ccccccccccccccccccccccccccc"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "int"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "vvvvvvvvvvvvvvvvvvvvvv"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "string"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkStmtList",
-          "sons": [
-            {
-              "kind": "nkDiscardStmt",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "a"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "Ddddddddddddddddddddddddd"
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "aaaaaaaaaaaaaaaaaaaaaaa"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "bbbbbbbbbbbbbbbbbbbbbb"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "cccccccccccccccc"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "string"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkStmtList",
-          "sons": [
-            {
-              "kind": "nkDiscardStmt",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "a"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "v"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "int"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkPragma",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "nimcall"
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkStmtList",
-          "sons": [
-            {
-              "kind": "nkDiscardStmt",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "a"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "v"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "int"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkPragma",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "nimcall"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "pragma2"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "pragma3"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "praaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagma"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "rrr"
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkStmtList",
-          "sons": [
-            {
-              "kind": "nkDiscardStmt",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "v"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "int"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkStmtList",
-          "sons": [
-            {
-              "kind": "nkDiscardStmt",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkPostfix",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "*"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "aaa"
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "v"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "int"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "aaa"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkGenericParams",
-          "sons": [
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "A"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "B"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "C"
-                },
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "v"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "int"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkPostfix",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "*"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "aaaa"
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkGenericParams",
-          "sons": [
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "A"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "B"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "C"
-                },
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "v"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "int"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "aaaaa"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkGenericParams",
-          "sons": [
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "A"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "B"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "C"
-                },
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "aaaaaaaaaaaaaaaaaaaaaaaaaaa"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "bbbbbbbbbbbbbbbbbbb"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "cccccccccccccccc"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "ddddddddddddddddddd"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "int"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkPostfix",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "*"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "aaaa"
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkGenericParams",
-          "sons": [
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "Aaaaaaaaaaaaaaaaaaaaaaaa"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "Bbbbbbbbbbbbbbbbbbbbbbbbbb"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "Cccccccccccccccccccccc"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "Dddddddddddddddddddddd"
-                },
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "v"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "int"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkPostfix",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "*"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "aaaaaaaaa"
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkGenericParams",
-          "sons": [
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "Aaaaaaaaaaaaaaaaaaaaaaaa"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "Bbbbbbbbbbbbbbbbbbbbbbbbbb"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "Cccccccccccccccccccccc"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "Dddddddddddddddddddddd"
-                },
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "aaaaaaaaaaaaaaaaaaaaaaaaaaa"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "bbbbbbbbbbbbbbbbbbb"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "cccccccccccccccc"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "ddddddddddddddddddd"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "int"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "aaaaaaaa"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkGenericParams",
-          "sons": [
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "T"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "Aaaa"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "v"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "int"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "aaaaaaaa"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkGenericParams",
-          "sons": [
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "Tttttttttttttttttttttttttttttttttttttttttt"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "v"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "int"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "aaaaaaaa"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkGenericParams",
-          "sons": [
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "T"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "Aaaa"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "S"
-                },
-                {
-                  "kind": "nkCommand",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "static"
-                    },
-                    {
-                      "kind": "nkIdent",
-                      "ident": "int"
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "v"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "int"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "aaaaaaaa"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkGenericParams",
-          "sons": [
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "T"
-                },
-                {
-                  "kind": "nkInfix",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "|"
-                    },
-                    {
-                      "kind": "nkInfix",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "|"
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "Aaaaaaaaaaaaaaaaaaaaaaaa"
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "Bbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-                        }
-                      ]
-                    },
-                    {
-                      "kind": "nkIdent",
-                      "ident": "Cccccccccccccccccccccccccc"
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "v"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "int"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "aaaaaaaaaaa"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "v"
-                },
-                {
-                  "kind": "nkInfix",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "|"
-                    },
-                    {
-                      "kind": "nkInfix",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "|"
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "Bbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-                        }
-                      ]
-                    },
-                    {
-                      "kind": "nkIdent",
-                      "ident": "Cccccccccccccccccccccccccc"
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        }
-      ]
-    },
-    {
-      "kind": "nkCommand",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-        },
-        {
-          "kind": "nkInfix",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "+"
-            },
-            {
-              "kind": "nkInfix",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "+"
-                },
-                {
-                  "kind": "nkIntLit",
-                  "intVal": 42
-                },
-                {
-                  "kind": "nkIntLit",
-                  "intVal": 33
-                }
-              ]
-            },
-            {
-              "kind": "nkIntLit",
-              "intVal": 44
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkCall",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "functionCall"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "aaaaaaaaaaaaaaaaaaaaaa"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "aaaaaaaaaaaaaaaaaa"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "aaaaaaaaaaaaaaaaaaa"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "aaaaaaaaaaaaaaaaaaaaaaa"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "aaaaaaaaaaaaa"
-        }
-      ]
-    },
-    {
-      "kind": "nkCall",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "aaaaaaaaaaaaaaa"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "aaaaaaaaaaaaaaaaaaa"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "aaaaaaaaaaaaaaaaa"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "aaaaaaaaaaaaaaaaaaaaa"
-        }
-      ]
-    },
-    {
-      "kind": "nkCall",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "aasdcsaa"
-        },
-        {
-          "kind": "nkExprEqExpr",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "aaaaaaaaaa"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "bbbbbbbbbbb"
-            }
-          ]
-        },
-        {
-          "kind": "nkExprEqExpr",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "ccccccccccc"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "ddddddddddddd"
-            }
-          ]
-        },
-        {
-          "kind": "nkExprEqExpr",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "eeeeeeeeeeee"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "ffffffffffff"
-            }
-          ]
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "gggggg"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "hhhhhhhh"
-        }
-      ]
-    },
-    {
-      "kind": "nkTypeSection",
-      "sons": [
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "Ap"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkProcTy",
-              "sons": [
-                {
-                  "kind": "nkFormalParams",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkTypeSection",
-      "sons": [
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "Bp"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkProcTy"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkTypeSection",
-      "sons": [
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "Cp"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkProcTy",
-              "sons": [
-                {
-                  "kind": "nkFormalParams",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    },
-                    {
-                      "kind": "nkIdentDefs",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "v"
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "int"
-                        },
-                        {
-                          "kind": "nkEmpty"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkTypeSection",
-      "sons": [
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "Dp"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkProcTy",
-              "sons": [
-                {
-                  "kind": "nkFormalParams",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkPragma",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "nimcall"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkTypeSection",
-      "sons": [
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "Ep"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkProcTy",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkPragma",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "nimcall"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkTypeSection",
-      "sons": [
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkProcTy",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkPragma",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "bbbbbbbbbbbbbbbbbbbbbbbb"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkTypeSection",
-      "sons": [
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkProcTy",
-              "sons": [
-                {
-                  "kind": "nkFormalParams",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    },
-                    {
-                      "kind": "nkIdentDefs",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "aaaaaaaa"
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "Bbbbbbb"
-                        },
-                        {
-                          "kind": "nkEmpty"
-                        }
-                      ]
-                    },
-                    {
-                      "kind": "nkIdentDefs",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "ccccccccc"
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "Dddddddddddd"
-                        },
-                        {
-                          "kind": "nkEmpty"
-                        }
-                      ]
-                    },
-                    {
-                      "kind": "nkIdentDefs",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "eeeeee"
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "Ffffff"
-                        },
-                        {
-                          "kind": "nkEmpty"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkTypeSection",
-      "sons": [
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkProcTy",
-              "sons": [
-                {
-                  "kind": "nkFormalParams",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    },
-                    {
-                      "kind": "nkIdentDefs",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "aaaaaaaa"
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "Bbbbbbb"
-                        },
-                        {
-                          "kind": "nkEmpty"
-                        }
-                      ]
-                    },
-                    {
-                      "kind": "nkIdentDefs",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "ccccccccc"
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "Dddddddddddd"
-                        },
-                        {
-                          "kind": "nkEmpty"
-                        }
-                      ]
-                    },
-                    {
-                      "kind": "nkIdentDefs",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "eeeeeeeeeeeee"
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "Ffffffffffffffff"
-                        },
-                        {
-                          "kind": "nkEmpty"
-                        }
-                      ]
-                    },
-                    {
-                      "kind": "nkIdentDefs",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "gggggggggggggg"
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "Hhhhhhhhhhhhhhhhhhhh"
-                        },
-                        {
-                          "kind": "nkEmpty"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
-  ]
-}
+kind: "nkStmtList"
+sons:
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "a"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "a"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "v"
+              - kind: "nkIdent"
+                ident: "int"
+              - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "a"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "aaaaaaaaaaaaaaaaaaaaaaa"
+              - kind: "nkIdent"
+                ident: "bbbbbbbbbbbbbbbbbbbbbb"
+              - kind: "nkIdent"
+                ident: "ccccccccccccccccccccccccccc"
+              - kind: "nkIdent"
+                ident: "vvvvvvvvvvvvvvvvvvvvvv"
+              - kind: "nkIdent"
+                ident: "string"
+              - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "a"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "aaaaaaaaaaaaaaaaaaaaaaa"
+              - kind: "nkIdent"
+                ident: "int"
+              - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "bbbbbbbbbbbbbbbbbbbbbb"
+              - kind: "nkIdent"
+                ident: "int"
+              - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "ccccccccccccccccccccccccccc"
+              - kind: "nkIdent"
+                ident: "int"
+              - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "vvvvvvvvvvvvvvvvvvvvvv"
+              - kind: "nkIdent"
+                ident: "string"
+              - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "a"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkIdent"
+            ident: "Ddddddddddddddddddddddddd"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "aaaaaaaaaaaaaaaaaaaaaaa"
+              - kind: "nkIdent"
+                ident: "bbbbbbbbbbbbbbbbbbbbbb"
+              - kind: "nkIdent"
+                ident: "cccccccccccccccc"
+              - kind: "nkIdent"
+                ident: "string"
+              - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "a"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "v"
+              - kind: "nkIdent"
+                ident: "int"
+              - kind: "nkEmpty"
+      - kind: "nkPragma"
+        sons:
+          - kind: "nkIdent"
+            ident: "nimcall"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "a"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "v"
+              - kind: "nkIdent"
+                ident: "int"
+              - kind: "nkEmpty"
+      - kind: "nkPragma"
+        sons:
+          - kind: "nkIdent"
+            ident: "nimcall"
+          - kind: "nkIdent"
+            ident: "pragma2"
+          - kind: "nkIdent"
+            ident: "pragma3"
+          - kind: "nkIdent"
+            ident: "praaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagma"
+          - kind: "nkIdent"
+            ident: "rrr"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "v"
+              - kind: "nkIdent"
+                ident: "int"
+              - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkPostfix"
+        sons:
+          - kind: "nkIdent"
+            ident: "*"
+          - kind: "nkIdent"
+            ident: "aaa"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "v"
+              - kind: "nkIdent"
+                ident: "int"
+              - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "aaa"
+      - kind: "nkEmpty"
+      - kind: "nkGenericParams"
+        sons:
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "A"
+              - kind: "nkIdent"
+                ident: "B"
+              - kind: "nkIdent"
+                ident: "C"
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "v"
+              - kind: "nkIdent"
+                ident: "int"
+              - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkPostfix"
+        sons:
+          - kind: "nkIdent"
+            ident: "*"
+          - kind: "nkIdent"
+            ident: "aaaa"
+      - kind: "nkEmpty"
+      - kind: "nkGenericParams"
+        sons:
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "A"
+              - kind: "nkIdent"
+                ident: "B"
+              - kind: "nkIdent"
+                ident: "C"
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "v"
+              - kind: "nkIdent"
+                ident: "int"
+              - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "aaaaa"
+      - kind: "nkEmpty"
+      - kind: "nkGenericParams"
+        sons:
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "A"
+              - kind: "nkIdent"
+                ident: "B"
+              - kind: "nkIdent"
+                ident: "C"
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "aaaaaaaaaaaaaaaaaaaaaaaaaaa"
+              - kind: "nkIdent"
+                ident: "bbbbbbbbbbbbbbbbbbb"
+              - kind: "nkIdent"
+                ident: "cccccccccccccccc"
+              - kind: "nkIdent"
+                ident: "ddddddddddddddddddd"
+              - kind: "nkIdent"
+                ident: "int"
+              - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkPostfix"
+        sons:
+          - kind: "nkIdent"
+            ident: "*"
+          - kind: "nkIdent"
+            ident: "aaaa"
+      - kind: "nkEmpty"
+      - kind: "nkGenericParams"
+        sons:
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "Aaaaaaaaaaaaaaaaaaaaaaaa"
+              - kind: "nkIdent"
+                ident: "Bbbbbbbbbbbbbbbbbbbbbbbbbb"
+              - kind: "nkIdent"
+                ident: "Cccccccccccccccccccccc"
+              - kind: "nkIdent"
+                ident: "Dddddddddddddddddddddd"
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "v"
+              - kind: "nkIdent"
+                ident: "int"
+              - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkPostfix"
+        sons:
+          - kind: "nkIdent"
+            ident: "*"
+          - kind: "nkIdent"
+            ident: "aaaaaaaaa"
+      - kind: "nkEmpty"
+      - kind: "nkGenericParams"
+        sons:
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "Aaaaaaaaaaaaaaaaaaaaaaaa"
+              - kind: "nkIdent"
+                ident: "Bbbbbbbbbbbbbbbbbbbbbbbbbb"
+              - kind: "nkIdent"
+                ident: "Cccccccccccccccccccccc"
+              - kind: "nkIdent"
+                ident: "Dddddddddddddddddddddd"
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "aaaaaaaaaaaaaaaaaaaaaaaaaaa"
+              - kind: "nkIdent"
+                ident: "bbbbbbbbbbbbbbbbbbb"
+              - kind: "nkIdent"
+                ident: "cccccccccccccccc"
+              - kind: "nkIdent"
+                ident: "ddddddddddddddddddd"
+              - kind: "nkIdent"
+                ident: "int"
+              - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "aaaaaaaa"
+      - kind: "nkEmpty"
+      - kind: "nkGenericParams"
+        sons:
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "T"
+              - kind: "nkIdent"
+                ident: "Aaaa"
+              - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "v"
+              - kind: "nkIdent"
+                ident: "int"
+              - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "aaaaaaaa"
+      - kind: "nkEmpty"
+      - kind: "nkGenericParams"
+        sons:
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "Tttttttttttttttttttttttttttttttttttttttttt"
+              - kind: "nkIdent"
+                ident: "Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+              - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "v"
+              - kind: "nkIdent"
+                ident: "int"
+              - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "aaaaaaaa"
+      - kind: "nkEmpty"
+      - kind: "nkGenericParams"
+        sons:
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "T"
+              - kind: "nkIdent"
+                ident: "Aaaa"
+              - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "S"
+              - kind: "nkCommand"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "static"
+                  - kind: "nkIdent"
+                    ident: "int"
+              - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "v"
+              - kind: "nkIdent"
+                ident: "int"
+              - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "aaaaaaaa"
+      - kind: "nkEmpty"
+      - kind: "nkGenericParams"
+        sons:
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "T"
+              - kind: "nkInfix"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "|"
+                  - kind: "nkInfix"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "|"
+                      - kind: "nkIdent"
+                        ident: "Aaaaaaaaaaaaaaaaaaaaaaaa"
+                      - kind: "nkIdent"
+                        ident: "Bbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                  - kind: "nkIdent"
+                    ident: "Cccccccccccccccccccccccccc"
+              - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "v"
+              - kind: "nkIdent"
+                ident: "int"
+              - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "aaaaaaaaaaa"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "v"
+              - kind: "nkInfix"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "|"
+                  - kind: "nkInfix"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "|"
+                      - kind: "nkIdent"
+                        ident: "Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                      - kind: "nkIdent"
+                        ident: "Bbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                  - kind: "nkIdent"
+                    ident: "Cccccccccccccccccccccccccc"
+              - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+  - kind: "nkCommand"
+    sons:
+      - kind: "nkIdent"
+        ident: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: "+"
+          - kind: "nkInfix"
+            sons:
+              - kind: "nkIdent"
+                ident: "+"
+              - kind: "nkIntLit"
+                intVal: 42
+              - kind: "nkIntLit"
+                intVal: 33
+          - kind: "nkIntLit"
+            intVal: 44
+  - kind: "nkCall"
+    sons:
+      - kind: "nkIdent"
+        ident: "functionCall"
+      - kind: "nkIdent"
+        ident: "aaaaaaaaaaaaaaaaaaaaaa"
+      - kind: "nkIdent"
+        ident: "aaaaaaaaaaaaaaaaaa"
+      - kind: "nkIdent"
+        ident: "aaaaaaaaaaaaaaaaaaa"
+      - kind: "nkIdent"
+        ident: "aaaaaaaaaaaaaaaaaaaaaaa"
+      - kind: "nkIdent"
+        ident: "aaaaaaaaaaaaa"
+  - kind: "nkCall"
+    sons:
+      - kind: "nkIdent"
+        ident: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      - kind: "nkIdent"
+        ident: "aaaaaaaaaaaaaaa"
+      - kind: "nkIdent"
+        ident: "aaaaaaaaaaaaaaaaaaa"
+      - kind: "nkIdent"
+        ident: "aaaaaaaaaaaaaaaaa"
+      - kind: "nkIdent"
+        ident: "aaaaaaaaaaaaaaaaaaaaa"
+  - kind: "nkCall"
+    sons:
+      - kind: "nkIdent"
+        ident: "aasdcsaa"
+      - kind: "nkExprEqExpr"
+        sons:
+          - kind: "nkIdent"
+            ident: "aaaaaaaaaa"
+          - kind: "nkIdent"
+            ident: "bbbbbbbbbbb"
+      - kind: "nkExprEqExpr"
+        sons:
+          - kind: "nkIdent"
+            ident: "ccccccccccc"
+          - kind: "nkIdent"
+            ident: "ddddddddddddd"
+      - kind: "nkExprEqExpr"
+        sons:
+          - kind: "nkIdent"
+            ident: "eeeeeeeeeeee"
+          - kind: "nkIdent"
+            ident: "ffffffffffff"
+      - kind: "nkIdent"
+        ident: "gggggg"
+      - kind: "nkIdent"
+        ident: "hhhhhhhh"
+  - kind: "nkTypeSection"
+    sons:
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkIdent"
+            ident: "Ap"
+          - kind: "nkEmpty"
+          - kind: "nkProcTy"
+            sons:
+              - kind: "nkFormalParams"
+                sons:
+                  - kind: "nkEmpty"
+              - kind: "nkEmpty"
+  - kind: "nkTypeSection"
+    sons:
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkIdent"
+            ident: "Bp"
+          - kind: "nkEmpty"
+          - kind: "nkProcTy"
+  - kind: "nkTypeSection"
+    sons:
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkIdent"
+            ident: "Cp"
+          - kind: "nkEmpty"
+          - kind: "nkProcTy"
+            sons:
+              - kind: "nkFormalParams"
+                sons:
+                  - kind: "nkEmpty"
+                  - kind: "nkIdentDefs"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "v"
+                      - kind: "nkIdent"
+                        ident: "int"
+                      - kind: "nkEmpty"
+              - kind: "nkEmpty"
+  - kind: "nkTypeSection"
+    sons:
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkIdent"
+            ident: "Dp"
+          - kind: "nkEmpty"
+          - kind: "nkProcTy"
+            sons:
+              - kind: "nkFormalParams"
+                sons:
+                  - kind: "nkEmpty"
+              - kind: "nkPragma"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "nimcall"
+  - kind: "nkTypeSection"
+    sons:
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkIdent"
+            ident: "Ep"
+          - kind: "nkEmpty"
+          - kind: "nkProcTy"
+            sons:
+              - kind: "nkEmpty"
+              - kind: "nkPragma"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "nimcall"
+  - kind: "nkTypeSection"
+    sons:
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkIdent"
+            ident: "Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+          - kind: "nkEmpty"
+          - kind: "nkProcTy"
+            sons:
+              - kind: "nkEmpty"
+              - kind: "nkPragma"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "bbbbbbbbbbbbbbbbbbbbbbbb"
+  - kind: "nkTypeSection"
+    sons:
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkIdent"
+            ident: "Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+          - kind: "nkEmpty"
+          - kind: "nkProcTy"
+            sons:
+              - kind: "nkFormalParams"
+                sons:
+                  - kind: "nkEmpty"
+                  - kind: "nkIdentDefs"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "aaaaaaaa"
+                      - kind: "nkIdent"
+                        ident: "Bbbbbbb"
+                      - kind: "nkEmpty"
+                  - kind: "nkIdentDefs"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "ccccccccc"
+                      - kind: "nkIdent"
+                        ident: "Dddddddddddd"
+                      - kind: "nkEmpty"
+                  - kind: "nkIdentDefs"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "eeeeee"
+                      - kind: "nkIdent"
+                        ident: "Ffffff"
+                      - kind: "nkEmpty"
+              - kind: "nkEmpty"
+  - kind: "nkTypeSection"
+    sons:
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkIdent"
+            ident: "Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+          - kind: "nkEmpty"
+          - kind: "nkProcTy"
+            sons:
+              - kind: "nkFormalParams"
+                sons:
+                  - kind: "nkEmpty"
+                  - kind: "nkIdentDefs"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "aaaaaaaa"
+                      - kind: "nkIdent"
+                        ident: "Bbbbbbb"
+                      - kind: "nkEmpty"
+                  - kind: "nkIdentDefs"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "ccccccccc"
+                      - kind: "nkIdent"
+                        ident: "Dddddddddddd"
+                      - kind: "nkEmpty"
+                  - kind: "nkIdentDefs"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "eeeeeeeeeeeee"
+                      - kind: "nkIdent"
+                        ident: "Ffffffffffffffff"
+                      - kind: "nkEmpty"
+                  - kind: "nkIdentDefs"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "gggggggggggggg"
+                      - kind: "nkIdent"
+                        ident: "Hhhhhhhhhhhhhhhhhhhh"
+                      - kind: "nkEmpty"
+              - kind: "nkEmpty"

--- a/tests/after/types.nim
+++ b/tests/after/types.nim
@@ -6,13 +6,15 @@ type Bbbbbbbbbbbbbbbbbbbbbbbbbbbbb =
   Aaaaaaaaaaaaaa | Bbbbbbbbbbbbbbbbb | Cccccccccccccccccccccc | Dddddddddddddddddddddd
 
 type A[
-  T: Aaaaaaaaaaaaaaaaaaa | Bbbbbbbbbbbbbbbbbbbbbbbb | Cccccccccccccccccccc |
-    Dddddddddddddddd | Eeeeeeeeeeeeeeeeeee
+  T:
+    Aaaaaaaaaaaaaaaaaaa | Bbbbbbbbbbbbbbbbbbbbbbbb | Cccccccccccccccccccc |
+      Dddddddddddddddd | Eeeeeeeeeeeeeeeeeee
 ] = Bbbbbbbbbbbbbbbbbb[T]
 
 proc f(
-  a: Aaaaaaaaaaaaaaaaaaaaaaa | Bbbbbbbbbbbbbbbbbbbbbb | Ccccccccccccccccccccccccccc |
-    Ddddddddddddddddddddddddd | Eeeeeeeeeeeeeeeee;
+  a:
+    Aaaaaaaaaaaaaaaaaaaaaaa | Bbbbbbbbbbbbbbbbbbbbbb | Ccccccccccccccccccccccccccc |
+      Ddddddddddddddddddddddddd | Eeeeeeeeeeeeeeeee;
 )
 
 type CaseObject = object

--- a/tests/after/types.nim.nph.yaml
+++ b/tests/after/types.nim.nph.yaml
@@ -1,434 +1,189 @@
-{
-  "kind": "nkStmtList",
-  "sons": [
-    {
-      "kind": "nkTypeSection",
-      "sons": [
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "A"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "int"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkTypeSection",
-      "sons": [
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "B"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkInfix",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "|"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "A"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "B"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkTypeSection",
-      "sons": [
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "Bbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkInfix",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "|"
-                },
-                {
-                  "kind": "nkInfix",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "|"
-                    },
-                    {
-                      "kind": "nkInfix",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "|"
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "Aaaaaaaaaaaaaa"
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "Bbbbbbbbbbbbbbbbb"
-                        }
-                      ]
-                    },
-                    {
-                      "kind": "nkIdent",
-                      "ident": "Cccccccccccccccccccccc"
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "Dddddddddddddddddddddd"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkTypeSection",
-      "sons": [
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "A"
-            },
-            {
-              "kind": "nkGenericParams",
-              "sons": [
-                {
-                  "kind": "nkIdentDefs",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "T"
-                    },
-                    {
-                      "kind": "nkInfix",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "|"
-                        },
-                        {
-                          "kind": "nkInfix",
-                          "sons": [
-                            {
-                              "kind": "nkIdent",
-                              "ident": "|"
-                            },
-                            {
-                              "kind": "nkInfix",
-                              "sons": [
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "|"
-                                },
-                                {
-                                  "kind": "nkInfix",
-                                  "sons": [
-                                    {
-                                      "kind": "nkIdent",
-                                      "ident": "|"
-                                    },
-                                    {
-                                      "kind": "nkIdent",
-                                      "ident": "Aaaaaaaaaaaaaaaaaaa"
-                                    },
-                                    {
-                                      "kind": "nkIdent",
-                                      "ident": "Bbbbbbbbbbbbbbbbbbbbbbbb"
-                                    }
-                                  ]
-                                },
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "Cccccccccccccccccccc"
-                                }
-                              ]
-                            },
-                            {
-                              "kind": "nkIdent",
-                              "ident": "Dddddddddddddddd"
-                            }
-                          ]
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "Eeeeeeeeeeeeeeeeeee"
-                        }
-                      ]
-                    },
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "kind": "nkBracketExpr",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "Bbbbbbbbbbbbbbbbbb"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "T"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "f"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "a"
-                },
-                {
-                  "kind": "nkInfix",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "|"
-                    },
-                    {
-                      "kind": "nkInfix",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "|"
-                        },
-                        {
-                          "kind": "nkInfix",
-                          "sons": [
-                            {
-                              "kind": "nkIdent",
-                              "ident": "|"
-                            },
-                            {
-                              "kind": "nkInfix",
-                              "sons": [
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "|"
-                                },
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "Aaaaaaaaaaaaaaaaaaaaaaa"
-                                },
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "Bbbbbbbbbbbbbbbbbbbbbb"
-                                }
-                              ]
-                            },
-                            {
-                              "kind": "nkIdent",
-                              "ident": "Ccccccccccccccccccccccccccc"
-                            }
-                          ]
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "Ddddddddddddddddddddddddd"
-                        }
-                      ]
-                    },
-                    {
-                      "kind": "nkIdent",
-                      "ident": "Eeeeeeeeeeeeeeeee"
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        }
-      ]
-    },
-    {
-      "kind": "nkTypeSection",
-      "sons": [
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "CaseObject"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkObjectTy",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkRecList",
-                  "sons": [
-                    {
-                      "kind": "nkRecCase",
-                      "sons": [
-                        {
-                          "kind": "nkIdentDefs",
-                          "sons": [
-                            {
-                              "kind": "nkIdent",
-                              "ident": "f"
-                            },
-                            {
-                              "kind": "nkIdent",
-                              "ident": "bool"
-                            },
-                            {
-                              "kind": "nkEmpty"
-                            }
-                          ]
-                        },
-                        {
-                          "kind": "nkOfBranch",
-                          "sons": [
-                            {
-                              "kind": "nkIdent",
-                              "ident": "false"
-                            },
-                            {
-                              "kind": "nkRecList",
-                              "sons": [
-                                {
-                                  "kind": "nkIdentDefs",
-                                  "sons": [
-                                    {
-                                      "kind": "nkIdent",
-                                      "ident": "vfalse"
-                                    },
-                                    {
-                                      "kind": "nkIdent",
-                                      "ident": "int"
-                                    },
-                                    {
-                                      "kind": "nkEmpty"
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        },
-                        {
-                          "kind": "nkOfBranch",
-                          "sons": [
-                            {
-                              "kind": "nkIdent",
-                              "ident": "true"
-                            },
-                            {
-                              "kind": "nkRecList",
-                              "sons": [
-                                {
-                                  "kind": "nkIdentDefs",
-                                  "sons": [
-                                    {
-                                      "kind": "nkIdent",
-                                      "ident": "vtrue"
-                                    },
-                                    {
-                                      "kind": "nkIdent",
-                                      "ident": "int"
-                                    },
-                                    {
-                                      "kind": "nkEmpty"
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
-  ]
-}
+kind: "nkStmtList"
+sons:
+  - kind: "nkTypeSection"
+    sons:
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkIdent"
+            ident: "A"
+          - kind: "nkEmpty"
+          - kind: "nkIdent"
+            ident: "int"
+  - kind: "nkTypeSection"
+    sons:
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkIdent"
+            ident: "B"
+          - kind: "nkEmpty"
+          - kind: "nkInfix"
+            sons:
+              - kind: "nkIdent"
+                ident: "|"
+              - kind: "nkIdent"
+                ident: "A"
+              - kind: "nkIdent"
+                ident: "B"
+  - kind: "nkTypeSection"
+    sons:
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkIdent"
+            ident: "Bbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+          - kind: "nkEmpty"
+          - kind: "nkInfix"
+            sons:
+              - kind: "nkIdent"
+                ident: "|"
+              - kind: "nkInfix"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "|"
+                  - kind: "nkInfix"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "|"
+                      - kind: "nkIdent"
+                        ident: "Aaaaaaaaaaaaaa"
+                      - kind: "nkIdent"
+                        ident: "Bbbbbbbbbbbbbbbbb"
+                  - kind: "nkIdent"
+                    ident: "Cccccccccccccccccccccc"
+              - kind: "nkIdent"
+                ident: "Dddddddddddddddddddddd"
+  - kind: "nkTypeSection"
+    sons:
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkIdent"
+            ident: "A"
+          - kind: "nkGenericParams"
+            sons:
+              - kind: "nkIdentDefs"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "T"
+                  - kind: "nkInfix"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "|"
+                      - kind: "nkInfix"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "|"
+                          - kind: "nkInfix"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: "|"
+                              - kind: "nkInfix"
+                                sons:
+                                  - kind: "nkIdent"
+                                    ident: "|"
+                                  - kind: "nkIdent"
+                                    ident: "Aaaaaaaaaaaaaaaaaaa"
+                                  - kind: "nkIdent"
+                                    ident: "Bbbbbbbbbbbbbbbbbbbbbbbb"
+                              - kind: "nkIdent"
+                                ident: "Cccccccccccccccccccc"
+                          - kind: "nkIdent"
+                            ident: "Dddddddddddddddd"
+                      - kind: "nkIdent"
+                        ident: "Eeeeeeeeeeeeeeeeeee"
+                  - kind: "nkEmpty"
+          - kind: "nkBracketExpr"
+            sons:
+              - kind: "nkIdent"
+                ident: "Bbbbbbbbbbbbbbbbbb"
+              - kind: "nkIdent"
+                ident: "T"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "f"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "a"
+              - kind: "nkInfix"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "|"
+                  - kind: "nkInfix"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "|"
+                      - kind: "nkInfix"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "|"
+                          - kind: "nkInfix"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: "|"
+                              - kind: "nkIdent"
+                                ident: "Aaaaaaaaaaaaaaaaaaaaaaa"
+                              - kind: "nkIdent"
+                                ident: "Bbbbbbbbbbbbbbbbbbbbbb"
+                          - kind: "nkIdent"
+                            ident: "Ccccccccccccccccccccccccccc"
+                      - kind: "nkIdent"
+                        ident: "Ddddddddddddddddddddddddd"
+                  - kind: "nkIdent"
+                    ident: "Eeeeeeeeeeeeeeeee"
+              - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+  - kind: "nkTypeSection"
+    sons:
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkIdent"
+            ident: "CaseObject"
+          - kind: "nkEmpty"
+          - kind: "nkObjectTy"
+            sons:
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkRecList"
+                sons:
+                  - kind: "nkRecCase"
+                    sons:
+                      - kind: "nkIdentDefs"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "f"
+                          - kind: "nkIdent"
+                            ident: "bool"
+                          - kind: "nkEmpty"
+                      - kind: "nkOfBranch"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "false"
+                          - kind: "nkRecList"
+                            sons:
+                              - kind: "nkIdentDefs"
+                                sons:
+                                  - kind: "nkIdent"
+                                    ident: "vfalse"
+                                  - kind: "nkIdent"
+                                    ident: "int"
+                                  - kind: "nkEmpty"
+                      - kind: "nkOfBranch"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "true"
+                          - kind: "nkRecList"
+                            sons:
+                              - kind: "nkIdentDefs"
+                                sons:
+                                  - kind: "nkIdent"
+                                    ident: "vtrue"
+                                  - kind: "nkIdent"
+                                    ident: "int"
+                                  - kind: "nkEmpty"

--- a/tests/before/comments.nim
+++ b/tests/before/comments.nim
@@ -62,6 +62,7 @@ type
     field: int # Field comment
     # comment between fields
     field2: int ## Field comment again
+    fiiiiiiiiiiiiiiiiiiiiiiiieeeeeeeeeld: int # loooooooooooooooooooong comment past the max line length
   # and here
 
   Inherited = object of RootObj # inherited eol comment
@@ -296,3 +297,10 @@ proc f: bool =
       (true or false)
     else:
       false
+
+
+command "a", "b", "c" # command eol comment
+
+command "first arg", # first arg comment
+  "second arg", # second arg comment
+  "third arg" # third arg comment

--- a/tests/before/comments.nim.nph.yaml
+++ b/tests/before/comments.nim.nph.yaml
@@ -1,2491 +1,1184 @@
-{
-  "kind": "nkStmtList",
-  "sons": [
-    {
-      "kind": "nkCommentStmt",
-      "comment": "#"
-    },
-    {
-      "kind": "nkCommentStmt",
-      "comment": "#"
-    },
-    {
-      "kind": "nkCommentStmt",
-      "comment": "# Some commentary"
-    },
-    {
-      "kind": "nkCommentStmt",
-      "comment": "## A doc comment"
-    },
-    {
-      "kind": "nkCommentStmt",
-      "comment": "##"
-    },
-    {
-      "kind": "nkCommentStmt",
-      "comment": "##"
-    },
-    {
-      "kind": "nkCommentStmt",
-      "comment": "## More doc comments"
-    },
-    {
-      "kind": "nkCommentStmt",
-      "comment": "##"
-    },
-    {
-      "kind": "nkCommentStmt",
-      "comment": "#"
-    },
-    {
-      "kind": "nkCommentStmt",
-      "comment": "# Comment"
-    },
-    {
-      "kind": "nkCommentStmt",
-      "comment": "#"
-    },
-    {
-      "kind": "nkCommentStmt",
-      "comment": "#[ a multiline comment\u000Athis is also part of it\u000Aand this\u000A]#"
-    },
-    {
-      "kind": "nkCommentStmt",
-      "comment": "##[\u000A  these also come in doc variants\u000A]##"
-    },
-    {
-      "kind": "nkCommentStmt",
-      "comment": "#[\u000A  #[\u000A    they can be nested\u000A  ]#\u000A]#"
-    },
-    {
-      "kind": "nkCommand",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "x"
-        },
-        {
-          "kind": "nkIntLit",
-          "intVal": 324
-        }
-      ]
-    },
-    {
-      "kind": "nkCommentStmt",
-      "comment": "# A comment after"
-    },
-    {
-      "kind": "nkTemplateDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "x"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkStmtList",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## A template doc comment\", line: 37, col: 2, offsetA: 274, offsetB: 299)"
-          ],
-          "sons": [
-            {
-              "kind": "nkTryStmt",
-              "sons": [
-                {
-                  "kind": "nkStmtList",
-                  "sons": [
-                    {
-                      "kind": "nkDiscardStmt",
-                      "sons": [
-                        {
-                          "kind": "nkEmpty"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkExceptBranch",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "Exception"
-                    },
-                    {
-                      "kind": "nkStmtList",
-                      "sons": [
-                        {
-                          "kind": "nkMixinStmt",
-                          "sons": [
-                            {
-                              "kind": "nkAccQuoted",
-                              "sons": [
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "$"
-                                }
-                              ]
-                            }
-                          ]
-                        },
-                        {
-                          "kind": "nkCommand",
-                          "sons": [
-                            {
-                              "kind": "nkIdent",
-                              "ident": "echo"
-                            },
-                            {
-                              "kind": "nkIntLit",
-                              "intVal": 4
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkTypeSection",
-      "sons": [
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkPragmaExpr",
-              "sons": [
-                {
-                  "kind": "nkPostfix",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "*"
-                    },
-                    {
-                      "kind": "nkIdent",
-                      "ident": "SingleValueSetting"
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkPragma",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "pure"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkEnumTy",
-              "mid": [
-                "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## \\\\\", line: 45, col: 38, offsetA: 432, offsetB: 436)",
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 22, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## settings resulting in a single string value\", line: 46, col: 22, offsetA: 459, offsetB: 505)"
-              ],
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "arguments",
-                  "postfix": [
-                    "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## experimental: the arguments passed after \\\'-r\\\'\", line: 47, col: 22, offsetA: 528, offsetB: 576)"
-                  ]
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "backend",
-                  "postfix": [
-                    "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## the backend (eg: c|cpp|objc|js); both `nim doc --backend:js`\", line: 48, col: 22, offsetA: 599, offsetB: 662)",
-                    "(tokType: tkComment, base: base10, spacing: {}, indent: 22, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## and `nim js` would imply backend=js\", line: 49, col: 22, offsetA: 685, offsetB: 723)"
-                  ]
-                },
-                {
-                  "kind": "nkPragmaExpr",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "gc"
-                    },
-                    {
-                      "kind": "nkPragma",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "deprecated"
-                        }
-                      ]
-                    }
-                  ],
-                  "postfix": [
-                    "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## gc selected\", line: 50, col: 22, offsetA: 746, offsetB: 760)"
-                  ]
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "mm",
-                  "postfix": [
-                    "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## memory management selected\", line: 51, col: 22, offsetA: 783, offsetB: 812)"
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkPostfix",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "*"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "FileSeekPos"
-                }
-              ]
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkEnumTy",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "fspEnd",
-                  "postfix": [
-                    "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## Seek relative to end\", line: 54, col: 11, offsetA: 847, offsetB: 870)",
-                    "(tokType: tkComment, base: base10, spacing: {}, indent: 4, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# text file handling:\", line: 55, col: 4, offsetA: 875, offsetB: 896)"
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "Object"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkObjectTy",
-              "mid": [
-                "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# comment\", line: 60, col: 18, offsetA: 1075, offsetB: 1084)",
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 4, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## more comment\", line: 61, col: 4, offsetA: 1089, offsetB: 1104)"
-              ],
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkRecList",
-                  "sons": [
-                    {
-                      "kind": "nkIdentDefs",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "field"
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "int"
-                        },
-                        {
-                          "kind": "nkEmpty"
-                        }
-                      ],
-                      "postfix": [
-                        "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# Field comment\", line: 62, col: 15, offsetA: 1120, offsetB: 1135)"
-                      ]
-                    },
-                    {
-                      "kind": "nkIdentDefs",
-                      "prefix": [
-                        "(tokType: tkComment, base: base10, spacing: {}, indent: 4, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# comment between fields\", line: 63, col: 4, offsetA: 1140, offsetB: 1164)"
-                      ],
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "field2"
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "int"
-                        },
-                        {
-                          "kind": "nkEmpty"
-                        }
-                      ],
-                      "postfix": [
-                        "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## Field comment again\", line: 64, col: 16, offsetA: 1181, offsetB: 1203)"
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "Inherited"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkObjectTy",
-              "mid": [
-                "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# inherited eol comment\", line: 67, col: 32, offsetA: 1250, offsetB: 1273)",
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 32, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# inherited next line indent comments\", line: 68, col: 32, offsetA: 1306, offsetB: 1343)"
-              ],
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkOfInherit",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "RootObj"
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkRecList",
-                  "sons": [
-                    {
-                      "kind": "nkIdentDefs",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "f"
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "int"
-                        },
-                        {
-                          "kind": "nkEmpty"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "CaseObject"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkObjectTy",
-              "mid": [
-                "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# caseobj eol\", line: 71, col: 22, offsetA: 1378, offsetB: 1391)"
-              ],
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkRecList",
-                  "sons": [
-                    {
-                      "kind": "nkRecCase",
-                      "sons": [
-                        {
-                          "kind": "nkIdentDefs",
-                          "sons": [
-                            {
-                              "kind": "nkIdent",
-                              "ident": "k"
-                            },
-                            {
-                              "kind": "nkIdent",
-                              "ident": "bool"
-                            },
-                            {
-                              "kind": "nkEmpty"
-                            }
-                          ],
-                          "postfix": [
-                            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# casetype eol\", line: 72, col: 17, offsetA: 1409, offsetB: 1423)"
-                          ]
-                        },
-                        {
-                          "kind": "nkOfBranch",
-                          "mid": [
-                            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# of eol\", line: 73, col: 20, offsetA: 1444, offsetB: 1452)"
-                          ],
-                          "sons": [
-                            {
-                              "kind": "nkIdent",
-                              "ident": "true"
-                            },
-                            {
-                              "kind": "nkIdent",
-                              "ident": "false"
-                            },
-                            {
-                              "kind": "nkRecList",
-                              "sons": [
-                                {
-                                  "kind": "nkIdentDefs",
-                                  "sons": [
-                                    {
-                                      "kind": "nkIdent",
-                                      "ident": "v"
-                                    },
-                                    {
-                                      "kind": "nkIdent",
-                                      "ident": "string"
-                                    },
-                                    {
-                                      "kind": "nkEmpty"
-                                    }
-                                  ],
-                                  "postfix": [
-                                    "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# case field eol\", line: 74, col: 16, offsetA: 1469, offsetB: 1485)"
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkPostfix",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "*"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "SomeAlias"
-                }
-              ]
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "int",
-              "postfix": [
-                "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## alias eol\", line: 76, col: 19, offsetA: 1506, offsetB: 1518)",
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 4, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## alias next\", line: 77, col: 4, offsetA: 1523, offsetB: 1536)"
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkPragmaExpr",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "SomeAlias2"
-                },
-                {
-                  "kind": "nkPragma",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "nodecl"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIdent",
-              "prefix": [
-                "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# after pragma\", line: 79, col: 24, offsetA: 1562, offsetB: 1576)"
-              ],
-              "ident": "int",
-              "postfix": [
-                "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## alias2 eol\", line: 80, col: 10, offsetA: 1587, offsetB: 1600)"
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "SomeAlias3",
-              "postfix": [
-                "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# alias after symbol\", line: 82, col: 13, offsetA: 1615, offsetB: 1635)"
-              ]
-            },
-            {
-              "kind": "nkGenericParams",
-              "sons": [
-                {
-                  "kind": "nkIdentDefs",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "T"
-                    },
-                    {
-                      "kind": "nkEmpty"
-                    },
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "kind": "nkIdent",
-              "prefix": [
-                "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# alias after equals\", line: 83, col: 10, offsetA: 1646, offsetB: 1666)"
-              ],
-              "ident": "int",
-              "postfix": [
-                "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# alias after type\", line: 84, col: 8, offsetA: 1675, offsetB: 1693)"
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "SomeAlias4"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkBracketExpr",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "SomeAlias3"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "int"
-                }
-              ],
-              "postfix": [
-                "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## after alias4\", line: 86, col: 31, offsetA: 1726, offsetB: 1741)",
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 4, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## more after alias4\", line: 87, col: 4, offsetA: 1746, offsetB: 1766)"
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkTypeDef",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## Some comment before whenobj\", line: 89, col: 2, offsetA: 1770, offsetB: 1800)"
-          ],
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "WhenObject"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkObjectTy",
-              "mid": [
-                "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# whenobject object line\", line: 90, col: 22, offsetA: 1823, offsetB: 1847)"
-              ],
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkRecList",
-                  "sons": [
-                    {
-                      "kind": "nkRecWhen",
-                      "sons": [
-                        {
-                          "kind": "nkElifBranch",
-                          "mid": [
-                            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# when object false line\", line: 91, col: 16, offsetA: 1864, offsetB: 1888)"
-                          ],
-                          "sons": [
-                            {
-                              "kind": "nkIdent",
-                              "ident": "false"
-                            },
-                            {
-                              "kind": "nkRecList",
-                              "sons": [
-                                {
-                                  "kind": "nkNilLit"
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkPostfix",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "*"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "NoField0"
-                }
-              ]
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkObjectTy",
-              "mid": [
-                "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## comment eol\", line: 94, col: 32, offsetA: 1936, offsetB: 1950)",
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 32, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## comment nl\", line: 95, col: 32, offsetA: 1983, offsetB: 1996)"
-              ],
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkOfInherit",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "RootObj"
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkPostfix",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "*"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "NoField1"
-                }
-              ]
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkObjectTy",
-              "mid": [
-                "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## comment nofield1 eol\", line: 97, col: 32, offsetA: 2030, offsetB: 2053)",
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 32, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## comment nl\", line: 98, col: 32, offsetA: 2086, offsetB: 2099)"
-              ],
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkOfInherit",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "RootObj"
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkWhenStmt",
-      "sons": [
-        {
-          "kind": "nkElifBranch",
-          "mid": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# when colon line\", line: 101, col: 24, offsetA: 2126, offsetB: 2143)"
-          ],
-          "sons": [
-            {
-              "kind": "nkCall",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "defined"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "somecond"
-                }
-              ]
-            },
-            {
-              "kind": "nkStmtList",
-              "prefix": [
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# when first line\", line: 102, col: 2, offsetA: 2146, offsetB: 2163)"
-              ],
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkElse",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# comment\", line: 104, col: 0, offsetA: 2174, offsetB: 2183)"
-          ],
-          "mid": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# else colon line\", line: 105, col: 6, offsetA: 2190, offsetB: 2207)"
-          ],
-          "sons": [
-            {
-              "kind": "nkStmtList",
-              "prefix": [
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# else first line\", line: 106, col: 2, offsetA: 2210, offsetB: 2227)"
-              ],
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkIfStmt",
-      "sons": [
-        {
-          "kind": "nkElifBranch",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "true"
-            },
-            {
-              "kind": "nkStmtList",
-              "prefix": [
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# if next line\", line: 110, col: 2, offsetA: 2250, offsetB: 2264)"
-              ],
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkElse",
-          "sons": [
-            {
-              "kind": "nkStmtList",
-              "prefix": [
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# else next line\", line: 113, col: 2, offsetA: 2283, offsetB: 2299)"
-              ],
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkIfStmt",
-      "sons": [
-        {
-          "kind": "nkElifBranch",
-          "mid": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# if colon line\", line: 116, col: 9, offsetA: 2320, offsetB: 2335)"
-          ],
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "true"
-            },
-            {
-              "kind": "nkStmtList",
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkElse",
-          "mid": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# else colon line\", line: 118, col: 6, offsetA: 2352, offsetB: 2369)"
-          ],
-          "sons": [
-            {
-              "kind": "nkStmtList",
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkIfStmt",
-      "sons": [
-        {
-          "kind": "nkElifBranch",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "true"
-            },
-            {
-              "kind": "nkStmtList",
-              "prefix": [
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# if dedented colon line\", line: 122, col: 0, offsetA: 2390, offsetB: 2414)"
-              ],
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkElse",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# before else dedented\", line: 124, col: 0, offsetA: 2425, offsetB: 2447)"
-          ],
-          "mid": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# else colon line\", line: 125, col: 6, offsetA: 2454, offsetB: 2471)"
-          ],
-          "sons": [
-            {
-              "kind": "nkStmtList",
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "mid": [
-        "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# after proc before indented name\", line: 128, col: 5, offsetA: 2488, offsetB: 2521)"
-      ],
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "xxx"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkStmtList",
-          "sons": [
-            {
-              "kind": "nkDiscardStmt",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "mid": [
-        "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# proc eq line\", line: 131, col: 12, offsetA: 2551, offsetB: 2565)"
-      ],
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "xxxx"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkStmtList",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# proc first line\", line: 132, col: 2, offsetA: 2568, offsetB: 2585)"
-          ],
-          "sons": [
-            {
-              "kind": "nkDiscardStmt",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "x"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkStmtList",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## A proc doc comment\", line: 136, col: 2, offsetA: 2608, offsetB: 2629)"
-          ],
-          "sons": [
-            {
-              "kind": "nkIfStmt",
-              "sons": [
-                {
-                  "kind": "nkElifBranch",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "true"
-                    },
-                    {
-                      "kind": "nkStmtList",
-                      "sons": [
-                        {
-                          "kind": "nkInfix",
-                          "sons": [
-                            {
-                              "kind": "nkIdent",
-                              "ident": "-="
-                            },
-                            {
-                              "kind": "nkIdent",
-                              "ident": "numberOfCharsRead"
-                            },
-                            {
-                              "kind": "nkIntLit",
-                              "intVal": 2
-                            }
-                          ],
-                          "postfix": [
-                            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# handle Ctrl+Z as EOF\", line: 138, col: 27, offsetA: 2668, offsetB: 2690)"
-                          ]
-                        },
-                        {
-                          "kind": "nkForStmt",
-                          "sons": [
-                            {
-                              "kind": "nkIdent",
-                              "ident": "i"
-                            },
-                            {
-                              "kind": "nkInfix",
-                              "sons": [
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "..<"
-                                },
-                                {
-                                  "kind": "nkIntLit",
-                                  "intVal": 0
-                                },
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "numberOfCharsRead"
-                                }
-                              ]
-                            },
-                            {
-                              "kind": "nkStmtList",
-                              "sons": [
-                                {
-                                  "kind": "nkDiscardStmt",
-                                  "sons": [
-                                    {
-                                      "kind": "nkEmpty"
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "x"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkStmtList",
-          "sons": [
-            {
-              "kind": "nkDiscardStmt",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkImportStmt",
-      "prefix": [
-        "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## indented doc comment for proc\", line: 144, col: 2, offsetA: 2764, offsetB: 2796)",
-        "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## that is long\", line: 145, col: 2, offsetA: 2799, offsetB: 2814)",
-        "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# before module\", line: 147, col: 0, offsetA: 2816, offsetB: 2831)"
-      ],
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "module"
-        }
-      ]
-    },
-    {
-      "kind": "nkImportStmt",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "module"
-        }
-      ]
-    },
-    {
-      "kind": "nkTryStmt",
-      "mid": [
-        "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# try colon line\", line: 151, col: 5, offsetA: 2901, offsetB: 2917)"
-      ],
-      "sons": [
-        {
-          "kind": "nkStmtList",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# try first line\", line: 152, col: 2, offsetA: 2920, offsetB: 2936)"
-          ],
-          "sons": [
-            {
-              "kind": "nkDiscardStmt",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkExceptBranch",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# try last line\", line: 154, col: 2, offsetA: 2949, offsetB: 2964)"
-          ],
-          "mid": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# except colon line\", line: 155, col: 8, offsetA: 2973, offsetB: 2992)"
-          ],
-          "sons": [
-            {
-              "kind": "nkStmtList",
-              "prefix": [
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# except first line\", line: 156, col: 2, offsetA: 2995, offsetB: 3014)"
-              ],
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkFinally",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# except last line\", line: 158, col: 2, offsetA: 3027, offsetB: 3045)"
-          ],
-          "mid": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# Finally colon line\", line: 159, col: 9, offsetA: 3055, offsetB: 3075)"
-          ],
-          "sons": [
-            {
-              "kind": "nkStmtList",
-              "prefix": [
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# finally first line\", line: 160, col: 2, offsetA: 3078, offsetB: 3098)"
-              ],
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkTryStmt",
-      "prefix": [
-        "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# finally last line\", line: 162, col: 2, offsetA: 3111, offsetB: 3130)"
-      ],
-      "sons": [
-        {
-          "kind": "nkStmtList",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# try first dedent line\", line: 165, col: 0, offsetA: 3137, offsetB: 3160)"
-          ],
-          "sons": [
-            {
-              "kind": "nkCall",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "f"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkExceptBranch",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# try last dedent line\", line: 167, col: 0, offsetA: 3167, offsetB: 3189)"
-          ],
-          "sons": [
-            {
-              "kind": "nkStmtList",
-              "prefix": [
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# except dedent first line\", line: 169, col: 0, offsetA: 3198, offsetB: 3224)"
-              ],
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkFinally",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# except dedent last line\", line: 171, col: 0, offsetA: 3235, offsetB: 3260)"
-          ],
-          "sons": [
-            {
-              "kind": "nkStmtList",
-              "prefix": [
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# finally first dedent line\", line: 173, col: 0, offsetA: 3270, offsetB: 3297)"
-              ],
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkForStmt",
-      "prefix": [
-        "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# finally last dedent line\", line: 175, col: 0, offsetA: 3308, offsetB: 3334)"
-      ],
-      "mid": [
-        "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# for colon line\", line: 178, col: 15, offsetA: 3352, offsetB: 3368)"
-      ],
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "i"
-        },
-        {
-          "kind": "nkInfix",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": ".."
-            },
-            {
-              "kind": "nkIntLit",
-              "intVal": 0
-            },
-            {
-              "kind": "nkIntLit",
-              "intVal": 1
-            }
-          ]
-        },
-        {
-          "kind": "nkStmtList",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# for first line\", line: 179, col: 2, offsetA: 3371, offsetB: 3387)"
-          ],
-          "sons": [
-            {
-              "kind": "nkDiscardStmt",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkCaseStmt",
-      "mid": [
-        "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# case line\", line: 182, col: 7, offsetA: 3406, offsetB: 3417)"
-      ],
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "a"
-        },
-        {
-          "kind": "nkOfBranch",
-          "mid": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# of colon line\", line: 183, col: 9, offsetA: 3427, offsetB: 3442)"
-          ],
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "true"
-            },
-            {
-              "kind": "nkStmtList",
-              "prefix": [
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# of first line\", line: 184, col: 2, offsetA: 3445, offsetB: 3460)"
-              ],
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkElse",
-          "mid": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# case else colon line\", line: 186, col: 6, offsetA: 3477, offsetB: 3499)"
-          ],
-          "sons": [
-            {
-              "kind": "nkStmtList",
-              "prefix": [
-                "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# case else first line\", line: 187, col: 2, offsetA: 3502, offsetB: 3524)"
-              ],
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkCall",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "f"
-        },
-        {
-          "kind": "nkDo",
-          "mid": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# do colon line\", line: 190, col: 13, offsetA: 3549, offsetB: 3564)"
-          ],
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkFormalParams",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "int"
-                }
-              ]
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkStmtList",
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkBlockStmt",
-      "mid": [
-        "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# block colon line\", line: 195, col: 7, offsetA: 3611, offsetB: 3629)"
-      ],
-      "sons": [
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkStmtList",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# block first line\", line: 196, col: 2, offsetA: 3632, offsetB: 3650)"
-          ],
-          "sons": [
-            {
-              "kind": "nkDiscardStmt",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            },
-            {
-              "kind": "nkDiscardStmt",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkLetSection",
-      "sons": [
-        {
-          "kind": "nkIdentDefs",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "x"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkLambda",
-              "mid": [
-                "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# lambda eq line\", line: 200, col: 22, offsetA: 3694, offsetB: 3710)"
-              ],
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkFormalParams",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "int"
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkStmtList",
-                  "prefix": [
-                    "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# lambda first line\", line: 201, col: 2, offsetA: 3713, offsetB: 3732)"
-                  ],
-                  "sons": [
-                    {
-                      "kind": "nkDiscardStmt",
-                      "sons": [
-                        {
-                          "kind": "nkEmpty"
-                        }
-                      ]
-                    },
-                    {
-                      "kind": "nkDiscardStmt",
-                      "sons": [
-                        {
-                          "kind": "nkEmpty"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkWhileStmt",
-      "mid": [
-        "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# while colon line\", line: 204, col: 13, offsetA: 3766, offsetB: 3784)"
-      ],
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "false"
-        },
-        {
-          "kind": "nkStmtList",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# while first line\", line: 205, col: 2, offsetA: 3787, offsetB: 3805)"
-          ],
-          "sons": [
-            {
-              "kind": "nkDiscardStmt",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkStaticStmt",
-      "mid": [
-        "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# static colon line\", line: 208, col: 8, offsetA: 3825, offsetB: 3844)"
-      ],
-      "sons": [
-        {
-          "kind": "nkStmtList",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# static first line\", line: 209, col: 2, offsetA: 3847, offsetB: 3866)"
-          ],
-          "sons": [
-            {
-              "kind": "nkDiscardStmt",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkDiscardStmt",
-      "sons": [
-        {
-          "kind": "nkObjConstr",
-          "mid": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# object eol\", line: 212, col: 16, offsetA: 3894, offsetB: 3906)"
-          ],
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "Object"
-            },
-            {
-              "kind": "nkExprColonExpr",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "prefix": [
-                    "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# object first line\", line: 213, col: 2, offsetA: 3909, offsetB: 3928)"
-                  ],
-                  "ident": "field"
-                },
-                {
-                  "kind": "nkIntLit",
-                  "intVal": 0
-                }
-              ]
-            },
-            {
-              "kind": "nkExprColonExpr",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "field2"
-                },
-                {
-                  "kind": "nkIntLit",
-                  "intVal": 42
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkAsgn",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "a"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "b"
-        }
-      ]
-    },
-    {
-      "kind": "nkCommentStmt",
-      "comment": "## Doc comment after assignment"
-    },
-    {
-      "kind": "nkCommentStmt",
-      "comment": "## needs to be double"
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "ffff"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkStmtList",
-          "sons": [
-            {
-              "kind": "nkCall",
-              "sons": [
-                {
-                  "kind": "nkDotExpr",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "result"
-                    },
-                    {
-                      "kind": "nkIdent",
-                      "ident": "add"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkInfix",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "and"
-        },
-        {
-          "kind": "nkIdent",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## Doc comment after indented statement\", line: 227, col: 0, offsetA: 4110, offsetB: 4149)",
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## needs to be double\", line: 228, col: 0, offsetA: 4150, offsetB: 4171)"
-          ],
-          "ident": "abc"
-        },
-        {
-          "kind": "nkIdent",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# dedented comment in infix\", line: 231, col: 0, offsetA: 4181, offsetB: 4208)"
-          ],
-          "ident": "def"
-        }
-      ]
-    },
-    {
-      "kind": "nkInfix",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "and"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "abc"
-        },
-        {
-          "kind": "nkIdent",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# indented comment in infix\", line: 235, col: 2, offsetA: 4226, offsetB: 4253)"
-          ],
-          "ident": "def"
-        }
-      ]
-    },
-    {
-      "kind": "nkIfStmt",
-      "sons": [
-        {
-          "kind": "nkElifBranch",
-          "sons": [
-            {
-              "kind": "nkInfix",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "and"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "abc"
-                },
-                {
-                  "kind": "nkIdent",
-                  "prefix": [
-                    "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# dedented comment in infix\", line: 239, col: 0, offsetA: 4272, offsetB: 4299)"
-                  ],
-                  "ident": "def"
-                }
-              ]
-            },
-            {
-              "kind": "nkStmtList",
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkIfStmt",
-      "sons": [
-        {
-          "kind": "nkElifBranch",
-          "sons": [
-            {
-              "kind": "nkInfix",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "and"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "abc"
-                },
-                {
-                  "kind": "nkIdent",
-                  "prefix": [
-                    "(tokType: tkComment, base: base10, spacing: {}, indent: 3, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# indented comment in infix\", line: 243, col: 3, offsetA: 4331, offsetB: 4358)"
-                  ],
-                  "ident": "def"
-                }
-              ]
-            },
-            {
-              "kind": "nkStmtList",
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkCall",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "a"
-        },
-        {
-          "kind": "nkExprEqExpr",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "b"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "c"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkCall",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "a"
-        },
-        {
-          "kind": "nkExprEqExpr",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "b"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "c"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkPragma",
-      "prefix": [
-        "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# dedented comment after keyword parameter\", line: 252, col: 0, offsetA: 4435, offsetB: 4477)"
-      ],
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "pragma"
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "a"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "v"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "int"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "abc"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "int"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        }
-      ]
-    },
-    {
-      "kind": "nkLetSection",
-      "sons": [
-        {
-          "kind": "nkIdentDefs",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# let first line indented\", line: 261, col: 2, offsetA: 4551, offsetB: 4576)"
-          ],
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "v"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIntLit",
-              "intVal": 53
-            }
-          ],
-          "postfix": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# after v\", line: 262, col: 9, offsetA: 4586, offsetB: 4595)"
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkVarSection",
-      "sons": [
-        {
-          "kind": "nkIdentDefs",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# var first line indented\", line: 265, col: 2, offsetA: 4603, offsetB: 4628)"
-          ],
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "v"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIntLit",
-              "intVal": 53
-            }
-          ],
-          "postfix": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# after v\", line: 266, col: 9, offsetA: 4638, offsetB: 4647)"
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkDiscardStmt",
-      "sons": [
-        {
-          "kind": "nkIntLit",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# discard eol\", line: 268, col: 8, offsetA: 4657, offsetB: 4670)",
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# discard first line\", line: 269, col: 2, offsetA: 4673, offsetB: 4693)"
-          ],
-          "intVal": 54,
-          "postfix": [
-            "(tokType: tkComment, base: base10, spacing: {tsLeading}, indent: -1, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# discard value\", line: 270, col: 5, offsetA: 4699, offsetB: 4714)"
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkBlockStmt",
-      "sons": [
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkStmtList",
-          "sons": [
-            {
-              "kind": "nkCall",
-              "sons": [
-                {
-                  "kind": "nkDotExpr",
-                  "prefix": [
-                    "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# also after call\", line: 277, col: 2, offsetA: 4770, offsetB: 4787)"
-                  ],
-                  "sons": [
-                    {
-                      "kind": "nkCall",
-                      "sons": [
-                        {
-                          "kind": "nkDotExpr",
-                          "prefix": [
-                            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# comment between the dots\", line: 275, col: 2, offsetA: 4734, offsetB: 4760)"
-                          ],
-                          "sons": [
-                            {
-                              "kind": "nkDotExpr",
-                              "sons": [
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "f"
-                                },
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "x"
-                                }
-                              ]
-                            },
-                            {
-                              "kind": "nkIdent",
-                              "ident": "z"
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "kind": "nkIdent",
-                      "ident": "d"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "f"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "bool"
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkStmtList",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## Comment here\", line: 281, col: 2, offsetA: 4813, offsetB: 4828)",
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## another\", line: 282, col: 2, offsetA: 4831, offsetB: 4841)"
-          ],
-          "sons": [
-            {
-              "kind": "nkPar",
-              "sons": [
-                {
-                  "kind": "nkInfix",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "or"
-                    },
-                    {
-                      "kind": "nkIdent",
-                      "ident": "true"
-                    },
-                    {
-                      "kind": "nkIdent",
-                      "ident": "false"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "f"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "bool"
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkStmtList",
-          "prefix": [
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## Comment here\", line: 286, col: 2, offsetA: 4878, offsetB: 4893)",
-            "(tokType: tkComment, base: base10, spacing: {}, indent: 2, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## another\", line: 287, col: 2, offsetA: 4896, offsetB: 4906)"
-          ],
-          "sons": [
-            {
-              "kind": "nkIfStmt",
-              "sons": [
-                {
-                  "kind": "nkElifBranch",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "true"
-                    },
-                    {
-                      "kind": "nkStmtList",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "false"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkElse",
-                  "sons": [
-                    {
-                      "kind": "nkStmtList",
-                      "prefix": [
-                        "(tokType: tkComment, base: base10, spacing: {}, indent: 4, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## comment\", line: 291, col: 4, offsetA: 4940, offsetB: 4950)",
-                        "(tokType: tkComment, base: base10, spacing: {}, indent: 4, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## comment 2\", line: 292, col: 4, offsetA: 4955, offsetB: 4967)"
-                      ],
-                      "sons": [
-                        {
-                          "kind": "nkIfStmt",
-                          "sons": [
-                            {
-                              "kind": "nkElifBranch",
-                              "sons": [
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "true"
-                                },
-                                {
-                                  "kind": "nkStmtList",
-                                  "prefix": [
-                                    "(tokType: tkComment, base: base10, spacing: {}, indent: 6, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## comment\", line: 294, col: 6, offsetA: 4987, offsetB: 4997)",
-                                    "(tokType: tkComment, base: base10, spacing: {}, indent: 6, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"## comment 2\", line: 295, col: 6, offsetA: 5004, offsetB: 5016)"
-                                  ],
-                                  "sons": [
-                                    {
-                                      "kind": "nkPar",
-                                      "sons": [
-                                        {
-                                          "kind": "nkInfix",
-                                          "sons": [
-                                            {
-                                              "kind": "nkIdent",
-                                              "ident": "or"
-                                            },
-                                            {
-                                              "kind": "nkIdent",
-                                              "ident": "true"
-                                            },
-                                            {
-                                              "kind": "nkIdent",
-                                              "ident": "false"
-                                            }
-                                          ]
-                                        }
-                                      ]
-                                    }
-                                  ]
-                                }
-                              ]
-                            },
-                            {
-                              "kind": "nkElse",
-                              "sons": [
-                                {
-                                  "kind": "nkStmtList",
-                                  "sons": [
-                                    {
-                                      "kind": "nkIdent",
-                                      "ident": "false"
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
-  ]
-}
+kind: "nkStmtList"
+sons:
+  - kind: "nkCommentStmt"
+    "comment": "#"
+  - kind: "nkCommentStmt"
+    "comment": "#"
+  - kind: "nkCommentStmt"
+    "comment": "# Some commentary"
+  - kind: "nkCommentStmt"
+    "comment": "## A doc comment"
+  - kind: "nkCommentStmt"
+    "comment": "##"
+  - kind: "nkCommentStmt"
+    "comment": "##"
+  - kind: "nkCommentStmt"
+    "comment": "## More doc comments"
+  - kind: "nkCommentStmt"
+    "comment": "##"
+  - kind: "nkCommentStmt"
+    "comment": "#"
+  - kind: "nkCommentStmt"
+    "comment": "# Comment"
+  - kind: "nkCommentStmt"
+    "comment": "#"
+  - kind: "nkCommentStmt"
+    "comment": "#[ a multiline comment\u000Athis is also part of it\u000Aand this\u000A]#"
+  - kind: "nkCommentStmt"
+    "comment": "##[\u000A  these also come in doc variants\u000A]##"
+  - kind: "nkCommentStmt"
+    "comment": "#[\u000A  #[\u000A    they can be nested\u000A  ]#\u000A]#"
+  - kind: "nkCommand"
+    sons:
+      - kind: "nkIdent"
+        ident: "x"
+      - kind: "nkIntLit"
+        intVal: 324
+        postfix:
+          - "# A comment after"
+  - kind: "nkTemplateDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "x"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        prefix:
+          - "## A template doc comment"
+        sons:
+          - kind: "nkTryStmt"
+            sons:
+              - kind: "nkStmtList"
+                sons:
+                  - kind: "nkDiscardStmt"
+                    sons:
+                      - kind: "nkEmpty"
+              - kind: "nkExceptBranch"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "Exception"
+                  - kind: "nkStmtList"
+                    sons:
+                      - kind: "nkMixinStmt"
+                        sons:
+                          - kind: "nkAccQuoted"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: "$"
+                            postfix:
+                              - "# A comment after mixin"
+                      - kind: "nkCommand"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "echo"
+                          - kind: "nkIntLit"
+                            intVal: 4
+  - kind: "nkTypeSection"
+    sons:
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkPragmaExpr"
+            sons:
+              - kind: "nkPostfix"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "*"
+                  - kind: "nkIdent"
+                    ident: "SingleValueSetting"
+              - kind: "nkPragma"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "pure"
+          - kind: "nkEmpty"
+          - kind: "nkEnumTy"
+            mid:
+              - "## \\"
+              - "## settings resulting in a single string value"
+            sons:
+              - kind: "nkEmpty"
+              - kind: "nkIdent"
+                ident: "arguments"
+                postfix:
+                  - "## experimental: the arguments passed after \'-r\'"
+              - kind: "nkIdent"
+                ident: "backend"
+                postfix:
+                  - "## the backend (eg: c|cpp|objc|js); both `nim doc --backend:js`"
+                  - "## and `nim js` would imply backend=js"
+              - kind: "nkPragmaExpr"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "gc"
+                  - kind: "nkPragma"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "deprecated"
+                postfix:
+                  - "## gc selected"
+              - kind: "nkIdent"
+                ident: "mm"
+                postfix:
+                  - "## memory management selected"
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkPostfix"
+            sons:
+              - kind: "nkIdent"
+                ident: "*"
+              - kind: "nkIdent"
+                ident: "FileSeekPos"
+          - kind: "nkEmpty"
+          - kind: "nkEnumTy"
+            sons:
+              - kind: "nkEmpty"
+              - kind: "nkIdent"
+                ident: "fspEnd"
+                postfix:
+                  - "## Seek relative to end"
+                  - "# text file handling:"
+      - kind: "nkTypeDef"
+        prefix:
+          - "## Position relative to which seek should happen."
+          - "# The values are ordered so that they match with stdio"
+          - "# SEEK_SET, SEEK_CUR and SEEK_END respectively."
+        sons:
+          - kind: "nkIdent"
+            ident: "Object"
+          - kind: "nkEmpty"
+          - kind: "nkObjectTy"
+            mid:
+              - "# comment"
+              - "## more comment"
+            sons:
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkRecList"
+                sons:
+                  - kind: "nkIdentDefs"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "field"
+                      - kind: "nkIdent"
+                        ident: "int"
+                      - kind: "nkEmpty"
+                    postfix:
+                      - "# Field comment"
+                  - kind: "nkIdentDefs"
+                    prefix:
+                      - "# comment between fields"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "field2"
+                      - kind: "nkIdent"
+                        ident: "int"
+                      - kind: "nkEmpty"
+                    postfix:
+                      - "## Field comment again"
+                  - kind: "nkIdentDefs"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "fiiiiiiiiiiiiiiiiiiiiiiiieeeeeeeeeld"
+                      - kind: "nkIdent"
+                        ident: "int"
+                      - kind: "nkEmpty"
+                    postfix:
+                      - "# loooooooooooooooooooong comment past the max line length"
+      - kind: "nkTypeDef"
+        prefix:
+          - "# and here"
+        sons:
+          - kind: "nkIdent"
+            ident: "Inherited"
+          - kind: "nkEmpty"
+          - kind: "nkObjectTy"
+            mid:
+              - "# inherited eol comment"
+              - "# inherited next line indent comments"
+            sons:
+              - kind: "nkEmpty"
+              - kind: "nkOfInherit"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "RootObj"
+              - kind: "nkRecList"
+                sons:
+                  - kind: "nkIdentDefs"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "f"
+                      - kind: "nkIdent"
+                        ident: "int"
+                      - kind: "nkEmpty"
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkIdent"
+            ident: "CaseObject"
+          - kind: "nkEmpty"
+          - kind: "nkObjectTy"
+            mid:
+              - "# caseobj eol"
+            sons:
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkRecList"
+                sons:
+                  - kind: "nkRecCase"
+                    sons:
+                      - kind: "nkIdentDefs"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "k"
+                          - kind: "nkIdent"
+                            ident: "bool"
+                          - kind: "nkEmpty"
+                        postfix:
+                          - "# casetype eol"
+                      - kind: "nkOfBranch"
+                        mid:
+                          - "# of eol"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "true"
+                          - kind: "nkIdent"
+                            ident: "false"
+                          - kind: "nkRecList"
+                            sons:
+                              - kind: "nkIdentDefs"
+                                sons:
+                                  - kind: "nkIdent"
+                                    ident: "v"
+                                  - kind: "nkIdent"
+                                    ident: "string"
+                                  - kind: "nkEmpty"
+                                postfix:
+                                  - "# case field eol"
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkPostfix"
+            sons:
+              - kind: "nkIdent"
+                ident: "*"
+              - kind: "nkIdent"
+                ident: "SomeAlias"
+          - kind: "nkEmpty"
+          - kind: "nkIdent"
+            ident: "int"
+            postfix:
+              - "## alias eol"
+              - "## alias next"
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkPragmaExpr"
+            prefix:
+              - "# after pragma"
+            sons:
+              - kind: "nkIdent"
+                ident: "SomeAlias2"
+              - kind: "nkPragma"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "nodecl"
+          - kind: "nkEmpty"
+          - kind: "nkIdent"
+            ident: "int"
+            postfix:
+              - "## alias2 eol"
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkIdent"
+            ident: "SomeAlias3"
+            postfix:
+              - "# alias after symbol"
+          - kind: "nkGenericParams"
+            sons:
+              - kind: "nkIdentDefs"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "T"
+                  - kind: "nkEmpty"
+                  - kind: "nkEmpty"
+          - kind: "nkIdent"
+            prefix:
+              - "# alias after equals"
+            ident: "int"
+            postfix:
+              - "# alias after type"
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkIdent"
+            ident: "SomeAlias4"
+          - kind: "nkEmpty"
+          - kind: "nkBracketExpr"
+            sons:
+              - kind: "nkIdent"
+                ident: "SomeAlias3"
+              - kind: "nkIdent"
+                ident: "int"
+            postfix:
+              - "## after alias4"
+              - "## more after alias4"
+      - kind: "nkTypeDef"
+        prefix:
+          - "## Some comment before whenobj"
+        sons:
+          - kind: "nkIdent"
+            ident: "WhenObject"
+          - kind: "nkEmpty"
+          - kind: "nkObjectTy"
+            mid:
+              - "# whenobject object line"
+            sons:
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkRecList"
+                sons:
+                  - kind: "nkRecWhen"
+                    sons:
+                      - kind: "nkElifBranch"
+                        mid:
+                          - "# when object false line"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "false"
+                          - kind: "nkRecList"
+                            sons:
+                              - kind: "nkNilLit"
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkPostfix"
+            sons:
+              - kind: "nkIdent"
+                ident: "*"
+              - kind: "nkIdent"
+                ident: "NoField0"
+          - kind: "nkEmpty"
+          - kind: "nkObjectTy"
+            mid:
+              - "## comment eol"
+              - "## comment nl"
+            sons:
+              - kind: "nkEmpty"
+              - kind: "nkOfInherit"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "RootObj"
+              - kind: "nkEmpty"
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkPostfix"
+            sons:
+              - kind: "nkIdent"
+                ident: "*"
+              - kind: "nkIdent"
+                ident: "NoField1"
+          - kind: "nkEmpty"
+          - kind: "nkObjectTy"
+            mid:
+              - "## comment nofield1 eol"
+              - "## comment nl"
+            sons:
+              - kind: "nkEmpty"
+              - kind: "nkOfInherit"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "RootObj"
+              - kind: "nkEmpty"
+  - kind: "nkWhenStmt"
+    sons:
+      - kind: "nkElifBranch"
+        mid:
+          - "# when colon line"
+        sons:
+          - kind: "nkCall"
+            sons:
+              - kind: "nkIdent"
+                ident: "defined"
+              - kind: "nkIdent"
+                ident: "somecond"
+          - kind: "nkStmtList"
+            prefix:
+              - "# when first line"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+      - kind: "nkElse"
+        prefix:
+          - "# comment"
+        mid:
+          - "# else colon line"
+        sons:
+          - kind: "nkStmtList"
+            prefix:
+              - "# else first line"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+  - kind: "nkIfStmt"
+    sons:
+      - kind: "nkElifBranch"
+        sons:
+          - kind: "nkIdent"
+            ident: "true"
+          - kind: "nkStmtList"
+            prefix:
+              - "# if next line"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+      - kind: "nkElse"
+        sons:
+          - kind: "nkStmtList"
+            prefix:
+              - "# else next line"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+  - kind: "nkIfStmt"
+    sons:
+      - kind: "nkElifBranch"
+        mid:
+          - "# if colon line"
+        sons:
+          - kind: "nkIdent"
+            ident: "true"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+      - kind: "nkElse"
+        mid:
+          - "# else colon line"
+        sons:
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+  - kind: "nkIfStmt"
+    sons:
+      - kind: "nkElifBranch"
+        sons:
+          - kind: "nkIdent"
+            ident: "true"
+          - kind: "nkStmtList"
+            prefix:
+              - "# if dedented colon line"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+      - kind: "nkElse"
+        prefix:
+          - "# before else dedented"
+        mid:
+          - "# else colon line"
+        sons:
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    mid:
+      - "# after proc before indented name"
+    sons:
+      - kind: "nkIdent"
+        ident: "xxx"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    mid:
+      - "# proc eq line"
+    sons:
+      - kind: "nkIdent"
+        ident: "xxxx"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        prefix:
+          - "# proc first line"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "x"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        prefix:
+          - "## A proc doc comment"
+        sons:
+          - kind: "nkIfStmt"
+            sons:
+              - kind: "nkElifBranch"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "true"
+                  - kind: "nkStmtList"
+                    sons:
+                      - kind: "nkInfix"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "-="
+                          - kind: "nkIdent"
+                            ident: "numberOfCharsRead"
+                          - kind: "nkIntLit"
+                            intVal: 2
+                        postfix:
+                          - "# handle Ctrl+Z as EOF"
+                      - kind: "nkForStmt"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "i"
+                          - kind: "nkInfix"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: "..<"
+                              - kind: "nkIntLit"
+                                intVal: 0
+                              - kind: "nkIdent"
+                                ident: "numberOfCharsRead"
+                          - kind: "nkStmtList"
+                            sons:
+                              - kind: "nkDiscardStmt"
+                                sons:
+                                  - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "x"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+  - kind: "nkImportStmt"
+    prefix:
+      - "## indented doc comment for proc"
+      - "## that is long"
+      - "# before module"
+    sons:
+      - kind: "nkIdent"
+        ident: "module"
+        postfix:
+          - "# with a comment"
+  - kind: "nkImportStmt"
+    sons:
+      - kind: "nkIdent"
+        ident: "module"
+        postfix:
+          - "## with a comment"
+  - kind: "nkTryStmt"
+    mid:
+      - "# try colon line"
+    sons:
+      - kind: "nkStmtList"
+        prefix:
+          - "# try first line"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+          - kind: "nkCommentStmt"
+            "comment": "# try last line"
+      - kind: "nkExceptBranch"
+        mid:
+          - "# except colon line"
+        sons:
+          - kind: "nkStmtList"
+            prefix:
+              - "# except first line"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+              - kind: "nkCommentStmt"
+                "comment": "# except last line"
+      - kind: "nkFinally"
+        mid:
+          - "# Finally colon line"
+        sons:
+          - kind: "nkStmtList"
+            prefix:
+              - "# finally first line"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+              - kind: "nkCommentStmt"
+                "comment": "# finally last line"
+  - kind: "nkTryStmt"
+    sons:
+      - kind: "nkStmtList"
+        prefix:
+          - "# try first dedent line"
+        sons:
+          - kind: "nkCall"
+            sons:
+              - kind: "nkIdent"
+                ident: "f"
+      - kind: "nkExceptBranch"
+        prefix:
+          - "# try last dedent line"
+        sons:
+          - kind: "nkStmtList"
+            prefix:
+              - "# except dedent first line"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+      - kind: "nkFinally"
+        prefix:
+          - "# except dedent last line"
+        sons:
+          - kind: "nkStmtList"
+            prefix:
+              - "# finally first dedent line"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+  - kind: "nkForStmt"
+    prefix:
+      - "# finally last dedent line"
+    mid:
+      - "# for colon line"
+    sons:
+      - kind: "nkIdent"
+        ident: "i"
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: ".."
+          - kind: "nkIntLit"
+            intVal: 0
+          - kind: "nkIntLit"
+            intVal: 1
+      - kind: "nkStmtList"
+        prefix:
+          - "# for first line"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+  - kind: "nkCaseStmt"
+    mid:
+      - "# case line"
+    sons:
+      - kind: "nkIdent"
+        ident: "a"
+      - kind: "nkOfBranch"
+        mid:
+          - "# of colon line"
+        sons:
+          - kind: "nkIdent"
+            ident: "true"
+          - kind: "nkStmtList"
+            prefix:
+              - "# of first line"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+      - kind: "nkElse"
+        mid:
+          - "# case else colon line"
+        sons:
+          - kind: "nkStmtList"
+            prefix:
+              - "# case else first line"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+  - kind: "nkCall"
+    sons:
+      - kind: "nkIdent"
+        ident: "f"
+      - kind: "nkDo"
+        mid:
+          - "# do colon line"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkEmpty"
+          - kind: "nkEmpty"
+          - kind: "nkFormalParams"
+            sons:
+              - kind: "nkIdent"
+                ident: "int"
+          - kind: "nkEmpty"
+          - kind: "nkEmpty"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+  - kind: "nkBlockStmt"
+    mid:
+      - "# block colon line"
+    sons:
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        prefix:
+          - "# block first line"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+  - kind: "nkLetSection"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "x"
+          - kind: "nkEmpty"
+          - kind: "nkLambda"
+            mid:
+              - "# lambda eq line"
+            sons:
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkFormalParams"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "int"
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkStmtList"
+                prefix:
+                  - "# lambda first line"
+                sons:
+                  - kind: "nkDiscardStmt"
+                    sons:
+                      - kind: "nkEmpty"
+                  - kind: "nkDiscardStmt"
+                    sons:
+                      - kind: "nkEmpty"
+  - kind: "nkWhileStmt"
+    mid:
+      - "# while colon line"
+    sons:
+      - kind: "nkIdent"
+        ident: "false"
+      - kind: "nkStmtList"
+        prefix:
+          - "# while first line"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+  - kind: "nkStaticStmt"
+    mid:
+      - "# static colon line"
+    sons:
+      - kind: "nkStmtList"
+        prefix:
+          - "# static first line"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+  - kind: "nkDiscardStmt"
+    sons:
+      - kind: "nkObjConstr"
+        mid:
+          - "# object eol"
+        sons:
+          - kind: "nkIdent"
+            ident: "Object"
+          - kind: "nkExprColonExpr"
+            sons:
+              - kind: "nkIdent"
+                prefix:
+                  - "# object first line"
+                ident: "field"
+              - kind: "nkIntLit"
+                intVal: 0
+            postfix:
+              - "# field line"
+          - kind: "nkExprColonExpr"
+            sons:
+              - kind: "nkIdent"
+                ident: "field2"
+              - kind: "nkIntLit"
+                prefix:
+                  - "# Field colon next line"
+                intVal: 42
+            postfix:
+              - "# field colon line"
+  - kind: "nkAsgn"
+    sons:
+      - kind: "nkIdent"
+        ident: "a"
+      - kind: "nkIdent"
+        ident: "b"
+  - kind: "nkCommentStmt"
+    "comment": "## Doc comment after assignment"
+  - kind: "nkCommentStmt"
+    "comment": "## needs to be double"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "ffff"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkCall"
+            sons:
+              - kind: "nkDotExpr"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "result"
+                  - kind: "nkIdent"
+                    ident: "add"
+  - kind: "nkInfix"
+    sons:
+      - kind: "nkIdent"
+        ident: "and"
+      - kind: "nkIdent"
+        prefix:
+          - "## Doc comment after indented statement"
+          - "## needs to be double"
+        ident: "abc"
+      - kind: "nkIdent"
+        prefix:
+          - "# dedented comment in infix"
+        ident: "def"
+  - kind: "nkInfix"
+    sons:
+      - kind: "nkIdent"
+        ident: "and"
+      - kind: "nkIdent"
+        ident: "abc"
+      - kind: "nkIdent"
+        prefix:
+          - "# indented comment in infix"
+        ident: "def"
+  - kind: "nkIfStmt"
+    sons:
+      - kind: "nkElifBranch"
+        sons:
+          - kind: "nkInfix"
+            sons:
+              - kind: "nkIdent"
+                ident: "and"
+              - kind: "nkIdent"
+                ident: "abc"
+              - kind: "nkIdent"
+                prefix:
+                  - "# dedented comment in infix"
+                ident: "def"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+  - kind: "nkIfStmt"
+    sons:
+      - kind: "nkElifBranch"
+        sons:
+          - kind: "nkInfix"
+            sons:
+              - kind: "nkIdent"
+                ident: "and"
+              - kind: "nkIdent"
+                ident: "abc"
+              - kind: "nkIdent"
+                prefix:
+                  - "# indented comment in infix"
+                ident: "def"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+  - kind: "nkCall"
+    sons:
+      - kind: "nkIdent"
+        ident: "a"
+      - kind: "nkExprEqExpr"
+        sons:
+          - kind: "nkIdent"
+            ident: "b"
+          - kind: "nkIdent"
+            ident: "c"
+        postfix:
+          - "# comment after keyword parameter"
+  - kind: "nkCall"
+    sons:
+      - kind: "nkIdent"
+        ident: "a"
+      - kind: "nkExprEqExpr"
+        sons:
+          - kind: "nkIdent"
+            ident: "b"
+          - kind: "nkIdent"
+            ident: "c"
+  - kind: "nkPragma"
+    prefix:
+      - "# dedented comment after keyword parameter"
+    sons:
+      - kind: "nkIdent"
+        ident: "pragma"
+        postfix:
+          - "# comment here"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "a"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "v"
+                postfix:
+                  - "#[block]#"
+              - kind: "nkIdent"
+                ident: "int"
+              - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "abc"
+              - kind: "nkIdent"
+                ident: "int"
+              - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+  - kind: "nkLetSection"
+    sons:
+      - kind: "nkIdentDefs"
+        prefix:
+          - "# let first line indented"
+        sons:
+          - kind: "nkIdent"
+            ident: "v"
+          - kind: "nkEmpty"
+          - kind: "nkIntLit"
+            intVal: 53
+        postfix:
+          - "# after v"
+  - kind: "nkVarSection"
+    sons:
+      - kind: "nkIdentDefs"
+        prefix:
+          - "# var first line indented"
+        sons:
+          - kind: "nkIdent"
+            ident: "v"
+          - kind: "nkEmpty"
+          - kind: "nkIntLit"
+            intVal: 53
+        postfix:
+          - "# after v"
+  - kind: "nkDiscardStmt"
+    sons:
+      - kind: "nkIntLit"
+        prefix:
+          - "# discard eol"
+          - "# discard first line"
+        intVal: 54
+        postfix:
+          - "# discard value"
+  - kind: "nkBlockStmt"
+    sons:
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkCall"
+            sons:
+              - kind: "nkDotExpr"
+                prefix:
+                  - "# also after call"
+                sons:
+                  - kind: "nkCall"
+                    sons:
+                      - kind: "nkDotExpr"
+                        prefix:
+                          - "# comment between the dots"
+                        sons:
+                          - kind: "nkDotExpr"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: "f"
+                              - kind: "nkIdent"
+                                ident: "x"
+                          - kind: "nkIdent"
+                            ident: "z"
+                  - kind: "nkIdent"
+                    ident: "d"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "f"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkIdent"
+            ident: "bool"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        prefix:
+          - "## Comment here"
+          - "## another"
+        sons:
+          - kind: "nkPar"
+            sons:
+              - kind: "nkInfix"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "or"
+                  - kind: "nkIdent"
+                    ident: "true"
+                  - kind: "nkIdent"
+                    ident: "false"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "f"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkIdent"
+            ident: "bool"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        prefix:
+          - "## Comment here"
+          - "## another"
+        sons:
+          - kind: "nkIfStmt"
+            sons:
+              - kind: "nkElifBranch"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "true"
+                  - kind: "nkStmtList"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "false"
+              - kind: "nkElse"
+                sons:
+                  - kind: "nkStmtList"
+                    prefix:
+                      - "## comment"
+                      - "## comment 2"
+                    sons:
+                      - kind: "nkIfStmt"
+                        sons:
+                          - kind: "nkElifBranch"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: "true"
+                              - kind: "nkStmtList"
+                                prefix:
+                                  - "## comment"
+                                  - "## comment 2"
+                                sons:
+                                  - kind: "nkPar"
+                                    sons:
+                                      - kind: "nkInfix"
+                                        sons:
+                                          - kind: "nkIdent"
+                                            ident: "or"
+                                          - kind: "nkIdent"
+                                            ident: "true"
+                                          - kind: "nkIdent"
+                                            ident: "false"
+                          - kind: "nkElse"
+                            sons:
+                              - kind: "nkStmtList"
+                                sons:
+                                  - kind: "nkIdent"
+                                    ident: "false"
+  - kind: "nkCommand"
+    sons:
+      - kind: "nkIdent"
+        ident: "command"
+      - kind: "nkStrLit"
+        strVal: "a"
+      - kind: "nkStrLit"
+        strVal: "b"
+      - kind: "nkStrLit"
+        strVal: "c"
+        postfix:
+          - "# command eol comment"
+  - kind: "nkCommand"
+    sons:
+      - kind: "nkIdent"
+        ident: "command"
+      - kind: "nkStrLit"
+        strVal: "first arg"
+        postfix:
+          - "# first arg comment"
+      - kind: "nkStrLit"
+        strVal: "second arg"
+        postfix:
+          - "# second arg comment"
+      - kind: "nkStrLit"
+        strVal: "third arg"
+        postfix:
+          - "# third arg comment"

--- a/tests/before/empty.nim.nph.yaml
+++ b/tests/before/empty.nim.nph.yaml
@@ -1,3 +1,1 @@
-{
-  "kind": "nkStmtList"
-}
+kind: "nkStmtList"

--- a/tests/before/exprs.nim.nph.yaml
+++ b/tests/before/exprs.nim.nph.yaml
@@ -1,2304 +1,1038 @@
-{
-  "kind": "nkStmtList",
-  "sons": [
-    {
-      "kind": "nkVarSection",
-      "sons": [
-        {
-          "kind": "nkIdentDefs",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "c3"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkInfix",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "+"
-                },
-                {
-                  "kind": "nkBracketExpr",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "row"
-                    },
-                    {
-                      "kind": "nkIdent",
-                      "ident": "p"
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkStmtListExpr",
-                  "sons": [
-                    {
-                      "kind": "nkIfStmt",
-                      "sons": [
-                        {
-                          "kind": "nkElifExpr",
-                          "sons": [
-                            {
-                              "kind": "nkInfix",
-                              "sons": [
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "!="
-                                },
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "runeA"
-                                },
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "runeB"
-                                }
-                              ]
-                            },
-                            {
-                              "kind": "nkStmtList",
-                              "sons": [
-                                {
-                                  "kind": "nkIntLit",
-                                  "intVal": 1
-                                }
-                              ]
-                            }
-                          ]
-                        },
-                        {
-                          "kind": "nkElseExpr",
-                          "sons": [
-                            {
-                              "kind": "nkStmtList",
-                              "sons": [
-                                {
-                                  "kind": "nkIntLit",
-                                  "intVal": 0
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkVarSection",
-      "sons": [
-        {
-          "kind": "nkIdentDefs",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "c3"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkInfix",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "+"
-                },
-                {
-                  "kind": "nkBracketExpr",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "row"
-                    },
-                    {
-                      "kind": "nkIdent",
-                      "ident": "p"
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkStmtListExpr",
-                  "sons": [
-                    {
-                      "kind": "nkIfStmt",
-                      "sons": [
-                        {
-                          "kind": "nkElifExpr",
-                          "sons": [
-                            {
-                              "kind": "nkInfix",
-                              "sons": [
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "!="
-                                },
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "runeA"
-                                },
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "runeB"
-                                }
-                              ]
-                            },
-                            {
-                              "kind": "nkIntLit",
-                              "intVal": 1
-                            }
-                          ]
-                        },
-                        {
-                          "kind": "nkElseExpr",
-                          "sons": [
-                            {
-                              "kind": "nkIntLit",
-                              "intVal": 0
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkForStmt",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "a"
-        },
-        {
-          "kind": "nkInfix",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "..<"
-            },
-            {
-              "kind": "nkIntLit",
-              "intVal": 0
-            },
-            {
-              "kind": "nkIntLit",
-              "intVal": 1
-            }
-          ]
-        },
-        {
-          "kind": "nkStmtList",
-          "sons": [
-            {
-              "kind": "nkDiscardStmt",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkForStmt",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "a"
-        },
-        {
-          "kind": "nkInfix",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": ".."
-            },
-            {
-              "kind": "nkIntLit",
-              "intVal": 0
-            },
-            {
-              "kind": "nkIntLit",
-              "intVal": 1
-            }
-          ]
-        },
-        {
-          "kind": "nkStmtList",
-          "sons": [
-            {
-              "kind": "nkDiscardStmt",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkForStmt",
-      "prefix": [
-        "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# needs spaces\", line: 14, col: 0, offsetA: 163, offsetB: 177)"
-      ],
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "a"
-        },
-        {
-          "kind": "nkInfix",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": ".."
-            },
-            {
-              "kind": "nkPrefix",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "^"
-                },
-                {
-                  "kind": "nkIntLit",
-                  "intVal": 1
-                }
-              ]
-            },
-            {
-              "kind": "nkPrefix",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "^"
-                },
-                {
-                  "kind": "nkIntLit",
-                  "intVal": 2
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkStmtList",
-          "sons": [
-            {
-              "kind": "nkDiscardStmt",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkTemplateDef",
-      "sons": [
-        {
-          "kind": "nkPostfix",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "*"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "ttt"
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "untyped"
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkStmtList",
-          "sons": [
-            {
-              "kind": "nkBracketExpr",
-              "sons": [
-                {
-                  "kind": "nkStmtListExpr",
-                  "sons": [
-                    {
-                      "kind": "nkBlockStmt",
-                      "sons": [
-                        {
-                          "kind": "nkEmpty"
-                        },
-                        {
-                          "kind": "nkStmtList",
-                          "sons": [
-                            {
-                              "kind": "nkIdent",
-                              "ident": "xxx"
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkDiscardStmt",
-      "prefix": [
-        "(tokType: tkComment, base: base10, spacing: {}, indent: 0, ident: ..., iNumber: 0, fNumber: 0.0, literal: \"# command syntax with colon\", line: 23, col: 0, offsetA: 256, offsetB: 283)"
-      ],
-      "sons": [
-        {
-          "kind": "nkCommand",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "xxxx"
-            },
-            {
-              "kind": "nkStrLit",
-              "strVal": "arg"
-            },
-            {
-              "kind": "nkStmtList",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "yyy"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkCommand",
-      "sons": [
-        {
-          "kind": "nkDotExpr",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "res"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "add"
-            }
-          ]
-        },
-        {
-          "kind": "nkCall",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "fff"
-            },
-            {
-              "kind": "nkStmtList",
-              "sons": [
-                {
-                  "kind": "nkCall",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "yy"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkCommentStmt",
-      "comment": "# we don\'t what `do` in let but need it in the above commend - this needs"
-    },
-    {
-      "kind": "nkCommentStmt",
-      "comment": "# more investigation - this is important for templates calls like Result.valueOr"
-    },
-    {
-      "kind": "nkCommentStmt",
-      "comment": "# which become ugly otherwise"
-    },
-    {
-      "kind": "nkLetSection",
-      "sons": [
-        {
-          "kind": "nkIdentDefs",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "xxx"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkCall",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "implicitdo"
-                },
-                {
-                  "kind": "nkStmtList",
-                  "sons": [
-                    {
-                      "kind": "nkReturnStmt",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "xxx"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkLetSection",
-      "sons": [
-        {
-          "kind": "nkIdentDefs",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "shortInfix"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkInfix",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "+"
-                },
-                {
-                  "kind": "nkInfix",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "+"
-                    },
-                    {
-                      "kind": "nkInfix",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "*"
-                        },
-                        {
-                          "kind": "nkInfix",
-                          "sons": [
-                            {
-                              "kind": "nkIdent",
-                              "ident": "*"
-                            },
-                            {
-                              "kind": "nkIdent",
-                              "ident": "a"
-                            },
-                            {
-                              "kind": "nkIdent",
-                              "ident": "b"
-                            }
-                          ]
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "c"
-                        }
-                      ]
-                    },
-                    {
-                      "kind": "nkInfix",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "*"
-                        },
-                        {
-                          "kind": "nkInfix",
-                          "sons": [
-                            {
-                              "kind": "nkIdent",
-                              "ident": "*"
-                            },
-                            {
-                              "kind": "nkIdent",
-                              "ident": "d"
-                            },
-                            {
-                              "kind": "nkIdent",
-                              "ident": "e"
-                            }
-                          ]
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "f"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkInfix",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "*"
-                    },
-                    {
-                      "kind": "nkPar",
-                      "sons": [
-                        {
-                          "kind": "nkInfix",
-                          "sons": [
-                            {
-                              "kind": "nkIdent",
-                              "ident": "+"
-                            },
-                            {
-                              "kind": "nkIdent",
-                              "ident": "a"
-                            },
-                            {
-                              "kind": "nkIdent",
-                              "ident": "b"
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "kind": "nkIdent",
-                      "ident": "g"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkLetSection",
-      "sons": [
-        {
-          "kind": "nkIdentDefs",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "longInfix"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkPar",
-              "sons": [
-                {
-                  "kind": "nkInfix",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "+"
-                    },
-                    {
-                      "kind": "nkInfix",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "-"
-                        },
-                        {
-                          "kind": "nkInfix",
-                          "sons": [
-                            {
-                              "kind": "nkIdent",
-                              "ident": "-"
-                            },
-                            {
-                              "kind": "nkInfix",
-                              "sons": [
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "+"
-                                },
-                                {
-                                  "kind": "nkInfix",
-                                  "sons": [
-                                    {
-                                      "kind": "nkIdent",
-                                      "ident": "+"
-                                    },
-                                    {
-                                      "kind": "nkInfix",
-                                      "sons": [
-                                        {
-                                          "kind": "nkIdent",
-                                          "ident": "-"
-                                        },
-                                        {
-                                          "kind": "nkInfix",
-                                          "sons": [
-                                            {
-                                              "kind": "nkIdent",
-                                              "ident": "-"
-                                            },
-                                            {
-                                              "kind": "nkInfix",
-                                              "sons": [
-                                                {
-                                                  "kind": "nkIdent",
-                                                  "ident": "+"
-                                                },
-                                                {
-                                                  "kind": "nkInfix",
-                                                  "sons": [
-                                                    {
-                                                      "kind": "nkIdent",
-                                                      "ident": "+"
-                                                    },
-                                                    {
-                                                      "kind": "nkInfix",
-                                                      "sons": [
-                                                        {
-                                                          "kind": "nkIdent",
-                                                          "ident": "-"
-                                                        },
-                                                        {
-                                                          "kind": "nkInfix",
-                                                          "sons": [
-                                                            {
-                                                              "kind": "nkIdent",
-                                                              "ident": "-"
-                                                            },
-                                                            {
-                                                              "kind": "nkInfix",
-                                                              "sons": [
-                                                                {
-                                                                  "kind": "nkIdent",
-                                                                  "ident": "+"
-                                                                },
-                                                                {
-                                                                  "kind": "nkInfix",
-                                                                  "sons": [
-                                                                    {
-                                                                      "kind": "nkIdent",
-                                                                      "ident": "+"
-                                                                    },
-                                                                    {
-                                                                      "kind": "nkInfix",
-                                                                      "sons": [
-                                                                        {
-                                                                          "kind": "nkIdent",
-                                                                          "ident": "-"
-                                                                        },
-                                                                        {
-                                                                          "kind": "nkInfix",
-                                                                          "sons": [
-                                                                            {
-                                                                              "kind": "nkIdent",
-                                                                              "ident": "-"
-                                                                            },
-                                                                            {
-                                                                              "kind": "nkInfix",
-                                                                              "sons": [
-                                                                                {
-                                                                                  "kind": "nkIdent",
-                                                                                  "ident": "+"
-                                                                                },
-                                                                                {
-                                                                                  "kind": "nkInfix",
-                                                                                  "sons": [
-                                                                                    {
-                                                                                      "kind": "nkIdent",
-                                                                                      "ident": "+"
-                                                                                    },
-                                                                                    {
-                                                                                      "kind": "nkInfix",
-                                                                                      "sons": [
-                                                                                        {
-                                                                                          "kind": "nkIdent",
-                                                                                          "ident": "-"
-                                                                                        },
-                                                                                        {
-                                                                                          "kind": "nkInfix",
-                                                                                          "sons": [
-                                                                                            {
-                                                                                              "kind": "nkIdent",
-                                                                                              "ident": "-"
-                                                                                            },
-                                                                                            {
-                                                                                              "kind": "nkInfix",
-                                                                                              "sons": [
-                                                                                                {
-                                                                                                  "kind": "nkIdent",
-                                                                                                  "ident": "+"
-                                                                                                },
-                                                                                                {
-                                                                                                  "kind": "nkInfix",
-                                                                                                  "sons": [
-                                                                                                    {
-                                                                                                      "kind": "nkIdent",
-                                                                                                      "ident": "+"
-                                                                                                    },
-                                                                                                    {
-                                                                                                      "kind": "nkInfix",
-                                                                                                      "sons": [
-                                                                                                        {
-                                                                                                          "kind": "nkIdent",
-                                                                                                          "ident": "-"
-                                                                                                        },
-                                                                                                        {
-                                                                                                          "kind": "nkInfix",
-                                                                                                          "sons": [
-                                                                                                            {
-                                                                                                              "kind": "nkIdent",
-                                                                                                              "ident": "-"
-                                                                                                            },
-                                                                                                            {
-                                                                                                              "kind": "nkInfix",
-                                                                                                              "sons": [
-                                                                                                                {
-                                                                                                                  "kind": "nkIdent",
-                                                                                                                  "ident": "*"
-                                                                                                                },
-                                                                                                                {
-                                                                                                                  "kind": "nkInfix",
-                                                                                                                  "sons": [
-                                                                                                                    {
-                                                                                                                      "kind": "nkIdent",
-                                                                                                                      "ident": "*"
-                                                                                                                    },
-                                                                                                                    {
-                                                                                                                      "kind": "nkInfix",
-                                                                                                                      "sons": [
-                                                                                                                        {
-                                                                                                                          "kind": "nkIdent",
-                                                                                                                          "ident": "*"
-                                                                                                                        },
-                                                                                                                        {
-                                                                                                                          "kind": "nkIdent",
-                                                                                                                          "ident": "a30"
-                                                                                                                        },
-                                                                                                                        {
-                                                                                                                          "kind": "nkIdent",
-                                                                                                                          "ident": "a21"
-                                                                                                                        }
-                                                                                                                      ]
-                                                                                                                    },
-                                                                                                                    {
-                                                                                                                      "kind": "nkIdent",
-                                                                                                                      "ident": "a12"
-                                                                                                                    }
-                                                                                                                  ]
-                                                                                                                },
-                                                                                                                {
-                                                                                                                  "kind": "nkIdent",
-                                                                                                                  "ident": "a03"
-                                                                                                                }
-                                                                                                              ]
-                                                                                                            },
-                                                                                                            {
-                                                                                                              "kind": "nkInfix",
-                                                                                                              "sons": [
-                                                                                                                {
-                                                                                                                  "kind": "nkIdent",
-                                                                                                                  "ident": "*"
-                                                                                                                },
-                                                                                                                {
-                                                                                                                  "kind": "nkInfix",
-                                                                                                                  "sons": [
-                                                                                                                    {
-                                                                                                                      "kind": "nkIdent",
-                                                                                                                      "ident": "*"
-                                                                                                                    },
-                                                                                                                    {
-                                                                                                                      "kind": "nkInfix",
-                                                                                                                      "sons": [
-                                                                                                                        {
-                                                                                                                          "kind": "nkIdent",
-                                                                                                                          "ident": "*"
-                                                                                                                        },
-                                                                                                                        {
-                                                                                                                          "kind": "nkIdent",
-                                                                                                                          "ident": "a20"
-                                                                                                                        },
-                                                                                                                        {
-                                                                                                                          "kind": "nkIdent",
-                                                                                                                          "ident": "a31"
-                                                                                                                        }
-                                                                                                                      ]
-                                                                                                                    },
-                                                                                                                    {
-                                                                                                                      "kind": "nkIdent",
-                                                                                                                      "ident": "a12"
-                                                                                                                    }
-                                                                                                                  ]
-                                                                                                                },
-                                                                                                                {
-                                                                                                                  "kind": "nkIdent",
-                                                                                                                  "ident": "a03"
-                                                                                                                }
-                                                                                                              ]
-                                                                                                            }
-                                                                                                          ]
-                                                                                                        },
-                                                                                                        {
-                                                                                                          "kind": "nkInfix",
-                                                                                                          "sons": [
-                                                                                                            {
-                                                                                                              "kind": "nkIdent",
-                                                                                                              "ident": "*"
-                                                                                                            },
-                                                                                                            {
-                                                                                                              "kind": "nkInfix",
-                                                                                                              "sons": [
-                                                                                                                {
-                                                                                                                  "kind": "nkIdent",
-                                                                                                                  "ident": "*"
-                                                                                                                },
-                                                                                                                {
-                                                                                                                  "kind": "nkInfix",
-                                                                                                                  "sons": [
-                                                                                                                    {
-                                                                                                                      "kind": "nkIdent",
-                                                                                                                      "ident": "*"
-                                                                                                                    },
-                                                                                                                    {
-                                                                                                                      "kind": "nkIdent",
-                                                                                                                      "ident": "a30"
-                                                                                                                    },
-                                                                                                                    {
-                                                                                                                      "kind": "nkIdent",
-                                                                                                                      "ident": "a11"
-                                                                                                                    }
-                                                                                                                  ]
-                                                                                                                },
-                                                                                                                {
-                                                                                                                  "kind": "nkIdent",
-                                                                                                                  "ident": "a22"
-                                                                                                                }
-                                                                                                              ]
-                                                                                                            },
-                                                                                                            {
-                                                                                                              "kind": "nkIdent",
-                                                                                                              "ident": "a03"
-                                                                                                            }
-                                                                                                          ]
-                                                                                                        }
-                                                                                                      ]
-                                                                                                    },
-                                                                                                    {
-                                                                                                      "kind": "nkInfix",
-                                                                                                      "sons": [
-                                                                                                        {
-                                                                                                          "kind": "nkIdent",
-                                                                                                          "ident": "*"
-                                                                                                        },
-                                                                                                        {
-                                                                                                          "kind": "nkInfix",
-                                                                                                          "sons": [
-                                                                                                            {
-                                                                                                              "kind": "nkIdent",
-                                                                                                              "ident": "*"
-                                                                                                            },
-                                                                                                            {
-                                                                                                              "kind": "nkInfix",
-                                                                                                              "sons": [
-                                                                                                                {
-                                                                                                                  "kind": "nkIdent",
-                                                                                                                  "ident": "*"
-                                                                                                                },
-                                                                                                                {
-                                                                                                                  "kind": "nkIdent",
-                                                                                                                  "ident": "a10"
-                                                                                                                },
-                                                                                                                {
-                                                                                                                  "kind": "nkIdent",
-                                                                                                                  "ident": "a31"
-                                                                                                                }
-                                                                                                              ]
-                                                                                                            },
-                                                                                                            {
-                                                                                                              "kind": "nkIdent",
-                                                                                                              "ident": "a22"
-                                                                                                            }
-                                                                                                          ]
-                                                                                                        },
-                                                                                                        {
-                                                                                                          "kind": "nkIdent",
-                                                                                                          "ident": "a03"
-                                                                                                        }
-                                                                                                      ]
-                                                                                                    }
-                                                                                                  ]
-                                                                                                },
-                                                                                                {
-                                                                                                  "kind": "nkInfix",
-                                                                                                  "sons": [
-                                                                                                    {
-                                                                                                      "kind": "nkIdent",
-                                                                                                      "ident": "*"
-                                                                                                    },
-                                                                                                    {
-                                                                                                      "kind": "nkInfix",
-                                                                                                      "sons": [
-                                                                                                        {
-                                                                                                          "kind": "nkIdent",
-                                                                                                          "ident": "*"
-                                                                                                        },
-                                                                                                        {
-                                                                                                          "kind": "nkInfix",
-                                                                                                          "sons": [
-                                                                                                            {
-                                                                                                              "kind": "nkIdent",
-                                                                                                              "ident": "*"
-                                                                                                            },
-                                                                                                            {
-                                                                                                              "kind": "nkIdent",
-                                                                                                              "ident": "a20"
-                                                                                                            },
-                                                                                                            {
-                                                                                                              "kind": "nkIdent",
-                                                                                                              "ident": "a11"
-                                                                                                            }
-                                                                                                          ]
-                                                                                                        },
-                                                                                                        {
-                                                                                                          "kind": "nkIdent",
-                                                                                                          "ident": "a32"
-                                                                                                        }
-                                                                                                      ]
-                                                                                                    },
-                                                                                                    {
-                                                                                                      "kind": "nkIdent",
-                                                                                                      "ident": "a03"
-                                                                                                    }
-                                                                                                  ]
-                                                                                                }
-                                                                                              ]
-                                                                                            },
-                                                                                            {
-                                                                                              "kind": "nkInfix",
-                                                                                              "sons": [
-                                                                                                {
-                                                                                                  "kind": "nkIdent",
-                                                                                                  "ident": "*"
-                                                                                                },
-                                                                                                {
-                                                                                                  "kind": "nkInfix",
-                                                                                                  "sons": [
-                                                                                                    {
-                                                                                                      "kind": "nkIdent",
-                                                                                                      "ident": "*"
-                                                                                                    },
-                                                                                                    {
-                                                                                                      "kind": "nkInfix",
-                                                                                                      "sons": [
-                                                                                                        {
-                                                                                                          "kind": "nkIdent",
-                                                                                                          "ident": "*"
-                                                                                                        },
-                                                                                                        {
-                                                                                                          "kind": "nkIdent",
-                                                                                                          "ident": "a10"
-                                                                                                        },
-                                                                                                        {
-                                                                                                          "kind": "nkIdent",
-                                                                                                          "ident": "a21"
-                                                                                                        }
-                                                                                                      ]
-                                                                                                    },
-                                                                                                    {
-                                                                                                      "kind": "nkIdent",
-                                                                                                      "ident": "a32"
-                                                                                                    }
-                                                                                                  ]
-                                                                                                },
-                                                                                                {
-                                                                                                  "kind": "nkIdent",
-                                                                                                  "ident": "a03"
-                                                                                                }
-                                                                                              ]
-                                                                                            }
-                                                                                          ]
-                                                                                        },
-                                                                                        {
-                                                                                          "kind": "nkInfix",
-                                                                                          "sons": [
-                                                                                            {
-                                                                                              "kind": "nkIdent",
-                                                                                              "ident": "*"
-                                                                                            },
-                                                                                            {
-                                                                                              "kind": "nkInfix",
-                                                                                              "sons": [
-                                                                                                {
-                                                                                                  "kind": "nkIdent",
-                                                                                                  "ident": "*"
-                                                                                                },
-                                                                                                {
-                                                                                                  "kind": "nkInfix",
-                                                                                                  "sons": [
-                                                                                                    {
-                                                                                                      "kind": "nkIdent",
-                                                                                                      "ident": "*"
-                                                                                                    },
-                                                                                                    {
-                                                                                                      "kind": "nkIdent",
-                                                                                                      "ident": "a30"
-                                                                                                    },
-                                                                                                    {
-                                                                                                      "kind": "nkIdent",
-                                                                                                      "ident": "a21"
-                                                                                                    }
-                                                                                                  ]
-                                                                                                },
-                                                                                                {
-                                                                                                  "kind": "nkIdent",
-                                                                                                  "ident": "a02"
-                                                                                                }
-                                                                                              ]
-                                                                                            },
-                                                                                            {
-                                                                                              "kind": "nkIdent",
-                                                                                              "ident": "a13"
-                                                                                            }
-                                                                                          ]
-                                                                                        }
-                                                                                      ]
-                                                                                    },
-                                                                                    {
-                                                                                      "kind": "nkInfix",
-                                                                                      "sons": [
-                                                                                        {
-                                                                                          "kind": "nkIdent",
-                                                                                          "ident": "*"
-                                                                                        },
-                                                                                        {
-                                                                                          "kind": "nkInfix",
-                                                                                          "sons": [
-                                                                                            {
-                                                                                              "kind": "nkIdent",
-                                                                                              "ident": "*"
-                                                                                            },
-                                                                                            {
-                                                                                              "kind": "nkInfix",
-                                                                                              "sons": [
-                                                                                                {
-                                                                                                  "kind": "nkIdent",
-                                                                                                  "ident": "*"
-                                                                                                },
-                                                                                                {
-                                                                                                  "kind": "nkIdent",
-                                                                                                  "ident": "a20"
-                                                                                                },
-                                                                                                {
-                                                                                                  "kind": "nkIdent",
-                                                                                                  "ident": "a31"
-                                                                                                }
-                                                                                              ]
-                                                                                            },
-                                                                                            {
-                                                                                              "kind": "nkIdent",
-                                                                                              "ident": "a02"
-                                                                                            }
-                                                                                          ]
-                                                                                        },
-                                                                                        {
-                                                                                          "kind": "nkIdent",
-                                                                                          "ident": "a13"
-                                                                                        }
-                                                                                      ]
-                                                                                    }
-                                                                                  ]
-                                                                                },
-                                                                                {
-                                                                                  "kind": "nkInfix",
-                                                                                  "sons": [
-                                                                                    {
-                                                                                      "kind": "nkIdent",
-                                                                                      "ident": "*"
-                                                                                    },
-                                                                                    {
-                                                                                      "kind": "nkInfix",
-                                                                                      "sons": [
-                                                                                        {
-                                                                                          "kind": "nkIdent",
-                                                                                          "ident": "*"
-                                                                                        },
-                                                                                        {
-                                                                                          "kind": "nkInfix",
-                                                                                          "sons": [
-                                                                                            {
-                                                                                              "kind": "nkIdent",
-                                                                                              "ident": "*"
-                                                                                            },
-                                                                                            {
-                                                                                              "kind": "nkIdent",
-                                                                                              "ident": "a30"
-                                                                                            },
-                                                                                            {
-                                                                                              "kind": "nkIdent",
-                                                                                              "ident": "a01"
-                                                                                            }
-                                                                                          ]
-                                                                                        },
-                                                                                        {
-                                                                                          "kind": "nkIdent",
-                                                                                          "ident": "a22"
-                                                                                        }
-                                                                                      ]
-                                                                                    },
-                                                                                    {
-                                                                                      "kind": "nkIdent",
-                                                                                      "ident": "a13"
-                                                                                    }
-                                                                                  ]
-                                                                                }
-                                                                              ]
-                                                                            },
-                                                                            {
-                                                                              "kind": "nkInfix",
-                                                                              "sons": [
-                                                                                {
-                                                                                  "kind": "nkIdent",
-                                                                                  "ident": "*"
-                                                                                },
-                                                                                {
-                                                                                  "kind": "nkInfix",
-                                                                                  "sons": [
-                                                                                    {
-                                                                                      "kind": "nkIdent",
-                                                                                      "ident": "*"
-                                                                                    },
-                                                                                    {
-                                                                                      "kind": "nkInfix",
-                                                                                      "sons": [
-                                                                                        {
-                                                                                          "kind": "nkIdent",
-                                                                                          "ident": "*"
-                                                                                        },
-                                                                                        {
-                                                                                          "kind": "nkIdent",
-                                                                                          "ident": "a00"
-                                                                                        },
-                                                                                        {
-                                                                                          "kind": "nkIdent",
-                                                                                          "ident": "a31"
-                                                                                        }
-                                                                                      ]
-                                                                                    },
-                                                                                    {
-                                                                                      "kind": "nkIdent",
-                                                                                      "ident": "a22"
-                                                                                    }
-                                                                                  ]
-                                                                                },
-                                                                                {
-                                                                                  "kind": "nkIdent",
-                                                                                  "ident": "a13"
-                                                                                }
-                                                                              ]
-                                                                            }
-                                                                          ]
-                                                                        },
-                                                                        {
-                                                                          "kind": "nkInfix",
-                                                                          "sons": [
-                                                                            {
-                                                                              "kind": "nkIdent",
-                                                                              "ident": "*"
-                                                                            },
-                                                                            {
-                                                                              "kind": "nkInfix",
-                                                                              "sons": [
-                                                                                {
-                                                                                  "kind": "nkIdent",
-                                                                                  "ident": "*"
-                                                                                },
-                                                                                {
-                                                                                  "kind": "nkInfix",
-                                                                                  "sons": [
-                                                                                    {
-                                                                                      "kind": "nkIdent",
-                                                                                      "ident": "*"
-                                                                                    },
-                                                                                    {
-                                                                                      "kind": "nkIdent",
-                                                                                      "ident": "a20"
-                                                                                    },
-                                                                                    {
-                                                                                      "kind": "nkIdent",
-                                                                                      "ident": "a01"
-                                                                                    }
-                                                                                  ]
-                                                                                },
-                                                                                {
-                                                                                  "kind": "nkIdent",
-                                                                                  "ident": "a32"
-                                                                                }
-                                                                              ]
-                                                                            },
-                                                                            {
-                                                                              "kind": "nkIdent",
-                                                                              "ident": "a13"
-                                                                            }
-                                                                          ]
-                                                                        }
-                                                                      ]
-                                                                    },
-                                                                    {
-                                                                      "kind": "nkInfix",
-                                                                      "sons": [
-                                                                        {
-                                                                          "kind": "nkIdent",
-                                                                          "ident": "*"
-                                                                        },
-                                                                        {
-                                                                          "kind": "nkInfix",
-                                                                          "sons": [
-                                                                            {
-                                                                              "kind": "nkIdent",
-                                                                              "ident": "*"
-                                                                            },
-                                                                            {
-                                                                              "kind": "nkInfix",
-                                                                              "sons": [
-                                                                                {
-                                                                                  "kind": "nkIdent",
-                                                                                  "ident": "*"
-                                                                                },
-                                                                                {
-                                                                                  "kind": "nkIdent",
-                                                                                  "ident": "a00"
-                                                                                },
-                                                                                {
-                                                                                  "kind": "nkIdent",
-                                                                                  "ident": "a21"
-                                                                                }
-                                                                              ]
-                                                                            },
-                                                                            {
-                                                                              "kind": "nkIdent",
-                                                                              "ident": "a32"
-                                                                            }
-                                                                          ]
-                                                                        },
-                                                                        {
-                                                                          "kind": "nkIdent",
-                                                                          "ident": "a13"
-                                                                        }
-                                                                      ]
-                                                                    }
-                                                                  ]
-                                                                },
-                                                                {
-                                                                  "kind": "nkInfix",
-                                                                  "sons": [
-                                                                    {
-                                                                      "kind": "nkIdent",
-                                                                      "ident": "*"
-                                                                    },
-                                                                    {
-                                                                      "kind": "nkInfix",
-                                                                      "sons": [
-                                                                        {
-                                                                          "kind": "nkIdent",
-                                                                          "ident": "*"
-                                                                        },
-                                                                        {
-                                                                          "kind": "nkInfix",
-                                                                          "sons": [
-                                                                            {
-                                                                              "kind": "nkIdent",
-                                                                              "ident": "*"
-                                                                            },
-                                                                            {
-                                                                              "kind": "nkIdent",
-                                                                              "ident": "a30"
-                                                                            },
-                                                                            {
-                                                                              "kind": "nkIdent",
-                                                                              "ident": "a11"
-                                                                            }
-                                                                          ]
-                                                                        },
-                                                                        {
-                                                                          "kind": "nkIdent",
-                                                                          "ident": "a02"
-                                                                        }
-                                                                      ]
-                                                                    },
-                                                                    {
-                                                                      "kind": "nkIdent",
-                                                                      "ident": "a23"
-                                                                    }
-                                                                  ]
-                                                                }
-                                                              ]
-                                                            },
-                                                            {
-                                                              "kind": "nkInfix",
-                                                              "sons": [
-                                                                {
-                                                                  "kind": "nkIdent",
-                                                                  "ident": "*"
-                                                                },
-                                                                {
-                                                                  "kind": "nkInfix",
-                                                                  "sons": [
-                                                                    {
-                                                                      "kind": "nkIdent",
-                                                                      "ident": "*"
-                                                                    },
-                                                                    {
-                                                                      "kind": "nkInfix",
-                                                                      "sons": [
-                                                                        {
-                                                                          "kind": "nkIdent",
-                                                                          "ident": "*"
-                                                                        },
-                                                                        {
-                                                                          "kind": "nkIdent",
-                                                                          "ident": "a10"
-                                                                        },
-                                                                        {
-                                                                          "kind": "nkIdent",
-                                                                          "ident": "a31"
-                                                                        }
-                                                                      ]
-                                                                    },
-                                                                    {
-                                                                      "kind": "nkIdent",
-                                                                      "ident": "a02"
-                                                                    }
-                                                                  ]
-                                                                },
-                                                                {
-                                                                  "kind": "nkIdent",
-                                                                  "ident": "a23"
-                                                                }
-                                                              ]
-                                                            }
-                                                          ]
-                                                        },
-                                                        {
-                                                          "kind": "nkInfix",
-                                                          "sons": [
-                                                            {
-                                                              "kind": "nkIdent",
-                                                              "ident": "*"
-                                                            },
-                                                            {
-                                                              "kind": "nkInfix",
-                                                              "sons": [
-                                                                {
-                                                                  "kind": "nkIdent",
-                                                                  "ident": "*"
-                                                                },
-                                                                {
-                                                                  "kind": "nkInfix",
-                                                                  "sons": [
-                                                                    {
-                                                                      "kind": "nkIdent",
-                                                                      "ident": "*"
-                                                                    },
-                                                                    {
-                                                                      "kind": "nkIdent",
-                                                                      "ident": "a30"
-                                                                    },
-                                                                    {
-                                                                      "kind": "nkIdent",
-                                                                      "ident": "a01"
-                                                                    }
-                                                                  ]
-                                                                },
-                                                                {
-                                                                  "kind": "nkIdent",
-                                                                  "ident": "a12"
-                                                                }
-                                                              ]
-                                                            },
-                                                            {
-                                                              "kind": "nkIdent",
-                                                              "ident": "a23"
-                                                            }
-                                                          ]
-                                                        }
-                                                      ]
-                                                    },
-                                                    {
-                                                      "kind": "nkInfix",
-                                                      "sons": [
-                                                        {
-                                                          "kind": "nkIdent",
-                                                          "ident": "*"
-                                                        },
-                                                        {
-                                                          "kind": "nkInfix",
-                                                          "sons": [
-                                                            {
-                                                              "kind": "nkIdent",
-                                                              "ident": "*"
-                                                            },
-                                                            {
-                                                              "kind": "nkInfix",
-                                                              "sons": [
-                                                                {
-                                                                  "kind": "nkIdent",
-                                                                  "ident": "*"
-                                                                },
-                                                                {
-                                                                  "kind": "nkIdent",
-                                                                  "ident": "a00"
-                                                                },
-                                                                {
-                                                                  "kind": "nkIdent",
-                                                                  "ident": "a31"
-                                                                }
-                                                              ]
-                                                            },
-                                                            {
-                                                              "kind": "nkIdent",
-                                                              "ident": "a12"
-                                                            }
-                                                          ]
-                                                        },
-                                                        {
-                                                          "kind": "nkIdent",
-                                                          "ident": "a23"
-                                                        }
-                                                      ]
-                                                    }
-                                                  ]
-                                                },
-                                                {
-                                                  "kind": "nkInfix",
-                                                  "sons": [
-                                                    {
-                                                      "kind": "nkIdent",
-                                                      "ident": "*"
-                                                    },
-                                                    {
-                                                      "kind": "nkInfix",
-                                                      "sons": [
-                                                        {
-                                                          "kind": "nkIdent",
-                                                          "ident": "*"
-                                                        },
-                                                        {
-                                                          "kind": "nkInfix",
-                                                          "sons": [
-                                                            {
-                                                              "kind": "nkIdent",
-                                                              "ident": "*"
-                                                            },
-                                                            {
-                                                              "kind": "nkIdent",
-                                                              "ident": "a10"
-                                                            },
-                                                            {
-                                                              "kind": "nkIdent",
-                                                              "ident": "a01"
-                                                            }
-                                                          ]
-                                                        },
-                                                        {
-                                                          "kind": "nkIdent",
-                                                          "ident": "a32"
-                                                        }
-                                                      ]
-                                                    },
-                                                    {
-                                                      "kind": "nkIdent",
-                                                      "ident": "a23"
-                                                    }
-                                                  ]
-                                                }
-                                              ]
-                                            },
-                                            {
-                                              "kind": "nkInfix",
-                                              "sons": [
-                                                {
-                                                  "kind": "nkIdent",
-                                                  "ident": "*"
-                                                },
-                                                {
-                                                  "kind": "nkInfix",
-                                                  "sons": [
-                                                    {
-                                                      "kind": "nkIdent",
-                                                      "ident": "*"
-                                                    },
-                                                    {
-                                                      "kind": "nkInfix",
-                                                      "sons": [
-                                                        {
-                                                          "kind": "nkIdent",
-                                                          "ident": "*"
-                                                        },
-                                                        {
-                                                          "kind": "nkIdent",
-                                                          "ident": "a00"
-                                                        },
-                                                        {
-                                                          "kind": "nkIdent",
-                                                          "ident": "a11"
-                                                        }
-                                                      ]
-                                                    },
-                                                    {
-                                                      "kind": "nkIdent",
-                                                      "ident": "a32"
-                                                    }
-                                                  ]
-                                                },
-                                                {
-                                                  "kind": "nkIdent",
-                                                  "ident": "a23"
-                                                }
-                                              ]
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "kind": "nkInfix",
-                                          "sons": [
-                                            {
-                                              "kind": "nkIdent",
-                                              "ident": "*"
-                                            },
-                                            {
-                                              "kind": "nkInfix",
-                                              "sons": [
-                                                {
-                                                  "kind": "nkIdent",
-                                                  "ident": "*"
-                                                },
-                                                {
-                                                  "kind": "nkInfix",
-                                                  "sons": [
-                                                    {
-                                                      "kind": "nkIdent",
-                                                      "ident": "*"
-                                                    },
-                                                    {
-                                                      "kind": "nkIdent",
-                                                      "ident": "a20"
-                                                    },
-                                                    {
-                                                      "kind": "nkIdent",
-                                                      "ident": "a11"
-                                                    }
-                                                  ]
-                                                },
-                                                {
-                                                  "kind": "nkIdent",
-                                                  "ident": "a02"
-                                                }
-                                              ]
-                                            },
-                                            {
-                                              "kind": "nkIdent",
-                                              "ident": "a33"
-                                            }
-                                          ]
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "kind": "nkInfix",
-                                      "sons": [
-                                        {
-                                          "kind": "nkIdent",
-                                          "ident": "*"
-                                        },
-                                        {
-                                          "kind": "nkInfix",
-                                          "sons": [
-                                            {
-                                              "kind": "nkIdent",
-                                              "ident": "*"
-                                            },
-                                            {
-                                              "kind": "nkInfix",
-                                              "sons": [
-                                                {
-                                                  "kind": "nkIdent",
-                                                  "ident": "*"
-                                                },
-                                                {
-                                                  "kind": "nkIdent",
-                                                  "ident": "a10"
-                                                },
-                                                {
-                                                  "kind": "nkIdent",
-                                                  "ident": "a21"
-                                                }
-                                              ]
-                                            },
-                                            {
-                                              "kind": "nkIdent",
-                                              "ident": "a02"
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "kind": "nkIdent",
-                                          "ident": "a33"
-                                        }
-                                      ]
-                                    }
-                                  ]
-                                },
-                                {
-                                  "kind": "nkInfix",
-                                  "sons": [
-                                    {
-                                      "kind": "nkIdent",
-                                      "ident": "*"
-                                    },
-                                    {
-                                      "kind": "nkInfix",
-                                      "sons": [
-                                        {
-                                          "kind": "nkIdent",
-                                          "ident": "*"
-                                        },
-                                        {
-                                          "kind": "nkInfix",
-                                          "sons": [
-                                            {
-                                              "kind": "nkIdent",
-                                              "ident": "*"
-                                            },
-                                            {
-                                              "kind": "nkIdent",
-                                              "ident": "a20"
-                                            },
-                                            {
-                                              "kind": "nkIdent",
-                                              "ident": "a01"
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "kind": "nkIdent",
-                                          "ident": "a12"
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "kind": "nkIdent",
-                                      "ident": "a33"
-                                    }
-                                  ]
-                                }
-                              ]
-                            },
-                            {
-                              "kind": "nkInfix",
-                              "sons": [
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "*"
-                                },
-                                {
-                                  "kind": "nkInfix",
-                                  "sons": [
-                                    {
-                                      "kind": "nkIdent",
-                                      "ident": "*"
-                                    },
-                                    {
-                                      "kind": "nkInfix",
-                                      "sons": [
-                                        {
-                                          "kind": "nkIdent",
-                                          "ident": "*"
-                                        },
-                                        {
-                                          "kind": "nkIdent",
-                                          "ident": "a00"
-                                        },
-                                        {
-                                          "kind": "nkIdent",
-                                          "ident": "a21"
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "kind": "nkIdent",
-                                      "ident": "a12"
-                                    }
-                                  ]
-                                },
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "a33"
-                                }
-                              ]
-                            }
-                          ]
-                        },
-                        {
-                          "kind": "nkInfix",
-                          "sons": [
-                            {
-                              "kind": "nkIdent",
-                              "ident": "*"
-                            },
-                            {
-                              "kind": "nkInfix",
-                              "sons": [
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "*"
-                                },
-                                {
-                                  "kind": "nkInfix",
-                                  "sons": [
-                                    {
-                                      "kind": "nkIdent",
-                                      "ident": "*"
-                                    },
-                                    {
-                                      "kind": "nkIdent",
-                                      "ident": "a10"
-                                    },
-                                    {
-                                      "kind": "nkIdent",
-                                      "ident": "a01"
-                                    }
-                                  ]
-                                },
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "a22"
-                                }
-                              ]
-                            },
-                            {
-                              "kind": "nkIdent",
-                              "ident": "a33"
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "kind": "nkInfix",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "*"
-                        },
-                        {
-                          "kind": "nkInfix",
-                          "sons": [
-                            {
-                              "kind": "nkIdent",
-                              "ident": "*"
-                            },
-                            {
-                              "kind": "nkInfix",
-                              "sons": [
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "*"
-                                },
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "a00"
-                                },
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "a11"
-                                }
-                              ]
-                            },
-                            {
-                              "kind": "nkIdent",
-                              "ident": "a22"
-                            }
-                          ]
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "a33"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkIfStmt",
-      "sons": [
-        {
-          "kind": "nkElifBranch",
-          "sons": [
-            {
-              "kind": "nkInfix",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "and"
-                },
-                {
-                  "kind": "nkInfix",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "and"
-                    },
-                    {
-                      "kind": "nkInfix",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "and"
-                        },
-                        {
-                          "kind": "nkInfix",
-                          "sons": [
-                            {
-                              "kind": "nkIdent",
-                              "ident": "and"
-                            },
-                            {
-                              "kind": "nkIdent",
-                              "ident": "aaaaaaaaaaaaaaaaaaaa"
-                            },
-                            {
-                              "kind": "nkIdent",
-                              "ident": "bbbbbbbbbbbbbbbbbbbbbbb"
-                            }
-                          ]
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "ccccccccccccccccccccccccc"
-                        }
-                      ]
-                    },
-                    {
-                      "kind": "nkIdent",
-                      "ident": "ddddddddddddddddd"
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "fffffffffffffffff"
-                }
-              ]
-            },
-            {
-              "kind": "nkStmtList",
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkIfStmt",
-      "sons": [
-        {
-          "kind": "nkElifBranch",
-          "sons": [
-            {
-              "kind": "nkInfix",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "or"
-                },
-                {
-                  "kind": "nkPar",
-                  "sons": [
-                    {
-                      "kind": "nkInfix",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "and"
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "aaaaaaaaaaaaaaaa"
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "bbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkPar",
-                  "sons": [
-                    {
-                      "kind": "nkInfix",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "and"
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "ccccccccccccccccccccccccccc"
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "ddddddddddddddddddddd"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "kind": "nkStmtList",
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkElifBranch",
-          "sons": [
-            {
-              "kind": "nkInfix",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "and"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "aaaaaaaaa"
-                },
-                {
-                  "kind": "nkPar",
-                  "sons": [
-                    {
-                      "kind": "nkInfix",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "or"
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "bbbbbbbbbb"
-                        },
-                        {
-                          "kind": "nkInfix",
-                          "sons": [
-                            {
-                              "kind": "nkIdent",
-                              "ident": "and"
-                            },
-                            {
-                              "kind": "nkIdent",
-                              "ident": "cccccccccccc"
-                            },
-                            {
-                              "kind": "nkPar",
-                              "sons": [
-                                {
-                                  "kind": "nkInfix",
-                                  "sons": [
-                                    {
-                                      "kind": "nkIdent",
-                                      "ident": "or"
-                                    },
-                                    {
-                                      "kind": "nkInfix",
-                                      "sons": [
-                                        {
-                                          "kind": "nkIdent",
-                                          "ident": "or"
-                                        },
-                                        {
-                                          "kind": "nkInfix",
-                                          "sons": [
-                                            {
-                                              "kind": "nkIdent",
-                                              "ident": "or"
-                                            },
-                                            {
-                                              "kind": "nkIdent",
-                                              "ident": "dddddddddddddddd"
-                                            },
-                                            {
-                                              "kind": "nkIdent",
-                                              "ident": "eeeeeeeeeeeeeee"
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "kind": "nkIdent",
-                                          "ident": "fffffffffffffff"
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "kind": "nkIdent",
-                                      "ident": "gggggggggggggg"
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "kind": "nkStmtList",
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkCaseStmt",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "aaaaaaaaaa"
-        },
-        {
-          "kind": "nkOfBranch",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "bbbbbbbbbbbbbbbbbbbbbbbbbb"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "ccccccccccccccccccccccc"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "ddddddddddddddddddddddd"
-            },
-            {
-              "kind": "nkStmtList",
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkOfBranch",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "aaaa"
-            },
-            {
-              "kind": "nkStmtList",
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkOfBranch",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "bbbbbbbbbbbbbbbbbbbbbbbbbb"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "ccccccccccccccccccccccc"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "dddddddddddddddddddddd"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "bbbbbbbbbbbbbbbbbbbbbbbbbb"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "ccccccccccccccccccccccc"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "dddddddddddddddddddddd"
-            },
-            {
-              "kind": "nkStmtList",
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkElse",
-          "sons": [
-            {
-              "kind": "nkStmtList",
-              "sons": [
-                {
-                  "kind": "nkDiscardStmt",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
-  ]
-}
+kind: "nkStmtList"
+sons:
+  - kind: "nkVarSection"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "c3"
+          - kind: "nkEmpty"
+          - kind: "nkInfix"
+            sons:
+              - kind: "nkIdent"
+                ident: "+"
+              - kind: "nkBracketExpr"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "row"
+                  - kind: "nkIdent"
+                    ident: "p"
+              - kind: "nkStmtListExpr"
+                sons:
+                  - kind: "nkIfStmt"
+                    sons:
+                      - kind: "nkElifExpr"
+                        sons:
+                          - kind: "nkInfix"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: "!="
+                              - kind: "nkIdent"
+                                ident: "runeA"
+                              - kind: "nkIdent"
+                                ident: "runeB"
+                          - kind: "nkStmtList"
+                            sons:
+                              - kind: "nkIntLit"
+                                intVal: 1
+                      - kind: "nkElseExpr"
+                        sons:
+                          - kind: "nkStmtList"
+                            sons:
+                              - kind: "nkIntLit"
+                                intVal: 0
+  - kind: "nkVarSection"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "c3"
+          - kind: "nkEmpty"
+          - kind: "nkInfix"
+            sons:
+              - kind: "nkIdent"
+                ident: "+"
+              - kind: "nkBracketExpr"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "row"
+                  - kind: "nkIdent"
+                    ident: "p"
+              - kind: "nkStmtListExpr"
+                sons:
+                  - kind: "nkIfStmt"
+                    sons:
+                      - kind: "nkElifExpr"
+                        sons:
+                          - kind: "nkInfix"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: "!="
+                              - kind: "nkIdent"
+                                ident: "runeA"
+                              - kind: "nkIdent"
+                                ident: "runeB"
+                          - kind: "nkIntLit"
+                            intVal: 1
+                      - kind: "nkElseExpr"
+                        sons:
+                          - kind: "nkIntLit"
+                            intVal: 0
+  - kind: "nkForStmt"
+    sons:
+      - kind: "nkIdent"
+        ident: "a"
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: "..<"
+          - kind: "nkIntLit"
+            intVal: 0
+          - kind: "nkIntLit"
+            intVal: 1
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+  - kind: "nkForStmt"
+    sons:
+      - kind: "nkIdent"
+        ident: "a"
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: ".."
+          - kind: "nkIntLit"
+            intVal: 0
+          - kind: "nkIntLit"
+            intVal: 1
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+  - kind: "nkForStmt"
+    prefix:
+      - "# needs spaces"
+    sons:
+      - kind: "nkIdent"
+        ident: "a"
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: ".."
+          - kind: "nkPrefix"
+            sons:
+              - kind: "nkIdent"
+                ident: "^"
+              - kind: "nkIntLit"
+                intVal: 1
+          - kind: "nkPrefix"
+            sons:
+              - kind: "nkIdent"
+                ident: "^"
+              - kind: "nkIntLit"
+                intVal: 2
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+  - kind: "nkTemplateDef"
+    sons:
+      - kind: "nkPostfix"
+        sons:
+          - kind: "nkIdent"
+            ident: "*"
+          - kind: "nkIdent"
+            ident: "ttt"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkIdent"
+            ident: "untyped"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkBracketExpr"
+            sons:
+              - kind: "nkStmtListExpr"
+                sons:
+                  - kind: "nkBlockStmt"
+                    sons:
+                      - kind: "nkEmpty"
+                      - kind: "nkStmtList"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "xxx"
+  - kind: "nkDiscardStmt"
+    prefix:
+      - "# command syntax with colon"
+    sons:
+      - kind: "nkCommand"
+        sons:
+          - kind: "nkIdent"
+            ident: "xxxx"
+          - kind: "nkStrLit"
+            strVal: "arg"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkIdent"
+                ident: "yyy"
+  - kind: "nkCommand"
+    sons:
+      - kind: "nkDotExpr"
+        sons:
+          - kind: "nkIdent"
+            ident: "res"
+          - kind: "nkIdent"
+            ident: "add"
+      - kind: "nkCall"
+        sons:
+          - kind: "nkIdent"
+            ident: "fff"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkCall"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "yy"
+  - kind: "nkLetSection"
+    prefix:
+      - "# we don\'t what `do` in let but need it in the above commend - this needs"
+      - "# more investigation - this is important for templates calls like Result.valueOr"
+      - "# which become ugly otherwise"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "xxx"
+          - kind: "nkEmpty"
+          - kind: "nkCall"
+            sons:
+              - kind: "nkIdent"
+                ident: "implicitdo"
+              - kind: "nkStmtList"
+                sons:
+                  - kind: "nkReturnStmt"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "xxx"
+  - kind: "nkLetSection"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "shortInfix"
+          - kind: "nkEmpty"
+          - kind: "nkInfix"
+            sons:
+              - kind: "nkIdent"
+                ident: "+"
+              - kind: "nkInfix"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "+"
+                  - kind: "nkInfix"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "*"
+                      - kind: "nkInfix"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "*"
+                          - kind: "nkIdent"
+                            ident: "a"
+                          - kind: "nkIdent"
+                            ident: "b"
+                      - kind: "nkIdent"
+                        ident: "c"
+                  - kind: "nkInfix"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "*"
+                      - kind: "nkInfix"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "*"
+                          - kind: "nkIdent"
+                            ident: "d"
+                          - kind: "nkIdent"
+                            ident: "e"
+                      - kind: "nkIdent"
+                        ident: "f"
+              - kind: "nkInfix"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "*"
+                  - kind: "nkPar"
+                    sons:
+                      - kind: "nkInfix"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "+"
+                          - kind: "nkIdent"
+                            ident: "a"
+                          - kind: "nkIdent"
+                            ident: "b"
+                  - kind: "nkIdent"
+                    ident: "g"
+  - kind: "nkLetSection"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "longInfix"
+          - kind: "nkEmpty"
+          - kind: "nkPar"
+            sons:
+              - kind: "nkInfix"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "+"
+                  - kind: "nkInfix"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "-"
+                      - kind: "nkInfix"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "-"
+                          - kind: "nkInfix"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: "+"
+                              - kind: "nkInfix"
+                                sons:
+                                  - kind: "nkIdent"
+                                    ident: "+"
+                                  - kind: "nkInfix"
+                                    sons:
+                                      - kind: "nkIdent"
+                                        ident: "-"
+                                      - kind: "nkInfix"
+                                        sons:
+                                          - kind: "nkIdent"
+                                            ident: "-"
+                                          - kind: "nkInfix"
+                                            sons:
+                                              - kind: "nkIdent"
+                                                ident: "+"
+                                              - kind: "nkInfix"
+                                                sons:
+                                                  - kind: "nkIdent"
+                                                    ident: "+"
+                                                  - kind: "nkInfix"
+                                                    sons:
+                                                      - kind: "nkIdent"
+                                                        ident: "-"
+                                                      - kind: "nkInfix"
+                                                        sons:
+                                                          - kind: "nkIdent"
+                                                            ident: "-"
+                                                          - kind: "nkInfix"
+                                                            sons:
+                                                              - kind: "nkIdent"
+                                                                ident: "+"
+                                                              - kind: "nkInfix"
+                                                                sons:
+                                                                  - kind: "nkIdent"
+                                                                    ident: "+"
+                                                                  - kind: "nkInfix"
+                                                                    sons:
+                                                                      - kind: "nkIdent"
+                                                                        ident: "-"
+                                                                      - kind: "nkInfix"
+                                                                        sons:
+                                                                          - kind: "nkIdent"
+                                                                            ident: "-"
+                                                                          - kind: "nkInfix"
+                                                                            sons:
+                                                                              - kind: "nkIdent"
+                                                                                ident: "+"
+                                                                              - kind: "nkInfix"
+                                                                                sons:
+                                                                                  - kind: "nkIdent"
+                                                                                    ident: "+"
+                                                                                  - kind: "nkInfix"
+                                                                                    sons:
+                                                                                      - kind: "nkIdent"
+                                                                                        ident: "-"
+                                                                                      - kind: "nkInfix"
+                                                                                        sons:
+                                                                                          - kind: "nkIdent"
+                                                                                            ident: "-"
+                                                                                          - kind: "nkInfix"
+                                                                                            sons:
+                                                                                              - kind: "nkIdent"
+                                                                                                ident: "+"
+                                                                                              - kind: "nkInfix"
+                                                                                                sons:
+                                                                                                  - kind: "nkIdent"
+                                                                                                    ident: "+"
+                                                                                                  - kind: "nkInfix"
+                                                                                                    sons:
+                                                                                                      - kind: "nkIdent"
+                                                                                                        ident: "-"
+                                                                                                      - kind: "nkInfix"
+                                                                                                        sons:
+                                                                                                          - kind: "nkIdent"
+                                                                                                            ident: "-"
+                                                                                                          - kind: "nkInfix"
+                                                                                                            sons:
+                                                                                                              - kind: "nkIdent"
+                                                                                                                ident: "*"
+                                                                                                              - kind: "nkInfix"
+                                                                                                                sons:
+                                                                                                                  - kind: "nkIdent"
+                                                                                                                    ident: "*"
+                                                                                                                  - kind: "nkInfix"
+                                                                                                                    sons:
+                                                                                                                      - kind: "nkIdent"
+                                                                                                                        ident: "*"
+                                                                                                                      - kind: "nkIdent"
+                                                                                                                        ident: "a30"
+                                                                                                                      - kind: "nkIdent"
+                                                                                                                        ident: "a21"
+                                                                                                                  - kind: "nkIdent"
+                                                                                                                    ident: "a12"
+                                                                                                              - kind: "nkIdent"
+                                                                                                                ident: "a03"
+                                                                                                          - kind: "nkInfix"
+                                                                                                            sons:
+                                                                                                              - kind: "nkIdent"
+                                                                                                                ident: "*"
+                                                                                                              - kind: "nkInfix"
+                                                                                                                sons:
+                                                                                                                  - kind: "nkIdent"
+                                                                                                                    ident: "*"
+                                                                                                                  - kind: "nkInfix"
+                                                                                                                    sons:
+                                                                                                                      - kind: "nkIdent"
+                                                                                                                        ident: "*"
+                                                                                                                      - kind: "nkIdent"
+                                                                                                                        ident: "a20"
+                                                                                                                      - kind: "nkIdent"
+                                                                                                                        ident: "a31"
+                                                                                                                  - kind: "nkIdent"
+                                                                                                                    ident: "a12"
+                                                                                                              - kind: "nkIdent"
+                                                                                                                ident: "a03"
+                                                                                                      - kind: "nkInfix"
+                                                                                                        sons:
+                                                                                                          - kind: "nkIdent"
+                                                                                                            ident: "*"
+                                                                                                          - kind: "nkInfix"
+                                                                                                            sons:
+                                                                                                              - kind: "nkIdent"
+                                                                                                                ident: "*"
+                                                                                                              - kind: "nkInfix"
+                                                                                                                sons:
+                                                                                                                  - kind: "nkIdent"
+                                                                                                                    ident: "*"
+                                                                                                                  - kind: "nkIdent"
+                                                                                                                    ident: "a30"
+                                                                                                                  - kind: "nkIdent"
+                                                                                                                    ident: "a11"
+                                                                                                              - kind: "nkIdent"
+                                                                                                                ident: "a22"
+                                                                                                          - kind: "nkIdent"
+                                                                                                            ident: "a03"
+                                                                                                  - kind: "nkInfix"
+                                                                                                    sons:
+                                                                                                      - kind: "nkIdent"
+                                                                                                        ident: "*"
+                                                                                                      - kind: "nkInfix"
+                                                                                                        sons:
+                                                                                                          - kind: "nkIdent"
+                                                                                                            ident: "*"
+                                                                                                          - kind: "nkInfix"
+                                                                                                            sons:
+                                                                                                              - kind: "nkIdent"
+                                                                                                                ident: "*"
+                                                                                                              - kind: "nkIdent"
+                                                                                                                ident: "a10"
+                                                                                                              - kind: "nkIdent"
+                                                                                                                ident: "a31"
+                                                                                                          - kind: "nkIdent"
+                                                                                                            ident: "a22"
+                                                                                                      - kind: "nkIdent"
+                                                                                                        ident: "a03"
+                                                                                              - kind: "nkInfix"
+                                                                                                sons:
+                                                                                                  - kind: "nkIdent"
+                                                                                                    ident: "*"
+                                                                                                  - kind: "nkInfix"
+                                                                                                    sons:
+                                                                                                      - kind: "nkIdent"
+                                                                                                        ident: "*"
+                                                                                                      - kind: "nkInfix"
+                                                                                                        sons:
+                                                                                                          - kind: "nkIdent"
+                                                                                                            ident: "*"
+                                                                                                          - kind: "nkIdent"
+                                                                                                            ident: "a20"
+                                                                                                          - kind: "nkIdent"
+                                                                                                            ident: "a11"
+                                                                                                      - kind: "nkIdent"
+                                                                                                        ident: "a32"
+                                                                                                  - kind: "nkIdent"
+                                                                                                    ident: "a03"
+                                                                                          - kind: "nkInfix"
+                                                                                            sons:
+                                                                                              - kind: "nkIdent"
+                                                                                                ident: "*"
+                                                                                              - kind: "nkInfix"
+                                                                                                sons:
+                                                                                                  - kind: "nkIdent"
+                                                                                                    ident: "*"
+                                                                                                  - kind: "nkInfix"
+                                                                                                    sons:
+                                                                                                      - kind: "nkIdent"
+                                                                                                        ident: "*"
+                                                                                                      - kind: "nkIdent"
+                                                                                                        ident: "a10"
+                                                                                                      - kind: "nkIdent"
+                                                                                                        ident: "a21"
+                                                                                                  - kind: "nkIdent"
+                                                                                                    ident: "a32"
+                                                                                              - kind: "nkIdent"
+                                                                                                ident: "a03"
+                                                                                      - kind: "nkInfix"
+                                                                                        sons:
+                                                                                          - kind: "nkIdent"
+                                                                                            ident: "*"
+                                                                                          - kind: "nkInfix"
+                                                                                            sons:
+                                                                                              - kind: "nkIdent"
+                                                                                                ident: "*"
+                                                                                              - kind: "nkInfix"
+                                                                                                sons:
+                                                                                                  - kind: "nkIdent"
+                                                                                                    ident: "*"
+                                                                                                  - kind: "nkIdent"
+                                                                                                    ident: "a30"
+                                                                                                  - kind: "nkIdent"
+                                                                                                    ident: "a21"
+                                                                                              - kind: "nkIdent"
+                                                                                                ident: "a02"
+                                                                                          - kind: "nkIdent"
+                                                                                            ident: "a13"
+                                                                                  - kind: "nkInfix"
+                                                                                    sons:
+                                                                                      - kind: "nkIdent"
+                                                                                        ident: "*"
+                                                                                      - kind: "nkInfix"
+                                                                                        sons:
+                                                                                          - kind: "nkIdent"
+                                                                                            ident: "*"
+                                                                                          - kind: "nkInfix"
+                                                                                            sons:
+                                                                                              - kind: "nkIdent"
+                                                                                                ident: "*"
+                                                                                              - kind: "nkIdent"
+                                                                                                ident: "a20"
+                                                                                              - kind: "nkIdent"
+                                                                                                ident: "a31"
+                                                                                          - kind: "nkIdent"
+                                                                                            ident: "a02"
+                                                                                      - kind: "nkIdent"
+                                                                                        ident: "a13"
+                                                                              - kind: "nkInfix"
+                                                                                sons:
+                                                                                  - kind: "nkIdent"
+                                                                                    ident: "*"
+                                                                                  - kind: "nkInfix"
+                                                                                    sons:
+                                                                                      - kind: "nkIdent"
+                                                                                        ident: "*"
+                                                                                      - kind: "nkInfix"
+                                                                                        sons:
+                                                                                          - kind: "nkIdent"
+                                                                                            ident: "*"
+                                                                                          - kind: "nkIdent"
+                                                                                            ident: "a30"
+                                                                                          - kind: "nkIdent"
+                                                                                            ident: "a01"
+                                                                                      - kind: "nkIdent"
+                                                                                        ident: "a22"
+                                                                                  - kind: "nkIdent"
+                                                                                    ident: "a13"
+                                                                          - kind: "nkInfix"
+                                                                            sons:
+                                                                              - kind: "nkIdent"
+                                                                                ident: "*"
+                                                                              - kind: "nkInfix"
+                                                                                sons:
+                                                                                  - kind: "nkIdent"
+                                                                                    ident: "*"
+                                                                                  - kind: "nkInfix"
+                                                                                    sons:
+                                                                                      - kind: "nkIdent"
+                                                                                        ident: "*"
+                                                                                      - kind: "nkIdent"
+                                                                                        ident: "a00"
+                                                                                      - kind: "nkIdent"
+                                                                                        ident: "a31"
+                                                                                  - kind: "nkIdent"
+                                                                                    ident: "a22"
+                                                                              - kind: "nkIdent"
+                                                                                ident: "a13"
+                                                                      - kind: "nkInfix"
+                                                                        sons:
+                                                                          - kind: "nkIdent"
+                                                                            ident: "*"
+                                                                          - kind: "nkInfix"
+                                                                            sons:
+                                                                              - kind: "nkIdent"
+                                                                                ident: "*"
+                                                                              - kind: "nkInfix"
+                                                                                sons:
+                                                                                  - kind: "nkIdent"
+                                                                                    ident: "*"
+                                                                                  - kind: "nkIdent"
+                                                                                    ident: "a20"
+                                                                                  - kind: "nkIdent"
+                                                                                    ident: "a01"
+                                                                              - kind: "nkIdent"
+                                                                                ident: "a32"
+                                                                          - kind: "nkIdent"
+                                                                            ident: "a13"
+                                                                  - kind: "nkInfix"
+                                                                    sons:
+                                                                      - kind: "nkIdent"
+                                                                        ident: "*"
+                                                                      - kind: "nkInfix"
+                                                                        sons:
+                                                                          - kind: "nkIdent"
+                                                                            ident: "*"
+                                                                          - kind: "nkInfix"
+                                                                            sons:
+                                                                              - kind: "nkIdent"
+                                                                                ident: "*"
+                                                                              - kind: "nkIdent"
+                                                                                ident: "a00"
+                                                                              - kind: "nkIdent"
+                                                                                ident: "a21"
+                                                                          - kind: "nkIdent"
+                                                                            ident: "a32"
+                                                                      - kind: "nkIdent"
+                                                                        ident: "a13"
+                                                              - kind: "nkInfix"
+                                                                sons:
+                                                                  - kind: "nkIdent"
+                                                                    ident: "*"
+                                                                  - kind: "nkInfix"
+                                                                    sons:
+                                                                      - kind: "nkIdent"
+                                                                        ident: "*"
+                                                                      - kind: "nkInfix"
+                                                                        sons:
+                                                                          - kind: "nkIdent"
+                                                                            ident: "*"
+                                                                          - kind: "nkIdent"
+                                                                            ident: "a30"
+                                                                          - kind: "nkIdent"
+                                                                            ident: "a11"
+                                                                      - kind: "nkIdent"
+                                                                        ident: "a02"
+                                                                  - kind: "nkIdent"
+                                                                    ident: "a23"
+                                                          - kind: "nkInfix"
+                                                            sons:
+                                                              - kind: "nkIdent"
+                                                                ident: "*"
+                                                              - kind: "nkInfix"
+                                                                sons:
+                                                                  - kind: "nkIdent"
+                                                                    ident: "*"
+                                                                  - kind: "nkInfix"
+                                                                    sons:
+                                                                      - kind: "nkIdent"
+                                                                        ident: "*"
+                                                                      - kind: "nkIdent"
+                                                                        ident: "a10"
+                                                                      - kind: "nkIdent"
+                                                                        ident: "a31"
+                                                                  - kind: "nkIdent"
+                                                                    ident: "a02"
+                                                              - kind: "nkIdent"
+                                                                ident: "a23"
+                                                      - kind: "nkInfix"
+                                                        sons:
+                                                          - kind: "nkIdent"
+                                                            ident: "*"
+                                                          - kind: "nkInfix"
+                                                            sons:
+                                                              - kind: "nkIdent"
+                                                                ident: "*"
+                                                              - kind: "nkInfix"
+                                                                sons:
+                                                                  - kind: "nkIdent"
+                                                                    ident: "*"
+                                                                  - kind: "nkIdent"
+                                                                    ident: "a30"
+                                                                  - kind: "nkIdent"
+                                                                    ident: "a01"
+                                                              - kind: "nkIdent"
+                                                                ident: "a12"
+                                                          - kind: "nkIdent"
+                                                            ident: "a23"
+                                                  - kind: "nkInfix"
+                                                    sons:
+                                                      - kind: "nkIdent"
+                                                        ident: "*"
+                                                      - kind: "nkInfix"
+                                                        sons:
+                                                          - kind: "nkIdent"
+                                                            ident: "*"
+                                                          - kind: "nkInfix"
+                                                            sons:
+                                                              - kind: "nkIdent"
+                                                                ident: "*"
+                                                              - kind: "nkIdent"
+                                                                ident: "a00"
+                                                              - kind: "nkIdent"
+                                                                ident: "a31"
+                                                          - kind: "nkIdent"
+                                                            ident: "a12"
+                                                      - kind: "nkIdent"
+                                                        ident: "a23"
+                                              - kind: "nkInfix"
+                                                sons:
+                                                  - kind: "nkIdent"
+                                                    ident: "*"
+                                                  - kind: "nkInfix"
+                                                    sons:
+                                                      - kind: "nkIdent"
+                                                        ident: "*"
+                                                      - kind: "nkInfix"
+                                                        sons:
+                                                          - kind: "nkIdent"
+                                                            ident: "*"
+                                                          - kind: "nkIdent"
+                                                            ident: "a10"
+                                                          - kind: "nkIdent"
+                                                            ident: "a01"
+                                                      - kind: "nkIdent"
+                                                        ident: "a32"
+                                                  - kind: "nkIdent"
+                                                    ident: "a23"
+                                          - kind: "nkInfix"
+                                            sons:
+                                              - kind: "nkIdent"
+                                                ident: "*"
+                                              - kind: "nkInfix"
+                                                sons:
+                                                  - kind: "nkIdent"
+                                                    ident: "*"
+                                                  - kind: "nkInfix"
+                                                    sons:
+                                                      - kind: "nkIdent"
+                                                        ident: "*"
+                                                      - kind: "nkIdent"
+                                                        ident: "a00"
+                                                      - kind: "nkIdent"
+                                                        ident: "a11"
+                                                  - kind: "nkIdent"
+                                                    ident: "a32"
+                                              - kind: "nkIdent"
+                                                ident: "a23"
+                                      - kind: "nkInfix"
+                                        sons:
+                                          - kind: "nkIdent"
+                                            ident: "*"
+                                          - kind: "nkInfix"
+                                            sons:
+                                              - kind: "nkIdent"
+                                                ident: "*"
+                                              - kind: "nkInfix"
+                                                sons:
+                                                  - kind: "nkIdent"
+                                                    ident: "*"
+                                                  - kind: "nkIdent"
+                                                    ident: "a20"
+                                                  - kind: "nkIdent"
+                                                    ident: "a11"
+                                              - kind: "nkIdent"
+                                                ident: "a02"
+                                          - kind: "nkIdent"
+                                            ident: "a33"
+                                  - kind: "nkInfix"
+                                    sons:
+                                      - kind: "nkIdent"
+                                        ident: "*"
+                                      - kind: "nkInfix"
+                                        sons:
+                                          - kind: "nkIdent"
+                                            ident: "*"
+                                          - kind: "nkInfix"
+                                            sons:
+                                              - kind: "nkIdent"
+                                                ident: "*"
+                                              - kind: "nkIdent"
+                                                ident: "a10"
+                                              - kind: "nkIdent"
+                                                ident: "a21"
+                                          - kind: "nkIdent"
+                                            ident: "a02"
+                                      - kind: "nkIdent"
+                                        ident: "a33"
+                              - kind: "nkInfix"
+                                sons:
+                                  - kind: "nkIdent"
+                                    ident: "*"
+                                  - kind: "nkInfix"
+                                    sons:
+                                      - kind: "nkIdent"
+                                        ident: "*"
+                                      - kind: "nkInfix"
+                                        sons:
+                                          - kind: "nkIdent"
+                                            ident: "*"
+                                          - kind: "nkIdent"
+                                            ident: "a20"
+                                          - kind: "nkIdent"
+                                            ident: "a01"
+                                      - kind: "nkIdent"
+                                        ident: "a12"
+                                  - kind: "nkIdent"
+                                    ident: "a33"
+                          - kind: "nkInfix"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: "*"
+                              - kind: "nkInfix"
+                                sons:
+                                  - kind: "nkIdent"
+                                    ident: "*"
+                                  - kind: "nkInfix"
+                                    sons:
+                                      - kind: "nkIdent"
+                                        ident: "*"
+                                      - kind: "nkIdent"
+                                        ident: "a00"
+                                      - kind: "nkIdent"
+                                        ident: "a21"
+                                  - kind: "nkIdent"
+                                    ident: "a12"
+                              - kind: "nkIdent"
+                                ident: "a33"
+                      - kind: "nkInfix"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "*"
+                          - kind: "nkInfix"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: "*"
+                              - kind: "nkInfix"
+                                sons:
+                                  - kind: "nkIdent"
+                                    ident: "*"
+                                  - kind: "nkIdent"
+                                    ident: "a10"
+                                  - kind: "nkIdent"
+                                    ident: "a01"
+                              - kind: "nkIdent"
+                                ident: "a22"
+                          - kind: "nkIdent"
+                            ident: "a33"
+                  - kind: "nkInfix"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "*"
+                      - kind: "nkInfix"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "*"
+                          - kind: "nkInfix"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: "*"
+                              - kind: "nkIdent"
+                                ident: "a00"
+                              - kind: "nkIdent"
+                                ident: "a11"
+                          - kind: "nkIdent"
+                            ident: "a22"
+                      - kind: "nkIdent"
+                        ident: "a33"
+  - kind: "nkIfStmt"
+    sons:
+      - kind: "nkElifBranch"
+        sons:
+          - kind: "nkInfix"
+            sons:
+              - kind: "nkIdent"
+                ident: "and"
+              - kind: "nkInfix"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "and"
+                  - kind: "nkInfix"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "and"
+                      - kind: "nkInfix"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "and"
+                          - kind: "nkIdent"
+                            ident: "aaaaaaaaaaaaaaaaaaaa"
+                          - kind: "nkIdent"
+                            ident: "bbbbbbbbbbbbbbbbbbbbbbb"
+                      - kind: "nkIdent"
+                        ident: "ccccccccccccccccccccccccc"
+                  - kind: "nkIdent"
+                    ident: "ddddddddddddddddd"
+              - kind: "nkIdent"
+                ident: "fffffffffffffffff"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+  - kind: "nkIfStmt"
+    sons:
+      - kind: "nkElifBranch"
+        sons:
+          - kind: "nkInfix"
+            sons:
+              - kind: "nkIdent"
+                ident: "or"
+              - kind: "nkPar"
+                sons:
+                  - kind: "nkInfix"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "and"
+                      - kind: "nkIdent"
+                        ident: "aaaaaaaaaaaaaaaa"
+                      - kind: "nkIdent"
+                        ident: "bbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+              - kind: "nkPar"
+                sons:
+                  - kind: "nkInfix"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "and"
+                      - kind: "nkIdent"
+                        ident: "ccccccccccccccccccccccccccc"
+                      - kind: "nkIdent"
+                        ident: "ddddddddddddddddddddd"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+      - kind: "nkElifBranch"
+        sons:
+          - kind: "nkInfix"
+            sons:
+              - kind: "nkIdent"
+                ident: "and"
+              - kind: "nkIdent"
+                ident: "aaaaaaaaa"
+              - kind: "nkPar"
+                sons:
+                  - kind: "nkInfix"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "or"
+                      - kind: "nkIdent"
+                        ident: "bbbbbbbbbb"
+                      - kind: "nkInfix"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "and"
+                          - kind: "nkIdent"
+                            ident: "cccccccccccc"
+                          - kind: "nkPar"
+                            sons:
+                              - kind: "nkInfix"
+                                sons:
+                                  - kind: "nkIdent"
+                                    ident: "or"
+                                  - kind: "nkInfix"
+                                    sons:
+                                      - kind: "nkIdent"
+                                        ident: "or"
+                                      - kind: "nkInfix"
+                                        sons:
+                                          - kind: "nkIdent"
+                                            ident: "or"
+                                          - kind: "nkIdent"
+                                            ident: "dddddddddddddddd"
+                                          - kind: "nkIdent"
+                                            ident: "eeeeeeeeeeeeeee"
+                                      - kind: "nkIdent"
+                                        ident: "fffffffffffffff"
+                                  - kind: "nkIdent"
+                                    ident: "gggggggggggggg"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+  - kind: "nkCaseStmt"
+    sons:
+      - kind: "nkIdent"
+        ident: "aaaaaaaaaa"
+      - kind: "nkOfBranch"
+        sons:
+          - kind: "nkIdent"
+            ident: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+          - kind: "nkIdent"
+            ident: "bbbbbbbbbbbbbbbbbbbbbbbbbb"
+          - kind: "nkIdent"
+            ident: "ccccccccccccccccccccccc"
+          - kind: "nkIdent"
+            ident: "ddddddddddddddddddddddd"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+      - kind: "nkOfBranch"
+        sons:
+          - kind: "nkIdent"
+            ident: "aaaa"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+      - kind: "nkOfBranch"
+        sons:
+          - kind: "nkIdent"
+            ident: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+          - kind: "nkIdent"
+            ident: "bbbbbbbbbbbbbbbbbbbbbbbbbb"
+          - kind: "nkIdent"
+            ident: "ccccccccccccccccccccccc"
+          - kind: "nkIdent"
+            ident: "dddddddddddddddddddddd"
+          - kind: "nkIdent"
+            ident: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+          - kind: "nkIdent"
+            ident: "bbbbbbbbbbbbbbbbbbbbbbbbbb"
+          - kind: "nkIdent"
+            ident: "ccccccccccccccccccccccc"
+          - kind: "nkIdent"
+            ident: "dddddddddddddddddddddd"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+      - kind: "nkElse"
+        sons:
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"

--- a/tests/before/import.nim.nph.yaml
+++ b/tests/before/import.nim.nph.yaml
@@ -1,449 +1,209 @@
-{
-  "kind": "nkStmtList",
-  "sons": [
-    {
-      "kind": "nkImportStmt",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "tables"
-        }
-      ]
-    },
-    {
-      "kind": "nkImportStmt",
-      "sons": [
-        {
-          "kind": "nkInfix",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "/"
-            },
-            {
-              "kind": "nkStrLit",
-              "strVal": "."
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "tables"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkImportStmt",
-      "sons": [
-        {
-          "kind": "nkInfix",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "/"
-            },
-            {
-              "kind": "nkStrLit",
-              "strVal": "."
-            },
-            {
-              "kind": "nkBracket",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "tables"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "sets"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkImportStmt",
-      "sons": [
-        {
-          "kind": "nkInfix",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "as"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "sets"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "dummies"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkImportStmt",
-      "sons": [
-        {
-          "kind": "nkInfix",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "as"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "aaaaaaaaaaaaaa"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "bbbbbbbbbbbbbb"
-            }
-          ]
-        },
-        {
-          "kind": "nkInfix",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "as"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "ccccccccccccc"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "dddddddddddddd"
-            }
-          ]
-        },
-        {
-          "kind": "nkInfix",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "as"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "eeeeeeeeeeeee"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "fffffffffffffff"
-            }
-          ]
-        },
-        {
-          "kind": "nkInfix",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "as"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "gggggggggggggggggg"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "hhhhhhhhhhhhhhhh"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkImportStmt",
-      "sons": [
-        {
-          "kind": "nkInfix",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "/"
-            },
-            {
-              "kind": "nkStrLit",
-              "strVal": "."
-            },
-            {
-              "kind": "nkBracket",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "tables"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "sets"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "long"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "modules"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "even"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "more"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "more"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "a_really_long_module_here"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "more"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "more"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "more"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "more"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "more"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkImportStmt",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "tables"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "sets"
-        }
-      ]
-    },
-    {
-      "kind": "nkFromStmt",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "tables"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "Xxx"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "yyy"
-        }
-      ]
-    },
-    {
-      "kind": "nkExportStmt",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "a"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "b"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "c"
-        }
-      ]
-    },
-    {
-      "kind": "nkExportStmt",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "bbbbbbbbbbbbbbbbbbbbbbbb"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "cccccccccccccccccccc"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "dddddddddddddddddd"
-        }
-      ]
-    },
-    {
-      "kind": "nkIncludeStmt",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "a"
-        }
-      ]
-    },
-    {
-      "kind": "nkIncludeStmt",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "aaaaaaaaaaaaaaaaaaaa"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "bbbbbbbbbbbbbbbbbbbbbbbbbbb"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "ccccccccccccccccccccccccc"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "dddddddddddddddddd"
-        }
-      ]
-    },
-    {
-      "kind": "nkImportStmt",
-      "sons": [
-        {
-          "kind": "nkInfix",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "/"
-            },
-            {
-              "kind": "nkStrLit",
-              "strVal": "a"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-            }
-          ]
-        },
-        {
-          "kind": "nkInfix",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "/"
-            },
-            {
-              "kind": "nkStrLit",
-              "strVal": "ccccccccccccccccccccccccc"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "dddddddddddddddddddddd"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkFromStmt",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "a"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "a"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "b"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "c"
-        }
-      ]
-    },
-    {
-      "kind": "nkFromStmt",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "aaaaaaaaaaaaaaaaaaaaaa"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "bbbbbbbbbbbbbbb"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "cccccccccccccccc"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "ddddddddddddddd"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "eeeeeeeeeeeeeeeeeeeeeee"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "ffffffffffffff"
-        }
-      ]
-    },
-    {
-      "kind": "nkPragma",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "push"
-        },
-        {
-          "kind": "nkExprColonExpr",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "raises"
-            },
-            {
-              "kind": "nkBracket"
-            }
-          ]
-        }
-      ]
-    }
-  ]
-}
+kind: "nkStmtList"
+sons:
+  - kind: "nkImportStmt"
+    sons:
+      - kind: "nkIdent"
+        ident: "tables"
+  - kind: "nkImportStmt"
+    sons:
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: "/"
+          - kind: "nkStrLit"
+            strVal: "."
+          - kind: "nkIdent"
+            ident: "tables"
+  - kind: "nkImportStmt"
+    sons:
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: "/"
+          - kind: "nkStrLit"
+            strVal: "."
+          - kind: "nkBracket"
+            sons:
+              - kind: "nkIdent"
+                ident: "tables"
+              - kind: "nkIdent"
+                ident: "sets"
+  - kind: "nkImportStmt"
+    sons:
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: "as"
+          - kind: "nkIdent"
+            ident: "sets"
+          - kind: "nkIdent"
+            ident: "dummies"
+  - kind: "nkImportStmt"
+    sons:
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: "as"
+          - kind: "nkIdent"
+            ident: "aaaaaaaaaaaaaa"
+          - kind: "nkIdent"
+            ident: "bbbbbbbbbbbbbb"
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: "as"
+          - kind: "nkIdent"
+            ident: "ccccccccccccc"
+          - kind: "nkIdent"
+            ident: "dddddddddddddd"
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: "as"
+          - kind: "nkIdent"
+            ident: "eeeeeeeeeeeee"
+          - kind: "nkIdent"
+            ident: "fffffffffffffff"
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: "as"
+          - kind: "nkIdent"
+            ident: "gggggggggggggggggg"
+          - kind: "nkIdent"
+            ident: "hhhhhhhhhhhhhhhh"
+  - kind: "nkImportStmt"
+    sons:
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: "/"
+          - kind: "nkStrLit"
+            strVal: "."
+          - kind: "nkBracket"
+            sons:
+              - kind: "nkIdent"
+                ident: "tables"
+              - kind: "nkIdent"
+                ident: "sets"
+              - kind: "nkIdent"
+                ident: "long"
+              - kind: "nkIdent"
+                ident: "modules"
+              - kind: "nkIdent"
+                ident: "even"
+              - kind: "nkIdent"
+                ident: "more"
+              - kind: "nkIdent"
+                ident: "more"
+              - kind: "nkIdent"
+                ident: "a_really_long_module_here"
+              - kind: "nkIdent"
+                ident: "more"
+              - kind: "nkIdent"
+                ident: "more"
+              - kind: "nkIdent"
+                ident: "more"
+              - kind: "nkIdent"
+                ident: "more"
+              - kind: "nkIdent"
+                ident: "more"
+  - kind: "nkImportStmt"
+    sons:
+      - kind: "nkIdent"
+        ident: "tables"
+      - kind: "nkIdent"
+        ident: "sets"
+  - kind: "nkFromStmt"
+    sons:
+      - kind: "nkIdent"
+        ident: "tables"
+      - kind: "nkIdent"
+        ident: "Xxx"
+      - kind: "nkIdent"
+        ident: "yyy"
+  - kind: "nkExportStmt"
+    sons:
+      - kind: "nkIdent"
+        ident: "a"
+      - kind: "nkIdent"
+        ident: "b"
+      - kind: "nkIdent"
+        ident: "c"
+  - kind: "nkExportStmt"
+    sons:
+      - kind: "nkIdent"
+        ident: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      - kind: "nkIdent"
+        ident: "bbbbbbbbbbbbbbbbbbbbbbbb"
+      - kind: "nkIdent"
+        ident: "cccccccccccccccccccc"
+      - kind: "nkIdent"
+        ident: "dddddddddddddddddd"
+  - kind: "nkIncludeStmt"
+    sons:
+      - kind: "nkIdent"
+        ident: "a"
+  - kind: "nkIncludeStmt"
+    sons:
+      - kind: "nkIdent"
+        ident: "aaaaaaaaaaaaaaaaaaaa"
+      - kind: "nkIdent"
+        ident: "bbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      - kind: "nkIdent"
+        ident: "ccccccccccccccccccccccccc"
+      - kind: "nkIdent"
+        ident: "dddddddddddddddddd"
+  - kind: "nkImportStmt"
+    sons:
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: "/"
+          - kind: "nkStrLit"
+            strVal: "a"
+          - kind: "nkIdent"
+            ident: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: "/"
+          - kind: "nkStrLit"
+            strVal: "ccccccccccccccccccccccccc"
+          - kind: "nkIdent"
+            ident: "dddddddddddddddddddddd"
+  - kind: "nkFromStmt"
+    sons:
+      - kind: "nkIdent"
+        ident: "a"
+      - kind: "nkIdent"
+        ident: "a"
+      - kind: "nkIdent"
+        ident: "b"
+      - kind: "nkIdent"
+        ident: "c"
+  - kind: "nkFromStmt"
+    sons:
+      - kind: "nkIdent"
+        ident: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      - kind: "nkIdent"
+        ident: "aaaaaaaaaaaaaaaaaaaaaa"
+      - kind: "nkIdent"
+        ident: "bbbbbbbbbbbbbbb"
+      - kind: "nkIdent"
+        ident: "cccccccccccccccc"
+      - kind: "nkIdent"
+        ident: "ddddddddddddddd"
+      - kind: "nkIdent"
+        ident: "eeeeeeeeeeeeeeeeeeeeeee"
+      - kind: "nkIdent"
+        ident: "ffffffffffffff"
+  - kind: "nkPragma"
+    sons:
+      - kind: "nkIdent"
+        ident: "push"
+      - kind: "nkExprColonExpr"
+        sons:
+          - kind: "nkIdent"
+            ident: "raises"
+          - kind: "nkBracket"

--- a/tests/before/procs.nim.nph.yaml
+++ b/tests/before/procs.nim.nph.yaml
@@ -1,1956 +1,818 @@
-{
-  "kind": "nkStmtList",
-  "sons": [
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "a"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkStmtList",
-          "sons": [
-            {
-              "kind": "nkDiscardStmt",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "a"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "v"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "int"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkStmtList",
-          "sons": [
-            {
-              "kind": "nkDiscardStmt",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "a"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "aaaaaaaaaaaaaaaaaaaaaaa"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "bbbbbbbbbbbbbbbbbbbbbb"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "ccccccccccccccccccccccccccc"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "vvvvvvvvvvvvvvvvvvvvvv"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "string"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkStmtList",
-          "sons": [
-            {
-              "kind": "nkDiscardStmt",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "a"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "aaaaaaaaaaaaaaaaaaaaaaa"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "int"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "bbbbbbbbbbbbbbbbbbbbbb"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "int"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "ccccccccccccccccccccccccccc"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "int"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "vvvvvvvvvvvvvvvvvvvvvv"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "string"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkStmtList",
-          "sons": [
-            {
-              "kind": "nkDiscardStmt",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "a"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "Ddddddddddddddddddddddddd"
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "aaaaaaaaaaaaaaaaaaaaaaa"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "bbbbbbbbbbbbbbbbbbbbbb"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "cccccccccccccccc"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "string"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkStmtList",
-          "sons": [
-            {
-              "kind": "nkDiscardStmt",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "a"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "v"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "int"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkPragma",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "nimcall"
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkStmtList",
-          "sons": [
-            {
-              "kind": "nkDiscardStmt",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "a"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "v"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "int"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkPragma",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "nimcall"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "pragma2"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "pragma3"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "praaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagma"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "rrr"
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkStmtList",
-          "sons": [
-            {
-              "kind": "nkDiscardStmt",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "v"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "int"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkStmtList",
-          "sons": [
-            {
-              "kind": "nkDiscardStmt",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkPostfix",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "*"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "aaa"
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "v"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "int"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "aaa"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkGenericParams",
-          "sons": [
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "A"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "B"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "C"
-                },
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "v"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "int"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkPostfix",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "*"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "aaaa"
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkGenericParams",
-          "sons": [
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "A"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "B"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "C"
-                },
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "v"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "int"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "aaaaa"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkGenericParams",
-          "sons": [
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "A"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "B"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "C"
-                },
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "aaaaaaaaaaaaaaaaaaaaaaaaaaa"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "bbbbbbbbbbbbbbbbbbb"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "cccccccccccccccc"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "ddddddddddddddddddd"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "int"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkPostfix",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "*"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "aaaa"
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkGenericParams",
-          "sons": [
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "Aaaaaaaaaaaaaaaaaaaaaaaa"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "Bbbbbbbbbbbbbbbbbbbbbbbbbb"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "Cccccccccccccccccccccc"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "Dddddddddddddddddddddd"
-                },
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "v"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "int"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkPostfix",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "*"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "aaaaaaaaa"
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkGenericParams",
-          "sons": [
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "Aaaaaaaaaaaaaaaaaaaaaaaa"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "Bbbbbbbbbbbbbbbbbbbbbbbbbb"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "Cccccccccccccccccccccc"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "Dddddddddddddddddddddd"
-                },
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "aaaaaaaaaaaaaaaaaaaaaaaaaaa"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "bbbbbbbbbbbbbbbbbbb"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "cccccccccccccccc"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "ddddddddddddddddddd"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "int"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "aaaaaaaa"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkGenericParams",
-          "sons": [
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "T"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "Aaaa"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "v"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "int"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "aaaaaaaa"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkGenericParams",
-          "sons": [
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "Tttttttttttttttttttttttttttttttttttttttttt"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "v"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "int"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "aaaaaaaa"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkGenericParams",
-          "sons": [
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "T"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "Aaaa"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "S"
-                },
-                {
-                  "kind": "nkCommand",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "static"
-                    },
-                    {
-                      "kind": "nkIdent",
-                      "ident": "int"
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "v"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "int"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "aaaaaaaa"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkGenericParams",
-          "sons": [
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "T"
-                },
-                {
-                  "kind": "nkInfix",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "|"
-                    },
-                    {
-                      "kind": "nkInfix",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "|"
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "Aaaaaaaaaaaaaaaaaaaaaaaa"
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "Bbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-                        }
-                      ]
-                    },
-                    {
-                      "kind": "nkIdent",
-                      "ident": "Cccccccccccccccccccccccccc"
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "v"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "int"
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "aaaaaaaaaaa"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "v"
-                },
-                {
-                  "kind": "nkInfix",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "|"
-                    },
-                    {
-                      "kind": "nkInfix",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "|"
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "Bbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-                        }
-                      ]
-                    },
-                    {
-                      "kind": "nkIdent",
-                      "ident": "Cccccccccccccccccccccccccc"
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        }
-      ]
-    },
-    {
-      "kind": "nkCommand",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-        },
-        {
-          "kind": "nkInfix",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "+"
-            },
-            {
-              "kind": "nkInfix",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "+"
-                },
-                {
-                  "kind": "nkIntLit",
-                  "intVal": 42
-                },
-                {
-                  "kind": "nkIntLit",
-                  "intVal": 33
-                }
-              ]
-            },
-            {
-              "kind": "nkIntLit",
-              "intVal": 44
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkCall",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "functionCall"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "aaaaaaaaaaaaaaaaaaaaaa"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "aaaaaaaaaaaaaaaaaa"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "aaaaaaaaaaaaaaaaaaa"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "aaaaaaaaaaaaaaaaaaaaaaa"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "aaaaaaaaaaaaa"
-        }
-      ]
-    },
-    {
-      "kind": "nkCall",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "aaaaaaaaaaaaaaa"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "aaaaaaaaaaaaaaaaaaa"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "aaaaaaaaaaaaaaaaa"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "aaaaaaaaaaaaaaaaaaaaa"
-        }
-      ]
-    },
-    {
-      "kind": "nkCall",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "aasdcsaa"
-        },
-        {
-          "kind": "nkExprEqExpr",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "aaaaaaaaaa"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "bbbbbbbbbbb"
-            }
-          ]
-        },
-        {
-          "kind": "nkExprEqExpr",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "ccccccccccc"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "ddddddddddddd"
-            }
-          ]
-        },
-        {
-          "kind": "nkExprEqExpr",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "eeeeeeeeeeee"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "ffffffffffff"
-            }
-          ]
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "gggggg"
-        },
-        {
-          "kind": "nkIdent",
-          "ident": "hhhhhhhh"
-        }
-      ]
-    },
-    {
-      "kind": "nkTypeSection",
-      "sons": [
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "Ap"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkProcTy",
-              "sons": [
-                {
-                  "kind": "nkFormalParams",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkTypeSection",
-      "sons": [
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "Bp"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkProcTy"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkTypeSection",
-      "sons": [
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "Cp"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkProcTy",
-              "sons": [
-                {
-                  "kind": "nkFormalParams",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    },
-                    {
-                      "kind": "nkIdentDefs",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "v"
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "int"
-                        },
-                        {
-                          "kind": "nkEmpty"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkTypeSection",
-      "sons": [
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "Dp"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkProcTy",
-              "sons": [
-                {
-                  "kind": "nkFormalParams",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkPragma",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "nimcall"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkTypeSection",
-      "sons": [
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "Ep"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkProcTy",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkPragma",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "nimcall"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkTypeSection",
-      "sons": [
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkProcTy",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkPragma",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "bbbbbbbbbbbbbbbbbbbbbbbb"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkTypeSection",
-      "sons": [
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkProcTy",
-              "sons": [
-                {
-                  "kind": "nkFormalParams",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    },
-                    {
-                      "kind": "nkIdentDefs",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "aaaaaaaa"
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "Bbbbbbb"
-                        },
-                        {
-                          "kind": "nkEmpty"
-                        }
-                      ]
-                    },
-                    {
-                      "kind": "nkIdentDefs",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "ccccccccc"
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "Dddddddddddd"
-                        },
-                        {
-                          "kind": "nkEmpty"
-                        }
-                      ]
-                    },
-                    {
-                      "kind": "nkIdentDefs",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "eeeeee"
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "Ffffff"
-                        },
-                        {
-                          "kind": "nkEmpty"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkTypeSection",
-      "sons": [
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkProcTy",
-              "sons": [
-                {
-                  "kind": "nkFormalParams",
-                  "sons": [
-                    {
-                      "kind": "nkEmpty"
-                    },
-                    {
-                      "kind": "nkIdentDefs",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "aaaaaaaa"
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "Bbbbbbb"
-                        },
-                        {
-                          "kind": "nkEmpty"
-                        }
-                      ]
-                    },
-                    {
-                      "kind": "nkIdentDefs",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "ccccccccc"
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "Dddddddddddd"
-                        },
-                        {
-                          "kind": "nkEmpty"
-                        }
-                      ]
-                    },
-                    {
-                      "kind": "nkIdentDefs",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "eeeeeeeeeeeee"
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "Ffffffffffffffff"
-                        },
-                        {
-                          "kind": "nkEmpty"
-                        }
-                      ]
-                    },
-                    {
-                      "kind": "nkIdentDefs",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "gggggggggggggg"
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "Hhhhhhhhhhhhhhhhhhhh"
-                        },
-                        {
-                          "kind": "nkEmpty"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
-  ]
-}
+kind: "nkStmtList"
+sons:
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "a"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "a"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "v"
+              - kind: "nkIdent"
+                ident: "int"
+              - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "a"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "aaaaaaaaaaaaaaaaaaaaaaa"
+              - kind: "nkIdent"
+                ident: "bbbbbbbbbbbbbbbbbbbbbb"
+              - kind: "nkIdent"
+                ident: "ccccccccccccccccccccccccccc"
+              - kind: "nkIdent"
+                ident: "vvvvvvvvvvvvvvvvvvvvvv"
+              - kind: "nkIdent"
+                ident: "string"
+              - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "a"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "aaaaaaaaaaaaaaaaaaaaaaa"
+              - kind: "nkIdent"
+                ident: "int"
+              - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "bbbbbbbbbbbbbbbbbbbbbb"
+              - kind: "nkIdent"
+                ident: "int"
+              - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "ccccccccccccccccccccccccccc"
+              - kind: "nkIdent"
+                ident: "int"
+              - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "vvvvvvvvvvvvvvvvvvvvvv"
+              - kind: "nkIdent"
+                ident: "string"
+              - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "a"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkIdent"
+            ident: "Ddddddddddddddddddddddddd"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "aaaaaaaaaaaaaaaaaaaaaaa"
+              - kind: "nkIdent"
+                ident: "bbbbbbbbbbbbbbbbbbbbbb"
+              - kind: "nkIdent"
+                ident: "cccccccccccccccc"
+              - kind: "nkIdent"
+                ident: "string"
+              - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "a"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "v"
+              - kind: "nkIdent"
+                ident: "int"
+              - kind: "nkEmpty"
+      - kind: "nkPragma"
+        sons:
+          - kind: "nkIdent"
+            ident: "nimcall"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "a"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "v"
+              - kind: "nkIdent"
+                ident: "int"
+              - kind: "nkEmpty"
+      - kind: "nkPragma"
+        sons:
+          - kind: "nkIdent"
+            ident: "nimcall"
+          - kind: "nkIdent"
+            ident: "pragma2"
+          - kind: "nkIdent"
+            ident: "pragma3"
+          - kind: "nkIdent"
+            ident: "praaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagma"
+          - kind: "nkIdent"
+            ident: "rrr"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "v"
+              - kind: "nkIdent"
+                ident: "int"
+              - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkPostfix"
+        sons:
+          - kind: "nkIdent"
+            ident: "*"
+          - kind: "nkIdent"
+            ident: "aaa"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "v"
+              - kind: "nkIdent"
+                ident: "int"
+              - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "aaa"
+      - kind: "nkEmpty"
+      - kind: "nkGenericParams"
+        sons:
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "A"
+              - kind: "nkIdent"
+                ident: "B"
+              - kind: "nkIdent"
+                ident: "C"
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "v"
+              - kind: "nkIdent"
+                ident: "int"
+              - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkPostfix"
+        sons:
+          - kind: "nkIdent"
+            ident: "*"
+          - kind: "nkIdent"
+            ident: "aaaa"
+      - kind: "nkEmpty"
+      - kind: "nkGenericParams"
+        sons:
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "A"
+              - kind: "nkIdent"
+                ident: "B"
+              - kind: "nkIdent"
+                ident: "C"
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "v"
+              - kind: "nkIdent"
+                ident: "int"
+              - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "aaaaa"
+      - kind: "nkEmpty"
+      - kind: "nkGenericParams"
+        sons:
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "A"
+              - kind: "nkIdent"
+                ident: "B"
+              - kind: "nkIdent"
+                ident: "C"
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "aaaaaaaaaaaaaaaaaaaaaaaaaaa"
+              - kind: "nkIdent"
+                ident: "bbbbbbbbbbbbbbbbbbb"
+              - kind: "nkIdent"
+                ident: "cccccccccccccccc"
+              - kind: "nkIdent"
+                ident: "ddddddddddddddddddd"
+              - kind: "nkIdent"
+                ident: "int"
+              - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkPostfix"
+        sons:
+          - kind: "nkIdent"
+            ident: "*"
+          - kind: "nkIdent"
+            ident: "aaaa"
+      - kind: "nkEmpty"
+      - kind: "nkGenericParams"
+        sons:
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "Aaaaaaaaaaaaaaaaaaaaaaaa"
+              - kind: "nkIdent"
+                ident: "Bbbbbbbbbbbbbbbbbbbbbbbbbb"
+              - kind: "nkIdent"
+                ident: "Cccccccccccccccccccccc"
+              - kind: "nkIdent"
+                ident: "Dddddddddddddddddddddd"
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "v"
+              - kind: "nkIdent"
+                ident: "int"
+              - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkPostfix"
+        sons:
+          - kind: "nkIdent"
+            ident: "*"
+          - kind: "nkIdent"
+            ident: "aaaaaaaaa"
+      - kind: "nkEmpty"
+      - kind: "nkGenericParams"
+        sons:
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "Aaaaaaaaaaaaaaaaaaaaaaaa"
+              - kind: "nkIdent"
+                ident: "Bbbbbbbbbbbbbbbbbbbbbbbbbb"
+              - kind: "nkIdent"
+                ident: "Cccccccccccccccccccccc"
+              - kind: "nkIdent"
+                ident: "Dddddddddddddddddddddd"
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "aaaaaaaaaaaaaaaaaaaaaaaaaaa"
+              - kind: "nkIdent"
+                ident: "bbbbbbbbbbbbbbbbbbb"
+              - kind: "nkIdent"
+                ident: "cccccccccccccccc"
+              - kind: "nkIdent"
+                ident: "ddddddddddddddddddd"
+              - kind: "nkIdent"
+                ident: "int"
+              - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "aaaaaaaa"
+      - kind: "nkEmpty"
+      - kind: "nkGenericParams"
+        sons:
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "T"
+              - kind: "nkIdent"
+                ident: "Aaaa"
+              - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "v"
+              - kind: "nkIdent"
+                ident: "int"
+              - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "aaaaaaaa"
+      - kind: "nkEmpty"
+      - kind: "nkGenericParams"
+        sons:
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "Tttttttttttttttttttttttttttttttttttttttttt"
+              - kind: "nkIdent"
+                ident: "Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+              - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "v"
+              - kind: "nkIdent"
+                ident: "int"
+              - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "aaaaaaaa"
+      - kind: "nkEmpty"
+      - kind: "nkGenericParams"
+        sons:
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "T"
+              - kind: "nkIdent"
+                ident: "Aaaa"
+              - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "S"
+              - kind: "nkCommand"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "static"
+                  - kind: "nkIdent"
+                    ident: "int"
+              - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "v"
+              - kind: "nkIdent"
+                ident: "int"
+              - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "aaaaaaaa"
+      - kind: "nkEmpty"
+      - kind: "nkGenericParams"
+        sons:
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "T"
+              - kind: "nkInfix"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "|"
+                  - kind: "nkInfix"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "|"
+                      - kind: "nkIdent"
+                        ident: "Aaaaaaaaaaaaaaaaaaaaaaaa"
+                      - kind: "nkIdent"
+                        ident: "Bbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                  - kind: "nkIdent"
+                    ident: "Cccccccccccccccccccccccccc"
+              - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "v"
+              - kind: "nkIdent"
+                ident: "int"
+              - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "aaaaaaaaaaa"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "v"
+              - kind: "nkInfix"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "|"
+                  - kind: "nkInfix"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "|"
+                      - kind: "nkIdent"
+                        ident: "Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                      - kind: "nkIdent"
+                        ident: "Bbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                  - kind: "nkIdent"
+                    ident: "Cccccccccccccccccccccccccc"
+              - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+  - kind: "nkCommand"
+    sons:
+      - kind: "nkIdent"
+        ident: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: "+"
+          - kind: "nkInfix"
+            sons:
+              - kind: "nkIdent"
+                ident: "+"
+              - kind: "nkIntLit"
+                intVal: 42
+              - kind: "nkIntLit"
+                intVal: 33
+          - kind: "nkIntLit"
+            intVal: 44
+  - kind: "nkCall"
+    sons:
+      - kind: "nkIdent"
+        ident: "functionCall"
+      - kind: "nkIdent"
+        ident: "aaaaaaaaaaaaaaaaaaaaaa"
+      - kind: "nkIdent"
+        ident: "aaaaaaaaaaaaaaaaaa"
+      - kind: "nkIdent"
+        ident: "aaaaaaaaaaaaaaaaaaa"
+      - kind: "nkIdent"
+        ident: "aaaaaaaaaaaaaaaaaaaaaaa"
+      - kind: "nkIdent"
+        ident: "aaaaaaaaaaaaa"
+  - kind: "nkCall"
+    sons:
+      - kind: "nkIdent"
+        ident: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      - kind: "nkIdent"
+        ident: "aaaaaaaaaaaaaaa"
+      - kind: "nkIdent"
+        ident: "aaaaaaaaaaaaaaaaaaa"
+      - kind: "nkIdent"
+        ident: "aaaaaaaaaaaaaaaaa"
+      - kind: "nkIdent"
+        ident: "aaaaaaaaaaaaaaaaaaaaa"
+  - kind: "nkCall"
+    sons:
+      - kind: "nkIdent"
+        ident: "aasdcsaa"
+      - kind: "nkExprEqExpr"
+        sons:
+          - kind: "nkIdent"
+            ident: "aaaaaaaaaa"
+          - kind: "nkIdent"
+            ident: "bbbbbbbbbbb"
+      - kind: "nkExprEqExpr"
+        sons:
+          - kind: "nkIdent"
+            ident: "ccccccccccc"
+          - kind: "nkIdent"
+            ident: "ddddddddddddd"
+      - kind: "nkExprEqExpr"
+        sons:
+          - kind: "nkIdent"
+            ident: "eeeeeeeeeeee"
+          - kind: "nkIdent"
+            ident: "ffffffffffff"
+      - kind: "nkIdent"
+        ident: "gggggg"
+      - kind: "nkIdent"
+        ident: "hhhhhhhh"
+  - kind: "nkTypeSection"
+    sons:
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkIdent"
+            ident: "Ap"
+          - kind: "nkEmpty"
+          - kind: "nkProcTy"
+            sons:
+              - kind: "nkFormalParams"
+                sons:
+                  - kind: "nkEmpty"
+              - kind: "nkEmpty"
+  - kind: "nkTypeSection"
+    sons:
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkIdent"
+            ident: "Bp"
+          - kind: "nkEmpty"
+          - kind: "nkProcTy"
+  - kind: "nkTypeSection"
+    sons:
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkIdent"
+            ident: "Cp"
+          - kind: "nkEmpty"
+          - kind: "nkProcTy"
+            sons:
+              - kind: "nkFormalParams"
+                sons:
+                  - kind: "nkEmpty"
+                  - kind: "nkIdentDefs"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "v"
+                      - kind: "nkIdent"
+                        ident: "int"
+                      - kind: "nkEmpty"
+              - kind: "nkEmpty"
+  - kind: "nkTypeSection"
+    sons:
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkIdent"
+            ident: "Dp"
+          - kind: "nkEmpty"
+          - kind: "nkProcTy"
+            sons:
+              - kind: "nkFormalParams"
+                sons:
+                  - kind: "nkEmpty"
+              - kind: "nkPragma"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "nimcall"
+  - kind: "nkTypeSection"
+    sons:
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkIdent"
+            ident: "Ep"
+          - kind: "nkEmpty"
+          - kind: "nkProcTy"
+            sons:
+              - kind: "nkEmpty"
+              - kind: "nkPragma"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "nimcall"
+  - kind: "nkTypeSection"
+    sons:
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkIdent"
+            ident: "Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+          - kind: "nkEmpty"
+          - kind: "nkProcTy"
+            sons:
+              - kind: "nkEmpty"
+              - kind: "nkPragma"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "bbbbbbbbbbbbbbbbbbbbbbbb"
+  - kind: "nkTypeSection"
+    sons:
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkIdent"
+            ident: "Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+          - kind: "nkEmpty"
+          - kind: "nkProcTy"
+            sons:
+              - kind: "nkFormalParams"
+                sons:
+                  - kind: "nkEmpty"
+                  - kind: "nkIdentDefs"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "aaaaaaaa"
+                      - kind: "nkIdent"
+                        ident: "Bbbbbbb"
+                      - kind: "nkEmpty"
+                  - kind: "nkIdentDefs"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "ccccccccc"
+                      - kind: "nkIdent"
+                        ident: "Dddddddddddd"
+                      - kind: "nkEmpty"
+                  - kind: "nkIdentDefs"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "eeeeee"
+                      - kind: "nkIdent"
+                        ident: "Ffffff"
+                      - kind: "nkEmpty"
+              - kind: "nkEmpty"
+  - kind: "nkTypeSection"
+    sons:
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkIdent"
+            ident: "Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+          - kind: "nkEmpty"
+          - kind: "nkProcTy"
+            sons:
+              - kind: "nkFormalParams"
+                sons:
+                  - kind: "nkEmpty"
+                  - kind: "nkIdentDefs"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "aaaaaaaa"
+                      - kind: "nkIdent"
+                        ident: "Bbbbbbb"
+                      - kind: "nkEmpty"
+                  - kind: "nkIdentDefs"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "ccccccccc"
+                      - kind: "nkIdent"
+                        ident: "Dddddddddddd"
+                      - kind: "nkEmpty"
+                  - kind: "nkIdentDefs"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "eeeeeeeeeeeee"
+                      - kind: "nkIdent"
+                        ident: "Ffffffffffffffff"
+                      - kind: "nkEmpty"
+                  - kind: "nkIdentDefs"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "gggggggggggggg"
+                      - kind: "nkIdent"
+                        ident: "Hhhhhhhhhhhhhhhhhhhh"
+                      - kind: "nkEmpty"
+              - kind: "nkEmpty"

--- a/tests/before/types.nim.nph.yaml
+++ b/tests/before/types.nim.nph.yaml
@@ -1,434 +1,189 @@
-{
-  "kind": "nkStmtList",
-  "sons": [
-    {
-      "kind": "nkTypeSection",
-      "sons": [
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "A"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIdent",
-              "ident": "int"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkTypeSection",
-      "sons": [
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "B"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkInfix",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "|"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "A"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "B"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkTypeSection",
-      "sons": [
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "Bbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkInfix",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "|"
-                },
-                {
-                  "kind": "nkInfix",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "|"
-                    },
-                    {
-                      "kind": "nkInfix",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "|"
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "Aaaaaaaaaaaaaa"
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "Bbbbbbbbbbbbbbbbb"
-                        }
-                      ]
-                    },
-                    {
-                      "kind": "nkIdent",
-                      "ident": "Cccccccccccccccccccccc"
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "Dddddddddddddddddddddd"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkTypeSection",
-      "sons": [
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "A"
-            },
-            {
-              "kind": "nkGenericParams",
-              "sons": [
-                {
-                  "kind": "nkIdentDefs",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "T"
-                    },
-                    {
-                      "kind": "nkInfix",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "|"
-                        },
-                        {
-                          "kind": "nkInfix",
-                          "sons": [
-                            {
-                              "kind": "nkIdent",
-                              "ident": "|"
-                            },
-                            {
-                              "kind": "nkInfix",
-                              "sons": [
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "|"
-                                },
-                                {
-                                  "kind": "nkInfix",
-                                  "sons": [
-                                    {
-                                      "kind": "nkIdent",
-                                      "ident": "|"
-                                    },
-                                    {
-                                      "kind": "nkIdent",
-                                      "ident": "Aaaaaaaaaaaaaaaaaaa"
-                                    },
-                                    {
-                                      "kind": "nkIdent",
-                                      "ident": "Bbbbbbbbbbbbbbbbbbbbbbbb"
-                                    }
-                                  ]
-                                },
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "Cccccccccccccccccccc"
-                                }
-                              ]
-                            },
-                            {
-                              "kind": "nkIdent",
-                              "ident": "Dddddddddddddddd"
-                            }
-                          ]
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "Eeeeeeeeeeeeeeeeeee"
-                        }
-                      ]
-                    },
-                    {
-                      "kind": "nkEmpty"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "kind": "nkBracketExpr",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "Bbbbbbbbbbbbbbbbbb"
-                },
-                {
-                  "kind": "nkIdent",
-                  "ident": "T"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "nkProcDef",
-      "sons": [
-        {
-          "kind": "nkIdent",
-          "ident": "f"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkFormalParams",
-          "sons": [
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkIdentDefs",
-              "sons": [
-                {
-                  "kind": "nkIdent",
-                  "ident": "a"
-                },
-                {
-                  "kind": "nkInfix",
-                  "sons": [
-                    {
-                      "kind": "nkIdent",
-                      "ident": "|"
-                    },
-                    {
-                      "kind": "nkInfix",
-                      "sons": [
-                        {
-                          "kind": "nkIdent",
-                          "ident": "|"
-                        },
-                        {
-                          "kind": "nkInfix",
-                          "sons": [
-                            {
-                              "kind": "nkIdent",
-                              "ident": "|"
-                            },
-                            {
-                              "kind": "nkInfix",
-                              "sons": [
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "|"
-                                },
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "Aaaaaaaaaaaaaaaaaaaaaaa"
-                                },
-                                {
-                                  "kind": "nkIdent",
-                                  "ident": "Bbbbbbbbbbbbbbbbbbbbbb"
-                                }
-                              ]
-                            },
-                            {
-                              "kind": "nkIdent",
-                              "ident": "Ccccccccccccccccccccccccccc"
-                            }
-                          ]
-                        },
-                        {
-                          "kind": "nkIdent",
-                          "ident": "Ddddddddddddddddddddddddd"
-                        }
-                      ]
-                    },
-                    {
-                      "kind": "nkIdent",
-                      "ident": "Eeeeeeeeeeeeeeeee"
-                    }
-                  ]
-                },
-                {
-                  "kind": "nkEmpty"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        },
-        {
-          "kind": "nkEmpty"
-        }
-      ]
-    },
-    {
-      "kind": "nkTypeSection",
-      "sons": [
-        {
-          "kind": "nkTypeDef",
-          "sons": [
-            {
-              "kind": "nkIdent",
-              "ident": "CaseObject"
-            },
-            {
-              "kind": "nkEmpty"
-            },
-            {
-              "kind": "nkObjectTy",
-              "sons": [
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkEmpty"
-                },
-                {
-                  "kind": "nkRecList",
-                  "sons": [
-                    {
-                      "kind": "nkRecCase",
-                      "sons": [
-                        {
-                          "kind": "nkIdentDefs",
-                          "sons": [
-                            {
-                              "kind": "nkIdent",
-                              "ident": "f"
-                            },
-                            {
-                              "kind": "nkIdent",
-                              "ident": "bool"
-                            },
-                            {
-                              "kind": "nkEmpty"
-                            }
-                          ]
-                        },
-                        {
-                          "kind": "nkOfBranch",
-                          "sons": [
-                            {
-                              "kind": "nkIdent",
-                              "ident": "false"
-                            },
-                            {
-                              "kind": "nkRecList",
-                              "sons": [
-                                {
-                                  "kind": "nkIdentDefs",
-                                  "sons": [
-                                    {
-                                      "kind": "nkIdent",
-                                      "ident": "vfalse"
-                                    },
-                                    {
-                                      "kind": "nkIdent",
-                                      "ident": "int"
-                                    },
-                                    {
-                                      "kind": "nkEmpty"
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        },
-                        {
-                          "kind": "nkOfBranch",
-                          "sons": [
-                            {
-                              "kind": "nkIdent",
-                              "ident": "true"
-                            },
-                            {
-                              "kind": "nkRecList",
-                              "sons": [
-                                {
-                                  "kind": "nkIdentDefs",
-                                  "sons": [
-                                    {
-                                      "kind": "nkIdent",
-                                      "ident": "vtrue"
-                                    },
-                                    {
-                                      "kind": "nkIdent",
-                                      "ident": "int"
-                                    },
-                                    {
-                                      "kind": "nkEmpty"
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
-  ]
-}
+kind: "nkStmtList"
+sons:
+  - kind: "nkTypeSection"
+    sons:
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkIdent"
+            ident: "A"
+          - kind: "nkEmpty"
+          - kind: "nkIdent"
+            ident: "int"
+  - kind: "nkTypeSection"
+    sons:
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkIdent"
+            ident: "B"
+          - kind: "nkEmpty"
+          - kind: "nkInfix"
+            sons:
+              - kind: "nkIdent"
+                ident: "|"
+              - kind: "nkIdent"
+                ident: "A"
+              - kind: "nkIdent"
+                ident: "B"
+  - kind: "nkTypeSection"
+    sons:
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkIdent"
+            ident: "Bbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+          - kind: "nkEmpty"
+          - kind: "nkInfix"
+            sons:
+              - kind: "nkIdent"
+                ident: "|"
+              - kind: "nkInfix"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "|"
+                  - kind: "nkInfix"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "|"
+                      - kind: "nkIdent"
+                        ident: "Aaaaaaaaaaaaaa"
+                      - kind: "nkIdent"
+                        ident: "Bbbbbbbbbbbbbbbbb"
+                  - kind: "nkIdent"
+                    ident: "Cccccccccccccccccccccc"
+              - kind: "nkIdent"
+                ident: "Dddddddddddddddddddddd"
+  - kind: "nkTypeSection"
+    sons:
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkIdent"
+            ident: "A"
+          - kind: "nkGenericParams"
+            sons:
+              - kind: "nkIdentDefs"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "T"
+                  - kind: "nkInfix"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "|"
+                      - kind: "nkInfix"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "|"
+                          - kind: "nkInfix"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: "|"
+                              - kind: "nkInfix"
+                                sons:
+                                  - kind: "nkIdent"
+                                    ident: "|"
+                                  - kind: "nkIdent"
+                                    ident: "Aaaaaaaaaaaaaaaaaaa"
+                                  - kind: "nkIdent"
+                                    ident: "Bbbbbbbbbbbbbbbbbbbbbbbb"
+                              - kind: "nkIdent"
+                                ident: "Cccccccccccccccccccc"
+                          - kind: "nkIdent"
+                            ident: "Dddddddddddddddd"
+                      - kind: "nkIdent"
+                        ident: "Eeeeeeeeeeeeeeeeeee"
+                  - kind: "nkEmpty"
+          - kind: "nkBracketExpr"
+            sons:
+              - kind: "nkIdent"
+                ident: "Bbbbbbbbbbbbbbbbbb"
+              - kind: "nkIdent"
+                ident: "T"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "f"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "a"
+              - kind: "nkInfix"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "|"
+                  - kind: "nkInfix"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "|"
+                      - kind: "nkInfix"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "|"
+                          - kind: "nkInfix"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: "|"
+                              - kind: "nkIdent"
+                                ident: "Aaaaaaaaaaaaaaaaaaaaaaa"
+                              - kind: "nkIdent"
+                                ident: "Bbbbbbbbbbbbbbbbbbbbbb"
+                          - kind: "nkIdent"
+                            ident: "Ccccccccccccccccccccccccccc"
+                      - kind: "nkIdent"
+                        ident: "Ddddddddddddddddddddddddd"
+                  - kind: "nkIdent"
+                    ident: "Eeeeeeeeeeeeeeeee"
+              - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+  - kind: "nkTypeSection"
+    sons:
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkIdent"
+            ident: "CaseObject"
+          - kind: "nkEmpty"
+          - kind: "nkObjectTy"
+            sons:
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkRecList"
+                sons:
+                  - kind: "nkRecCase"
+                    sons:
+                      - kind: "nkIdentDefs"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "f"
+                          - kind: "nkIdent"
+                            ident: "bool"
+                          - kind: "nkEmpty"
+                      - kind: "nkOfBranch"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "false"
+                          - kind: "nkRecList"
+                            sons:
+                              - kind: "nkIdentDefs"
+                                sons:
+                                  - kind: "nkIdent"
+                                    ident: "vfalse"
+                                  - kind: "nkIdent"
+                                    ident: "int"
+                                  - kind: "nkEmpty"
+                      - kind: "nkOfBranch"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "true"
+                          - kind: "nkRecList"
+                            sons:
+                              - kind: "nkIdentDefs"
+                                sons:
+                                  - kind: "nkIdent"
+                                    ident: "vtrue"
+                                  - kind: "nkIdent"
+                                    ident: "int"
+                                  - kind: "nkEmpty"

--- a/vscode-nph/LICENSE.txt
+++ b/vscode-nph/LICENSE.txt
@@ -1,0 +1,1 @@
+../copying.txt

--- a/vscode-nph/package.json
+++ b/vscode-nph/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-nph",
   "displayName": "nph - Nim code formatter",
   "description": "Opinionated code formatter for Nim",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "publisher": "arnetheduck",
   "engines": {
     "vscode": "^1.85.0"


### PR DESCRIPTION
Based on popular feedback, nph will now retain most empty lines in code as they are often used to signal logical grouping.

Similar to black / prettier and somewhat similar to nimpretty, this PR moves blank line handlng to a "normalisation" strategy where excessive blanks are removed, some blanks are inserted aroound complex statements and user-entered blanks are retained, normalising them to a single line.

* output yaml trees for debugging
* line-break postfix comments
* fix some missing mid comments
* remove comma after `push`