### PR TITLE
the expression (fixes #11)

### DIFF
--- a/src/astcmp.nim
+++ b/src/astcmp.nim
@@ -18,8 +18,9 @@ type
       a*, b*: PNode
 
 proc similarKinds(ak, bk: TNodeKind): bool =
-  ak == bk or (ak in {nkElseExpr, nkElse} and bk in {nkElseExpr, nkElse}) or
-    (ak in {nkElifExpr, nkElifBranch} and bk in {nkElifExpr, nkElifBranch})
+  ak == bk or (ak in {nkElseExpr, nkElse} and bk in {nkElseExpr, nkElse}) or (
+    ak in {nkElifExpr, nkElifBranch} and bk in {nkElifExpr, nkElifBranch}
+  )
 
 proc equivalent*(a, b: PNode): Outcome =
   if not similarKinds(a.kind, b.kind):
@@ -57,11 +58,11 @@ proc equivalent*(a, b: PNode): Outcome =
 
   let eq =
     case a.kind
-    of nkCharLit .. nkUInt64Lit:
+    of nkCharLit..nkUInt64Lit:
       a.intVal == b.intVal
-    of nkFloatLit .. nkFloat128Lit:
+    of nkFloatLit..nkFloat128Lit:
       a.floatVal == b.floatVal
-    of nkStrLit .. nkTripleStrLit:
+    of nkStrLit..nkTripleStrLit:
       a.strVal == b.strVal
     of nkSym:
       raiseAssert "Shouldn't eixst in parser"

--- a/src/astyaml.nim
+++ b/src/astyaml.nim
@@ -19,7 +19,7 @@ proc addYamlString*(res: var string; s: string) =
   res.add "\""
   for c in s:
     case c
-    of '\0' .. '\x1F', '\x7F' .. '\xFF':
+    of '\0'..'\x1F', '\x7F'..'\xFF':
       res.add("\\u" & strutils.toHex(ord(c), 4))
     of '\"', '\\':
       res.add '\\' & c
@@ -156,11 +156,11 @@ proc treeToYamlAux(
       if conf != nil:
         res.addf("\n$1info: $2", [istr, lineInfoToStr(conf, n.info)])
       case n.kind
-      of nkCharLit .. nkInt64Lit:
+      of nkCharLit..nkInt64Lit:
         res.addf("\n$1intVal: $2", [istr, $(n.intVal)])
       of nkFloatLit, nkFloat32Lit, nkFloat64Lit:
         res.addf("\n$1floatVal: $2", [istr, n.floatVal.toStrMaxPrecision])
-      of nkStrLit .. nkTripleStrLit:
+      of nkStrLit..nkTripleStrLit:
         res.addf("\n$1strVal: $2", [istr, makeYamlString(n.strVal)])
       of nkSym:
         res.addf("\n$1sym: ", [istr])
@@ -173,7 +173,7 @@ proc treeToYamlAux(
       else:
         if n.len > 0:
           res.addf("\n$1sons: ", [istr])
-          for i in 0 ..< n.len:
+          for i in 0..<n.len:
             res.addf("\n$1  - ", [istr])
             res.treeToYamlAux(conf, n[i], marker, indent + 1, maxRecDepth - 1)
       if n.typ != nil:

--- a/src/nph.nim
+++ b/src/nph.nim
@@ -3,11 +3,10 @@
 ## Opinionated source code formatter
 
 import
-  "."/
-    [
-      astcmp, astyaml, phast, phastalgo, phmsgs, phlineinfos, phoptions, phparser,
-      phrenderer
-    ]
+  "."/[
+    astcmp, astyaml, phast, phastalgo, phmsgs, phlineinfos, phoptions, phparser,
+    phrenderer
+  ]
 
 import "$nim"/compiler/idents
 

--- a/src/phast.nim
+++ b/src/phast.nim
@@ -499,24 +499,21 @@ const
   tyError* = tyProxy # as an errornous node should match everything
   tyUnknown* = tyFromExpr
   tyUnknownTypes* = {tyError, tyFromExpr}
-  tyTypeClasses* =
-    {
-      tyBuiltInTypeClass, tyCompositeTypeClass, tyUserTypeClass, tyUserTypeClassInst,
-      tyAnd, tyOr, tyNot, tyAnything
-    }
+  tyTypeClasses* = {
+    tyBuiltInTypeClass, tyCompositeTypeClass, tyUserTypeClass, tyUserTypeClassInst,
+    tyAnd, tyOr, tyNot, tyAnything
+  }
   tyMetaTypes* = {tyGenericParam, tyTypeDesc, tyUntyped} + tyTypeClasses
   tyUserTypeClasses* = {tyUserTypeClass, tyUserTypeClassInst}
   # consider renaming as `tyAbstractVarRange`
-  abstractVarRange* =
-    {
-      tyGenericInst, tyRange, tyVar, tyDistinct, tyOrdinal, tyTypeDesc, tyAlias,
-      tyInferred, tySink, tyOwned
-    }
-  abstractInst* =
-    {
-      tyGenericInst, tyDistinct, tyOrdinal, tyTypeDesc, tyAlias, tyInferred, tySink,
-      tyOwned
-    } # xxx what about tyStatic?
+  abstractVarRange* = {
+    tyGenericInst, tyRange, tyVar, tyDistinct, tyOrdinal, tyTypeDesc, tyAlias,
+    tyInferred, tySink, tyOwned
+  }
+  abstractInst* = {
+    tyGenericInst, tyDistinct, tyOrdinal, tyTypeDesc, tyAlias, tyInferred, tySink,
+    tyOwned
+  } # xxx what about tyStatic?
 
 type
   TTypeKinds* = set[TTypeKind]
@@ -679,8 +676,9 @@ type
   TSymKinds* = set[TSymKind]
 
 const
-  routineKinds* =
-    {skProc, skFunc, skMethod, skIterator, skConverter, skMacro, skTemplate}
+  routineKinds* = {
+    skProc, skFunc, skMethod, skIterator, skConverter, skMacro, skTemplate
+  }
   ExportableSymKinds* =
     {skVar, skLet, skConst, skType, skEnumField, skStub} + routineKinds
   tfUnion* = tfNoSideEffect
@@ -689,8 +687,9 @@ const
   tfReturnsNew* = tfInheritable
   skError* = skUnknown
 
-var eqTypeFlags* =
-  {tfIterator, tfNotNil, tfVarIsPtr, tfGcSafe, tfNoSideEffect, tfIsOutParam, tfSendable}
+var eqTypeFlags* = {
+  tfIterator, tfNotNil, tfVarIsPtr, tfGcSafe, tfNoSideEffect, tfIsOutParam, tfSendable
+}
   ## type flags that are essential for type equality.
   ## This is now a variable because for emulation of version:1.0 we
   ## might exclude {tfGcSafe, tfNoSideEffect}.
@@ -979,20 +978,19 @@ type TMagic* = enum # symbols that require compiler magic:
 
 const
   # things that we can evaluate safely at compile time, even if not asked for it:
-  ctfeWhitelist* =
-    {
-      mNone, mSucc, mPred, mInc, mDec, mOrd, mLengthOpenArray, mLengthStr, mLengthArray,
-      mLengthSeq, mArrGet, mArrPut, mAsgn, mDestroy, mIncl, mExcl, mCard, mChr, mAddI,
-      mSubI, mMulI, mDivI, mModI, mAddF64, mSubF64, mMulF64, mDivF64, mShrI, mShlI,
-      mBitandI, mBitorI, mBitxorI, mMinI, mMaxI, mAddU, mSubU, mMulU, mDivU, mModU,
-      mEqI, mLeI, mLtI, mEqF64, mLeF64, mLtF64, mLeU, mLtU, mEqEnum, mLeEnum, mLtEnum,
-      mEqCh, mLeCh, mLtCh, mEqB, mLeB, mLtB, mEqRef, mEqProc, mLePtr, mLtPtr,
-      mEqCString, mXor, mUnaryMinusI, mUnaryMinusI64, mAbsI, mNot, mUnaryPlusI,
-      mBitnotI, mUnaryPlusF64, mUnaryMinusF64, mCharToStr, mBoolToStr, mIntToStr,
-      mInt64ToStr, mFloatToStr, mCStrToStr, mStrToStr, mEnumToStr, mAnd, mOr, mEqStr,
-      mLeStr, mLtStr, mEqSet, mLeSet, mLtSet, mMulSet, mPlusSet, mMinusSet, mConStrStr,
-      mAppendStrCh, mAppendStrStr, mAppendSeqElem, mInSet, mRepr, mOpenArrayToSeq
-    }
+  ctfeWhitelist* = {
+    mNone, mSucc, mPred, mInc, mDec, mOrd, mLengthOpenArray, mLengthStr, mLengthArray,
+    mLengthSeq, mArrGet, mArrPut, mAsgn, mDestroy, mIncl, mExcl, mCard, mChr, mAddI,
+    mSubI, mMulI, mDivI, mModI, mAddF64, mSubF64, mMulF64, mDivF64, mShrI, mShlI,
+    mBitandI, mBitorI, mBitxorI, mMinI, mMaxI, mAddU, mSubU, mMulU, mDivU, mModU, mEqI,
+    mLeI, mLtI, mEqF64, mLeF64, mLtF64, mLeU, mLtU, mEqEnum, mLeEnum, mLtEnum, mEqCh,
+    mLeCh, mLtCh, mEqB, mLeB, mLtB, mEqRef, mEqProc, mLePtr, mLtPtr, mEqCString, mXor,
+    mUnaryMinusI, mUnaryMinusI64, mAbsI, mNot, mUnaryPlusI, mBitnotI, mUnaryPlusF64,
+    mUnaryMinusF64, mCharToStr, mBoolToStr, mIntToStr, mInt64ToStr, mFloatToStr,
+    mCStrToStr, mStrToStr, mEnumToStr, mAnd, mOr, mEqStr, mLeStr, mLtStr, mEqSet,
+    mLeSet, mLtSet, mMulSet, mPlusSet, mMinusSet, mConStrStr, mAppendStrCh,
+    mAppendStrStr, mAppendSeqElem, mInSet, mRepr, mOpenArrayToSeq
+  }
   generatedMagics* = {mNone, mIsolate, mFinished, mOpenArrayToSeq}
     ## magics that are generated as normal procs in the backend
 
@@ -1028,11 +1026,11 @@ type
     info*: TLineInfo
     flags*: TNodeFlags
     case kind*: TNodeKind
-    of nkCharLit .. nkUInt64Lit:
+    of nkCharLit..nkUInt64Lit:
       intVal*: BiggestInt
-    of nkFloatLit .. nkFloat128Lit:
+    of nkFloatLit..nkFloat128Lit:
       floatVal*: BiggestFloat
-    of nkStrLit .. nkTripleStrLit, nkCommentStmt:
+    of nkStrLit..nkTripleStrLit, nkCommentStmt:
       strVal*: string
     of nkSym:
       sym*: PSym
@@ -1288,9 +1286,6 @@ type
     impNo
     impYes
 
-template nodeId(n: PNode): int =
-  cast[int](n)
-
 type Gconfig = object
   # we put comments in a side channel to avoid increasing `sizeof(TNode)`, which
   # reduces memory usage given that `PNode` is the most allocated type by far.
@@ -1305,62 +1300,52 @@ proc setUseIc*(useIc: bool) =
 # same name as an imported module. This is necessary because of
 # the poor naming choices in the standard library.
 const
-  OverloadableSyms* =
-    {
-      skProc, skFunc, skMethod, skIterator, skConverter, skModule, skTemplate, skMacro,
-      skEnumField
-    }
+  OverloadableSyms* = {
+    skProc, skFunc, skMethod, skIterator, skConverter, skModule, skTemplate, skMacro,
+    skEnumField
+  }
   GenericTypes*: TTypeKinds = {tyGenericInvocation, tyGenericBody, tyGenericParam}
-  StructuralEquivTypes*: TTypeKinds =
-    {
-      tyNil, tyTuple, tyArray, tySet, tyRange, tyPtr, tyRef, tyVar, tyLent, tySequence,
-      tyProc, tyOpenArray, tyVarargs
-    }
-  ConcreteTypes*: TTypeKinds =
-    {
-      tyBool,
-      tyChar,
-      tyEnum,
-      tyArray,
-      tyObject,
-      tySet,
-      tyTuple,
-      tyRange,
-      tyPtr,
-      tyRef,
-      tyVar,
-      tyLent,
-      tySequence,
-      tyProc,
-      tyPointer,
-      tyOpenArray,
-      tyString,
-      tyCstring,
-      tyInt .. tyInt64,
-      tyFloat .. tyFloat128,
-      tyUInt .. tyUInt64
-    }
+  StructuralEquivTypes*: TTypeKinds = {
+    tyNil, tyTuple, tyArray, tySet, tyRange, tyPtr, tyRef, tyVar, tyLent, tySequence,
+    tyProc, tyOpenArray, tyVarargs
+  }
+  ConcreteTypes*: TTypeKinds = {
+    tyBool,
+    tyChar,
+    tyEnum,
+    tyArray,
+    tyObject,
+    tySet,
+    tyTuple,
+    tyRange,
+    tyPtr,
+    tyRef,
+    tyVar,
+    tyLent,
+    tySequence,
+    tyProc,
+    tyPointer,
+    tyOpenArray,
+    tyString,
+    tyCstring,
+    tyInt..tyInt64,
+    tyFloat..tyFloat128,
+    tyUInt..tyUInt64
+  }
     # types of the expr that may occur in::
     # var x = expr
-  IntegralTypes* =
-    {
-      tyBool,
-      tyChar,
-      tyEnum,
-      tyInt .. tyInt64,
-      tyFloat .. tyFloat128,
-      tyUInt .. tyUInt64
-    } # weird name because it contains tyFloat
+  IntegralTypes* = {
+    tyBool, tyChar, tyEnum, tyInt..tyInt64, tyFloat..tyFloat128, tyUInt..tyUInt64
+  } # weird name because it contains tyFloat
   ConstantDataTypes*: TTypeKinds = {tyArray, tySet, tyTuple, tySequence}
   NilableTypes*: TTypeKinds = {tyPointer, tyCstring, tyRef, tyPtr, tyProc, tyError}
     # TODO
   PtrLikeKinds*: TTypeKinds = {tyPointer, tyPtr} # for VM
-  PersistentNodeFlags*: TNodeFlags =
-    {
-      nfBase2, nfBase8, nfBase16, nfDotSetter, nfDotField, nfIsRef, nfIsPtr,
-      nfPreventCg, nfLL, nfFromTemplate, nfDefaultRefsParam, nfExecuteOnReload,
-      nfLastRead, nfFirstWrite, nfSkipFieldChecking
-    }
+  PersistentNodeFlags*: TNodeFlags = {
+    nfBase2, nfBase8, nfBase16, nfDotSetter, nfDotField, nfIsRef, nfIsPtr, nfPreventCg,
+    nfLL, nfFromTemplate, nfDefaultRefsParam, nfExecuteOnReload, nfLastRead,
+    nfFirstWrite, nfSkipFieldChecking
+  }
   namePos* = 0
   patternPos* = 1 # empty except for term rewriting macros
   genericParamsPos* = 2
@@ -1371,22 +1356,24 @@ const
   resultPos* = 7
   dispatcherPos* = 8
   nfAllFieldsSet* = nfBase2
-  nkCallKinds* =
-    {nkCall, nkInfix, nkPrefix, nkPostfix, nkCommand, nkCallStrLit, nkHiddenCallConv}
+  nkCallKinds* = {
+    nkCall, nkInfix, nkPrefix, nkPostfix, nkCommand, nkCallStrLit, nkHiddenCallConv
+  }
   nkIdentKinds* = {nkIdent, nkSym, nkAccQuoted, nkOpenSymChoice, nkClosedSymChoice}
   nkPragmaCallKinds* = {nkExprColonExpr, nkCall, nkCallStrLit}
-  nkLiterals* = {nkCharLit .. nkTripleStrLit}
-  nkFloatLiterals* = {nkFloatLit .. nkFloat128Lit}
+  nkLiterals* = {nkCharLit..nkTripleStrLit}
+  nkFloatLiterals* = {nkFloatLit..nkFloat128Lit}
   nkLambdaKinds* = {nkLambda, nkDo}
   declarativeDefs* = {nkProcDef, nkFuncDef, nkMethodDef, nkIteratorDef, nkConverterDef}
   routineDefs* = declarativeDefs + {nkMacroDef, nkTemplateDef}
   procDefs* = nkLambdaKinds + declarativeDefs
   callableDefs* = nkLambdaKinds + routineDefs
   nkSymChoices* = {nkClosedSymChoice, nkOpenSymChoice}
-  nkStrKinds* = {nkStrLit .. nkTripleStrLit}
+  nkStrKinds* = {nkStrLit..nkTripleStrLit}
   skLocalVars* = {skVar, skLet, skForVar, skParam, skResult}
-  skProcKinds* =
-    {skProc, skFunc, skTemplate, skMacro, skIterator, skMethod, skConverter}
+  skProcKinds* = {
+    skProc, skFunc, skTemplate, skMacro, skIterator, skMethod, skConverter
+  }
   defaultSize = -1
   defaultAlignment = -1
   defaultOffset* = -1
@@ -1487,16 +1474,16 @@ proc len*(n: Indexable): int {.inline.} =
 
 proc safeLen*(n: PNode): int {.inline.} =
   ## works even for leaves.
-  if n.kind in {nkNone .. nkNilLit}:
+  if n.kind in {nkNone..nkNilLit}:
     result = 0
   else:
     result = n.len
 
 proc safeArrLen*(n: PNode): int {.inline.} =
   ## works for array-like objects (strings passed as openArray in VM).
-  if n.kind in {nkStrLit .. nkTripleStrLit}:
+  if n.kind in {nkStrLit..nkTripleStrLit}:
     result = n.strVal.len
-  elif n.kind in {nkNone .. nkFloat128Lit}:
+  elif n.kind in {nkNone..nkFloat128Lit}:
     result = 0
   else:
     result = n.len
@@ -1578,7 +1565,7 @@ proc skipPragmaExpr*(n: PNode): PNode =
 proc setInfoRecursive*(n: PNode; info: TLineInfo) =
   ## set line info recursively
   if n != nil:
-    for i in 0 ..< n.safeLen:
+    for i in 0..<n.safeLen:
       setInfoRecursive(n[i], info)
 
     n.info = info
@@ -1751,21 +1738,21 @@ proc copyStrTable*(dest: var TStrTable; src: TStrTable) =
   dest.counter = src.counter
 
   setLen(dest.data, src.data.len)
-  for i in 0 .. high(src.data):
+  for i in 0..high(src.data):
     dest.data[i] = src.data[i]
 
 proc copyIdTable*(dest: var TIdTable; src: TIdTable) =
   dest.counter = src.counter
 
   newSeq(dest.data, src.data.len)
-  for i in 0 .. high(src.data):
+  for i in 0..high(src.data):
     dest.data[i] = src.data[i]
 
 proc copyObjectSet*(dest: var TObjectSet; src: TObjectSet) =
   dest.counter = src.counter
 
   setLen(dest.data, src.data.len)
-  for i in 0 .. high(src.data):
+  for i in 0..high(src.data):
     dest.data[i] = src.data[i]
 
 proc discardSons*(father: PNode) =
@@ -1874,8 +1861,9 @@ proc newProcNode*(
   result = newNodeI(kind, info)
   result.sons = @[name, pattern, genericParams, params, pragmas, exceptions, body]
 
-const AttachedOpToStr*: array[TTypeAttachedOp, string] =
-  ["=wasMoved", "=destroy", "=copy", "=dup", "=sink", "=trace", "=deepcopy"]
+const AttachedOpToStr*: array[TTypeAttachedOp, string] = [
+  "=wasMoved", "=destroy", "=copy", "=dup", "=sink", "=trace", "=deepcopy"
+]
 
 proc `$`*(s: PSym): string =
   if s != nil:
@@ -1936,7 +1924,7 @@ proc assignType*(dest, src: PType) =
       dest.sym = src.sym
 
   newSons(dest, src.len)
-  for i in 0 ..< src.len:
+  for i in 0..<src.len:
     dest[i] = src[i]
 
 proc copyType*(t: PType; id: ItemId; owner: PSym): PType =
@@ -2078,7 +2066,7 @@ proc delSon*(father: PNode; idx: int) =
   if father.len == 0:
     return
 
-  for i in idx ..< father.len - 1:
+  for i in idx..<father.len - 1:
     father[i] = father[i + 1]
 
   father.sons.setLen(father.len - 1)
@@ -2100,17 +2088,17 @@ template transitionNodeKindCommon(k: TNodeKind) =
   when defined(useNodeIds):
     n.id = obj.id
 
-proc transitionSonsKind*(n: PNode; kind: range[nkComesFrom .. nkTupleConstr]) =
+proc transitionSonsKind*(n: PNode; kind: range[nkComesFrom..nkTupleConstr]) =
   transitionNodeKindCommon(kind)
 
   n.sons = obj.sons
 
-proc transitionIntKind*(n: PNode; kind: range[nkCharLit .. nkUInt64Lit]) =
+proc transitionIntKind*(n: PNode; kind: range[nkCharLit..nkUInt64Lit]) =
   transitionNodeKindCommon(kind)
 
   n.intVal = obj.intVal
 
-proc transitionIntToFloatKind*(n: PNode; kind: range[nkFloatLit .. nkFloat128Lit]) =
+proc transitionIntToFloatKind*(n: PNode; kind: range[nkFloatLit..nkFloat128Lit]) =
   transitionNodeKindCommon(kind)
 
   n.floatVal = BiggestFloat(obj.intVal)
@@ -2149,7 +2137,7 @@ template transitionSymKindCommon*(k: TSymKind) =
 proc transitionGenericParamToType*(s: PSym) =
   transitionSymKindCommon(skType)
 
-proc transitionRoutineSymKind*(s: PSym; kind: range[skProc .. skTemplate]) =
+proc transitionRoutineSymKind*(s: PSym; kind: range[skProc..skTemplate]) =
   transitionSymKindCommon(kind)
 
   s.gcUnsafetyReason = obj.gcUnsafetyReason
@@ -2163,14 +2151,14 @@ proc transitionToLet*(s: PSym) =
   s.alignment = obj.alignment
 
 proc hasSonWith*(n: PNode; kind: TNodeKind): bool =
-  for i in 0 ..< n.len:
+  for i in 0..<n.len:
     if n[i].kind == kind:
       return true
 
   result = false
 
 proc hasNilSon*(n: PNode): bool =
-  for i in 0 ..< n.safeLen:
+  for i in 0..<n.safeLen:
     if n[i] == nil:
       return true
     elif hasNilSon(n[i]):
@@ -2183,19 +2171,19 @@ proc containsNode*(n: PNode; kinds: TNodeKinds): bool =
     return
 
   case n.kind
-  of nkEmpty .. nkNilLit:
+  of nkEmpty..nkNilLit:
     result = n.kind in kinds
   else:
-    for i in 0 ..< n.len:
+    for i in 0..<n.len:
       if n.kind in kinds or containsNode(n[i], kinds):
         return true
 
 proc hasSubnodeWith*(n: PNode; kind: TNodeKind): bool =
   case n.kind
-  of nkEmpty .. nkNilLit, nkFormalParams:
+  of nkEmpty..nkNilLit, nkFormalParams:
     result = n.kind == kind
   else:
-    for i in 0 ..< n.len:
+    for i in 0..<n.len:
       if (n[i].kind == kind) or hasSubnodeWith(n[i], kind):
         return true
 
@@ -2203,9 +2191,9 @@ proc hasSubnodeWith*(n: PNode; kind: TNodeKind): bool =
 
 proc getInt*(a: PNode): Int128 =
   case a.kind
-  of nkCharLit, nkUIntLit .. nkUInt64Lit:
+  of nkCharLit, nkUIntLit..nkUInt64Lit:
     result = toInt128(cast[uint64](a.intVal))
-  of nkInt8Lit .. nkInt64Lit:
+  of nkInt8Lit..nkInt64Lit:
     result = toInt128(a.intVal)
   of nkIntLit:
     # XXX: enable this assert
@@ -2216,7 +2204,7 @@ proc getInt*(a: PNode): Int128 =
 
 proc getInt64*(a: PNode): int64 {.deprecated: "use getInt".} =
   case a.kind
-  of nkCharLit, nkUIntLit .. nkUInt64Lit, nkIntLit .. nkInt64Lit:
+  of nkCharLit, nkUIntLit..nkUInt64Lit, nkIntLit..nkInt64Lit:
     result = a.intVal
   else:
     raiseRecoverableError("cannot extract number from invalid AST node")
@@ -2225,7 +2213,7 @@ proc getFloat*(a: PNode): BiggestFloat =
   case a.kind
   of nkFloatLiterals:
     result = a.floatVal
-  of nkCharLit, nkUIntLit .. nkUInt64Lit, nkIntLit .. nkInt64Lit:
+  of nkCharLit, nkUIntLit..nkUInt64Lit, nkIntLit..nkInt64Lit:
     result = BiggestFloat a.intVal
   else:
     raiseRecoverableError("cannot extract number from invalid AST node")
@@ -2235,7 +2223,7 @@ proc getFloat*(a: PNode): BiggestFloat =
 
 proc getStr*(a: PNode): string =
   case a.kind
-  of nkStrLit .. nkTripleStrLit:
+  of nkStrLit..nkTripleStrLit:
     result = a.strVal
   of nkNilLit:
     # let's hope this fixes more problems than it creates:
@@ -2248,9 +2236,9 @@ proc getStr*(a: PNode): string =
 
 proc getStrOrChar*(a: PNode): string =
   case a.kind
-  of nkStrLit .. nkTripleStrLit:
+  of nkStrLit..nkTripleStrLit:
     result = a.strVal
-  of nkCharLit .. nkUInt64Lit:
+  of nkCharLit..nkUInt64Lit:
     result = $chr(int(a.intVal))
   else:
     raiseRecoverableError("cannot extract string from invalid AST node")
@@ -2309,11 +2297,11 @@ proc hasPattern*(s: PSym): bool {.inline.} =
   result = isRoutine(s) and s.ast[patternPos].kind != nkEmpty
 
 iterator items*(n: PNode): PNode =
-  for i in 0 ..< n.safeLen:
+  for i in 0..<n.safeLen:
     yield n[i]
 
 iterator pairs*(n: PNode): tuple[i: int, n: PNode] =
-  for i in 0 ..< n.safeLen:
+  for i in 0..<n.safeLen:
     yield (i, n[i])
 
 proc isAtom*(n: PNode): bool {.inline.} =
@@ -2333,7 +2321,7 @@ proc makeStmtList*(n: PNode): PNode =
 
 proc skipStmtList*(n: PNode): PNode =
   if n.kind in {nkStmtList, nkStmtListExpr}:
-    for i in 0 ..< n.len - 1:
+    for i in 0..<n.len - 1:
       if n[i].kind notin {nkEmpty, nkCommentStmt}:
         return n
 
@@ -2426,7 +2414,7 @@ when false:
     if n.isNil:
       return true
 
-    for i in 0 ..< n.safeLen:
+    for i in 0..<n.safeLen:
       if n[i].containsNil:
         return true
 
@@ -2477,8 +2465,9 @@ proc addParam*(procType: PType; param: PSym) =
 
   rawAddSon(procType, param.typ)
 
-const magicsThatCanRaise =
-  {mNone, mSlurp, mStaticExec, mParseExprToAst, mParseStmtToAst, mEcho}
+const magicsThatCanRaise = {
+  mNone, mSlurp, mStaticExec, mParseExprToAst, mParseStmtToAst, mEcho
+}
 
 proc canRaiseConservative*(fn: PNode): bool =
   if fn.kind == nkSym and fn.sym.magic notin magicsThatCanRaise:
@@ -2487,12 +2476,11 @@ proc canRaiseConservative*(fn: PNode): bool =
     result = true
 
 proc canRaise*(fn: PNode): bool =
-  if fn.kind == nkSym and
-      (
-        fn.sym.magic notin magicsThatCanRaise or
-        {sfImportc, sfInfixCall} * fn.sym.flags == {sfImportc} or
-        sfGeneratedOp in fn.sym.flags
-      ):
+  if fn.kind == nkSym and (
+    fn.sym.magic notin magicsThatCanRaise or
+    {sfImportc, sfInfixCall} * fn.sym.flags == {sfImportc} or
+    sfGeneratedOp in fn.sym.flags
+  ):
     result = false
   elif fn.kind == nkSym and fn.sym.magic == mEcho:
     result = true
@@ -2502,18 +2490,16 @@ proc canRaise*(fn: PNode): bool =
       result = false
     else:
       result =
-        fn.typ != nil and fn.typ.n != nil and
-          (
-            (fn.typ.n[0].len < effectListLen) or
-            (
-              fn.typ.n[0][exceptionEffects] != nil and
-              fn.typ.n[0][exceptionEffects].safeLen > 0
-            )
+        fn.typ != nil and fn.typ.n != nil and (
+          (fn.typ.n[0].len < effectListLen) or (
+            fn.typ.n[0][exceptionEffects] != nil and
+            fn.typ.n[0][exceptionEffects].safeLen > 0
           )
+        )
 
 proc toHumanStrImpl[T](kind: T; num: static int): string =
   result = $kind
-  result = result[num ..^ 1]
+  result = result[num..^1]
   result[0] = result[0].toLowerAscii
 
 proc toHumanStr*(kind: TSymKind): string =
@@ -2538,29 +2524,28 @@ proc isNewStyleConcept*(n: PNode): bool {.inline.} =
 proc isOutParam*(t: PType): bool {.inline.} =
   tfIsOutParam in t.flags
 
-const nodesToIgnoreSet* =
-  {
-    nkNone .. pred(nkSym),
-    succ(nkSym) .. nkNilLit,
-    nkTypeSection,
-    nkProcDef,
-    nkConverterDef,
-    nkMethodDef,
-    nkIteratorDef,
-    nkMacroDef,
-    nkTemplateDef,
-    nkLambda,
-    nkDo,
-    nkFuncDef,
-    nkConstSection,
-    nkConstDef,
-    nkIncludeStmt,
-    nkImportStmt,
-    nkExportStmt,
-    nkPragma,
-    nkCommentStmt,
-    nkBreakState,
-    nkTypeOfExpr,
-    nkMixinStmt,
-    nkBindStmt
-  }
+const nodesToIgnoreSet* = {
+  nkNone..pred(nkSym),
+  succ(nkSym)..nkNilLit,
+  nkTypeSection,
+  nkProcDef,
+  nkConverterDef,
+  nkMethodDef,
+  nkIteratorDef,
+  nkMacroDef,
+  nkTemplateDef,
+  nkLambda,
+  nkDo,
+  nkFuncDef,
+  nkConstSection,
+  nkConstDef,
+  nkIncludeStmt,
+  nkImportStmt,
+  nkExportStmt,
+  nkPragma,
+  nkCommentStmt,
+  nkBreakState,
+  nkTypeOfExpr,
+  nkMixinStmt,
+  nkBindStmt
+}

--- a/src/phastalgo.nim
+++ b/src/phastalgo.nim
@@ -147,14 +147,14 @@ proc skipConvCastAndClosure*(n: PNode): PNode =
 proc sameValue*(a, b: PNode): bool =
   result = false
   case a.kind
-  of nkCharLit .. nkUInt64Lit:
-    if b.kind in {nkCharLit .. nkUInt64Lit}:
+  of nkCharLit..nkUInt64Lit:
+    if b.kind in {nkCharLit..nkUInt64Lit}:
       result = getInt(a) == getInt(b)
-  of nkFloatLit .. nkFloat64Lit:
-    if b.kind in {nkFloatLit .. nkFloat64Lit}:
+  of nkFloatLit..nkFloat64Lit:
+    if b.kind in {nkFloatLit..nkFloat64Lit}:
       result = a.floatVal == b.floatVal
-  of nkStrLit .. nkTripleStrLit:
-    if b.kind in {nkStrLit .. nkTripleStrLit}:
+  of nkStrLit..nkTripleStrLit:
+    if b.kind in {nkStrLit..nkTripleStrLit}:
       result = a.strVal == b.strVal
   else:
     # don't raise an internal error for 'nim check':
@@ -165,14 +165,14 @@ proc leValue*(a, b: PNode): bool =
   # a <= b?
   result = false
   case a.kind
-  of nkCharLit .. nkUInt64Lit:
-    if b.kind in {nkCharLit .. nkUInt64Lit}:
+  of nkCharLit..nkUInt64Lit:
+    if b.kind in {nkCharLit..nkUInt64Lit}:
       result = getInt(a) <= getInt(b)
-  of nkFloatLit .. nkFloat64Lit:
-    if b.kind in {nkFloatLit .. nkFloat64Lit}:
+  of nkFloatLit..nkFloat64Lit:
+    if b.kind in {nkFloatLit..nkFloat64Lit}:
       result = a.floatVal <= b.floatVal
-  of nkStrLit .. nkTripleStrLit:
-    if b.kind in {nkStrLit .. nkTripleStrLit}:
+  of nkStrLit..nkTripleStrLit:
+    if b.kind in {nkStrLit..nkTripleStrLit}:
       result = a.strVal <= b.strVal
   else:
     # don't raise an internal error for 'nim check':
@@ -193,7 +193,7 @@ proc lookupInRecord(n: PNode; field: PIdent): PSym =
   result = nil
   case n.kind
   of nkRecList:
-    for i in 0 ..< n.len:
+    for i in 0..<n.len:
       result = lookupInRecord(n[i], field)
       if result != nil:
         return
@@ -205,7 +205,7 @@ proc lookupInRecord(n: PNode; field: PIdent): PSym =
     if result != nil:
       return
 
-    for i in 1 ..< n.len:
+    for i in 1..<n.len:
       case n[i].kind
       of nkOfBranch, nkElse:
         result = lookupInRecord(lastSon(n[i]), field)
@@ -230,7 +230,7 @@ proc fromSystem*(op: PSym): bool {.inline.} =
   sfSystemModule in getModule(op).flags
 
 proc getSymFromList*(list: PNode; ident: PIdent; start: int = 0): PSym =
-  for i in start ..< list.len:
+  for i in start..<list.len:
     if list[i].kind == nkSym:
       result = list[i].sym
       if result.name.id == ident.id:
@@ -295,7 +295,7 @@ proc getNamedParamFromList*(list: PNode; ident: PIdent): PSym =
   ##   result.add newIdentNode(getIdent(c.ic, x.name.s & "\`gensym" & $x.id),
   ##            if c.instLines: actual.info else: templ.info)
   ##   ```
-  for i in 1 ..< list.len:
+  for i in 1..<list.len:
     let it = list[i].sym
     if it.name.id == ident.id or sameIgnoreBacktickGensymInfo(it.name.s, ident.s):
       return it
@@ -314,7 +314,7 @@ proc rspaces(x: int): Rope =
 
 proc toYamlChar(c: char): string =
   case c
-  of '\0' .. '\x1F', '\x7F' .. '\xFF':
+  of '\0'..'\x1F', '\x7F'..'\xFF':
     result = "\\u" & strutils.toHex(ord(c), 4)
   of '\"', '\\':
     result = '\\' & c
@@ -330,7 +330,7 @@ proc makeYamlString*(s: string): Rope =
   result = ""
 
   var res = "\""
-  for i in 0 ..< s.len:
+  for i in 0..<s.len:
     if (i + 1) mod MaxLineLength == 0:
       res.add('\"')
       res.add("\n")
@@ -358,12 +358,11 @@ proc flagsToStr[T](flags: set[T]): Rope =
 
 proc lineInfoToStr(conf: ConfigRef; info: TLineInfo): Rope =
   result =
-    "[$1, $2, $3]" %
-      [
-        makeYamlString(toFilename(conf, info)),
-        rope(toLinenumber(info)),
-        rope(toColumn(info))
-      ]
+    "[$1, $2, $3]" % [
+      makeYamlString(toFilename(conf, info)),
+      rope(toLinenumber(info)),
+      rope(toColumn(info))
+    ]
 
 proc treeToYamlAux(
   conf: ConfigRef; n: PNode; marker: var IntSet; indent, maxRecDepth: int
@@ -437,7 +436,7 @@ proc typeToYamlAux(
   else:
     if n.len > 0:
       sonsRope = rope("[")
-      for i in 0 ..< n.len:
+      for i in 0..<n.len:
         if i > 0:
           sonsRope.add(",")
 
@@ -491,20 +490,20 @@ proc treeToYamlAux(
 
       if n.prefix.len > 0:
         result.addf("$N$1prefix:", [istr])
-        for i in 0 ..< n.prefix.len:
+        for i in 0..<n.prefix.len:
           result.addf("$N$1  - $2", [istr, makeYamlString($(n.prefix[i]))])
 
       if n.mid.len > 0:
         result.addf("$N$1mid:", [istr])
-        for i in 0 ..< n.mid.len:
+        for i in 0..<n.mid.len:
           result.addf("$N$1  - $2", [istr, makeYamlString($(n.mid[i]))])
 
       case n.kind
-      of nkCharLit .. nkUInt64Lit:
+      of nkCharLit..nkUInt64Lit:
         result.addf("$N$1intVal: $2", [istr, rope(n.intVal)])
-      of nkFloatLit .. nkFloat128Lit:
+      of nkFloatLit..nkFloat128Lit:
         result.addf("$N$1floatVal: $2", [istr, rope(n.floatVal.toStrMaxPrecision)])
-      of nkStrLit .. nkTripleStrLit:
+      of nkStrLit..nkTripleStrLit:
         result.addf("$N$1strVal: $2", [istr, makeYamlString(n.strVal)])
       of nkSym:
         result.addf(
@@ -521,7 +520,7 @@ proc treeToYamlAux(
       else:
         if n.len > 0:
           result.addf("$N$1sons:", [istr])
-          for i in 0 ..< n.len:
+          for i in 0..<n.len:
             result.addf(
               "$N$1  - $2",
               [istr, treeToYamlAux(conf, n[i], marker, indent + 4, maxRecDepth - 1)],
@@ -535,7 +534,7 @@ proc treeToYamlAux(
 
       if n.postfix.len > 0:
         result.addf("$N$1postfix:", [istr])
-        for i in 0 ..< n.postfix.len:
+        for i in 0..<n.postfix.len:
           result.addf("$N$1  - $2", [istr, makeYamlString($n.postfix[i])])
 
 proc treeToYaml(conf: ConfigRef; n: PNode; indent: int = 0; maxRecDepth: int = -1): Rope =
@@ -581,7 +580,7 @@ proc newlineAndIndent(this: var DebugPrinter) =
   this.res.add "\n"
 
   this.currentLine += 1
-  for i in 0 ..< this.indent:
+  for i in 0..<this.indent:
     this.res.add ' '
 
 proc openCurly(this: var DebugPrinter) =
@@ -741,7 +740,7 @@ proc value(this: var DebugPrinter; value: PType) =
     this.key "sons"
 
     this.openBracket
-    for i in 0 ..< value.len:
+    for i in 0..<value.len:
       this.value value[i]
       if i != value.len - 1:
         this.comma
@@ -785,13 +784,13 @@ proc value(this: var DebugPrinter; value: PNode) =
     this.value "nil"
 
   case value.kind
-  of nkCharLit .. nkUInt64Lit:
+  of nkCharLit..nkUInt64Lit:
     this.key "intVal"
     this.value value.intVal
   of nkFloatLit, nkFloat32Lit, nkFloat64Lit:
     this.key "floatVal"
     this.value value.floatVal.toStrMaxPrecision
-  of nkStrLit .. nkTripleStrLit:
+  of nkStrLit..nkTripleStrLit:
     this.key "strVal"
     this.value value.strVal
   of nkSym:
@@ -810,7 +809,7 @@ proc value(this: var DebugPrinter; value: PNode) =
       this.key "sons"
 
       this.openBracket
-      for i in 0 ..< value.len:
+      for i in 0..<value.len:
         this.value value[i]
         if i != value.len - 1:
           this.comma
@@ -881,7 +880,7 @@ proc objectSetEnlarge(t: var TObjectSet) =
   var n: TObjectSeq
 
   newSeq(n, t.data.len * GrowthFactor)
-  for i in 0 .. high(t.data):
+  for i in 0..high(t.data):
     if t.data[i] != nil:
       objectSetRawInsert(n, t.data[i])
 
@@ -964,7 +963,7 @@ proc strTableEnlarge(t: var TStrTable) =
   var n: seq[PSym]
 
   newSeq(n, t.data.len * GrowthFactor)
-  for i in 0 .. high(t.data):
+  for i in 0..high(t.data):
     if t.data[i] != nil:
       strTableRawInsert(n, t.data[i])
 
@@ -1142,7 +1141,7 @@ iterator items*(tab: TStrTable): PSym =
     s = nextIter(it, tab)
 
 proc hasEmptySlot(data: TIdPairSeq): bool =
-  for h in 0 .. high(data):
+  for h in 0..high(data):
     if data[h].key == nil:
       return true
 
@@ -1182,7 +1181,7 @@ proc idTableGet(t: TIdTable; key: int): RootRef =
     result = nil
 
 iterator pairs*(t: TIdTable): tuple[key: int, value: RootRef] =
-  for i in 0 .. high(t.data):
+  for i in 0..high(t.data):
     if t.data[i].key != nil:
       yield (t.data[i].key.id, t.data[i].val)
 
@@ -1213,7 +1212,7 @@ proc idTablePut(t: var TIdTable; key: PIdObj; val: RootRef) =
   else:
     if mustRehash(t.data.len, t.counter):
       newSeq(n, t.data.len * GrowthFactor)
-      for i in 0 .. high(t.data):
+      for i in 0..high(t.data):
         if t.data[i].key != nil:
           idTableRawInsert(n, t.data[i].key, t.data[i].val)
 
@@ -1224,7 +1223,7 @@ proc idTablePut(t: var TIdTable; key: PIdObj; val: RootRef) =
     inc(t.counter)
 
 iterator idTablePairs*(t: TIdTable): tuple[key: PIdObj, val: RootRef] =
-  for i in 0 .. high(t.data):
+  for i in 0..high(t.data):
     if not isNil(t.data[i].key):
       yield (t.data[i].key, t.data[i].val)
 
@@ -1274,7 +1273,7 @@ proc idNodeTablePut(t: var TIdNodeTable; key: PIdObj; val: PNode) =
       var n: TIdNodePairSeq
 
       newSeq(n, t.data.len * GrowthFactor)
-      for i in 0 .. high(t.data):
+      for i in 0..high(t.data):
         if t.data[i].key != nil:
           idNodeTableRawInsert(n, t.data[i].key, t.data[i].val)
 
@@ -1284,7 +1283,7 @@ proc idNodeTablePut(t: var TIdNodeTable; key: PIdObj; val: PNode) =
     inc(t.counter)
 
 iterator pairs*(t: TIdNodeTable): tuple[key: PIdObj, val: PNode] =
-  for i in 0 .. high(t.data):
+  for i in 0..high(t.data):
     if not isNil(t.data[i].key):
       yield (t.data[i].key, t.data[i].val)
 
@@ -1292,7 +1291,7 @@ proc initIITable(x: var TIITable) =
   x.counter = 0
 
   newSeq(x.data, StartSize)
-  for i in 0 ..< StartSize:
+  for i in 0..<StartSize:
     x.data[i].key = InvalidKey
 
 proc iiTableRawGet(t: TIITable; key: int): int =
@@ -1339,10 +1338,10 @@ proc iiTablePut(t: var TIITable; key, val: int) =
       var n: TIIPairSeq
 
       newSeq(n, t.data.len * GrowthFactor)
-      for i in 0 .. high(n):
+      for i in 0..high(n):
         n[i].key = InvalidKey
 
-      for i in 0 .. high(t.data):
+      for i in 0..high(t.data):
         if t.data[i].key != InvalidKey:
           iiTableRawInsert(n, t.data[i].key, t.data[i].val)
 

--- a/src/phlexer.nim
+++ b/src/phlexer.nim
@@ -34,14 +34,13 @@ when defined(nimPreviewSlimSystem):
   import std/[assertions, formatfloat]
 
 const
-  numChars*: set[char] = {'0' .. '9', 'a' .. 'z', 'A' .. 'Z'}
-  SymChars*: set[char] = {'a' .. 'z', 'A' .. 'Z', '0' .. '9', '\x80' .. '\xFF'}
-  SymStartChars*: set[char] = {'a' .. 'z', 'A' .. 'Z', '\x80' .. '\xFF'}
-  OpChars*: set[char] =
-    {
-      '+', '-', '*', '/', '\\', '<', '>', '!', '?', '^', '.', '|', '=', '%', '&', '$',
-      '@', '~', ':'
-    }
+  numChars*: set[char] = {'0'..'9', 'a'..'z', 'A'..'Z'}
+  SymChars*: set[char] = {'a'..'z', 'A'..'Z', '0'..'9', '\x80'..'\xFF'}
+  SymStartChars*: set[char] = {'a'..'z', 'A'..'Z', '\x80'..'\xFF'}
+  OpChars*: set[char] = {
+    '+', '-', '*', '/', '\\', '<', '>', '!', '?', '^', '.', '|', '=', '%', '&', '$',
+    '@', '~', ':'
+  }
   UnaryMinusWhitelist = {' ', '\t', '\n', '\r', ',', ';', '(', '[', '{'}
 # don't forget to update the 'highlite' module if these charsets should change
 
@@ -259,13 +258,13 @@ proc isNimIdentifier*(s: string): bool =
 
 proc `$`*(tok: Token): string =
   case tok.tokType
-  of tkIntLit .. tkInt64Lit:
+  of tkIntLit..tkInt64Lit:
     $tok.iNumber
-  of tkFloatLit .. tkFloat64Lit:
+  of tkFloatLit..tkFloat64Lit:
     $tok.fNumber
-  of tkInvalid, tkStrLit .. tkCharLit, tkComment:
+  of tkInvalid, tkStrLit..tkCharLit, tkComment:
     tok.literal
-  of tkParLe .. tkColon, tkEof, tkAccent:
+  of tkParLe..tkColon, tkEof, tkAccent:
     $tok.tokType
   else:
     if tok.ident != nil:
@@ -412,7 +411,7 @@ proc getNumber(L: var Lexer; result: var Token) =
       L: var Lexer; msg: string; startpos: int; msgKind = errGenerated
   ) =
     # Used to get slightly human friendlier err messages.
-    const literalishChars = {'A' .. 'Z', 'a' .. 'z', '0' .. '9', '_', '.', '\''}
+    const literalishChars = {'A'..'Z', 'a'..'z', '0'..'9', '_', '.', '\''}
 
     var msgPos = L.bufpos
     var t: Token
@@ -430,7 +429,7 @@ proc getNumber(L: var Lexer; result: var Token) =
     if L.buf[L.bufpos] in literalishChars:
       t.literal.add(L.buf[L.bufpos])
       inc(L.bufpos)
-      matchChars(L, t, {'0' .. '9'})
+      matchChars(L, t, {'0'..'9'})
 
     L.bufpos = msgPos
 
@@ -444,7 +443,7 @@ proc getNumber(L: var Lexer; result: var Token) =
   const
     # 'c', 'C' is deprecated
     baseCodeChars = {'X', 'x', 'o', 'b', 'B', 'c', 'C'}
-    literalishChars = baseCodeChars + {'A' .. 'F', 'a' .. 'f', '0' .. '9', '_', '\''}
+    literalishChars = baseCodeChars + {'A'..'F', 'a'..'f', '0'..'9', '_', '\''}
     floatTypes = {tkFloatLit, tkFloat32Lit, tkFloat64Lit, tkFloat128Lit}
 
   result.tokType = tkIntLit # int literal until we know better
@@ -462,11 +461,11 @@ proc getNumber(L: var Lexer; result: var Token) =
   let startpos = L.bufpos
 
   template setNumber(field, value) =
-    field =
-      (if isPositive:
+    field = (
+      if isPositive:
         value
       else: -value
-      )
+    )
 
   # First stage: find out base, make verifications, build token literal string
   # {'c', 'C'} is added for deprecation reasons to provide a clear error message
@@ -486,7 +485,7 @@ proc getNumber(L: var Lexer; result: var Token) =
 
       eatChar(L, result, 'c')
 
-      numDigits = matchUnderscoreChars(L, result, {'0' .. '7'})
+      numDigits = matchUnderscoreChars(L, result, {'0'..'7'})
     of 'O':
       lexMessageLitNum(
         L,
@@ -496,28 +495,28 @@ proc getNumber(L: var Lexer; result: var Token) =
     of 'x', 'X':
       eatChar(L, result, 'x')
 
-      numDigits = matchUnderscoreChars(L, result, {'0' .. '9', 'a' .. 'f', 'A' .. 'F'})
+      numDigits = matchUnderscoreChars(L, result, {'0'..'9', 'a'..'f', 'A'..'F'})
     of 'o':
       eatChar(L, result, 'o')
 
-      numDigits = matchUnderscoreChars(L, result, {'0' .. '7'})
+      numDigits = matchUnderscoreChars(L, result, {'0'..'7'})
     of 'b', 'B':
       eatChar(L, result, 'b')
 
-      numDigits = matchUnderscoreChars(L, result, {'0' .. '1'})
+      numDigits = matchUnderscoreChars(L, result, {'0'..'1'})
     else:
       internalError(L.config, getLineInfo(L), "getNumber")
 
     if numDigits == 0:
       lexMessageLitNum(L, "invalid number: '$1'", startpos)
   else:
-    discard matchUnderscoreChars(L, result, {'0' .. '9'})
-    if (L.buf[L.bufpos] == '.') and (L.buf[L.bufpos + 1] in {'0' .. '9'}):
+    discard matchUnderscoreChars(L, result, {'0'..'9'})
+    if (L.buf[L.bufpos] == '.') and (L.buf[L.bufpos + 1] in {'0'..'9'}):
       result.tokType = tkFloatLit
 
       eatChar(L, result, '.')
 
-      discard matchUnderscoreChars(L, result, {'0' .. '9'})
+      discard matchUnderscoreChars(L, result, {'0'..'9'})
 
     if L.buf[L.bufpos] in {'e', 'E'}:
       result.tokType = tkFloatLit
@@ -526,7 +525,7 @@ proc getNumber(L: var Lexer; result: var Token) =
       if L.buf[L.bufpos] in {'+', '-'}:
         eatChar(L, result)
 
-      discard matchUnderscoreChars(L, result, {'0' .. '9'})
+      discard matchUnderscoreChars(L, result, {'0'..'9'})
 
   let endpos = L.bufpos
   # Second stage, find out if there's a datatype suffix and handle it
@@ -588,8 +587,9 @@ proc getNumber(L: var Lexer; result: var Token) =
     else:
       lexMessageLitNum(L, "invalid number suffix: '$1'", errPos)
   # Is there still a literalish char awaiting? Then it's an error!
-  if L.buf[postPos] in literalishChars or
-      (L.buf[postPos] == '.' and L.buf[postPos + 1] in {'0' .. '9'}):
+  if L.buf[postPos] in literalishChars or (
+    L.buf[postPos] == '.' and L.buf[postPos + 1] in {'0'..'9'}
+  ):
     lexMessageLitNum(L, "invalid number: '$1'", startpos)
 
   if result.tokType != tkCustomLit:
@@ -623,15 +623,15 @@ proc getNumber(L: var Lexer; result: var Token) =
             case L.buf[pos]
             of '_':
               inc(pos)
-            of '0' .. '9':
+            of '0'..'9':
               xi = `shl`(xi, 4) or (ord(L.buf[pos]) - ord('0'))
 
               inc(pos)
-            of 'a' .. 'f':
+            of 'a'..'f':
               xi = `shl`(xi, 4) or (ord(L.buf[pos]) - ord('a') + 10)
 
               inc(pos)
-            of 'A' .. 'F':
+            of 'A'..'F':
               xi = `shl`(xi, 4) or (ord(L.buf[pos]) - ord('A') + 10)
 
               inc(pos)
@@ -742,7 +742,7 @@ proc getNumber(L: var Lexer; result: var Token) =
 
   L.bufpos = postPos
 
-proc handleHexChar(L: var Lexer; xi: var int; position: range[0 .. 4]) =
+proc handleHexChar(L: var Lexer; xi: var int; position: range[0..4]) =
   template invalid() =
     lexMessage(
       L,
@@ -751,15 +751,15 @@ proc handleHexChar(L: var Lexer; xi: var int; position: range[0 .. 4]) =
     )
 
   case L.buf[L.bufpos]
-  of '0' .. '9':
+  of '0'..'9':
     xi = (xi shl 4) or (ord(L.buf[L.bufpos]) - ord('0'))
 
     inc(L.bufpos)
-  of 'a' .. 'f':
+  of 'a'..'f':
     xi = (xi shl 4) or (ord(L.buf[L.bufpos]) - ord('a') + 10)
 
     inc(L.bufpos)
-  of 'A' .. 'F':
+  of 'A'..'F':
     xi = (xi shl 4) or (ord(L.buf[L.bufpos]) - ord('A') + 10)
 
     inc(L.bufpos)
@@ -775,7 +775,7 @@ proc handleHexChar(L: var Lexer; xi: var int; position: range[0 .. 4]) =
     inc(L.bufpos)
 
 proc handleDecChars(L: var Lexer; xi: var int) =
-  while L.buf[L.bufpos] in {'0' .. '9'}:
+  while L.buf[L.bufpos] in {'0'..'9'}:
     xi = (xi * 10) + (ord(L.buf[L.bufpos]) - ord('0'))
 
     inc(L.bufpos)
@@ -893,7 +893,7 @@ proc getEscapedChar(L: var Lexer; tok: var Token) =
 
       inc(L.bufpos)
       if xi > 0x10FFFF:
-        let hex = ($L.buf)[start .. L.bufpos - 2]
+        let hex = ($L.buf)[start..L.bufpos - 2]
 
         lexMessage(
           L,
@@ -907,8 +907,8 @@ proc getEscapedChar(L: var Lexer; tok: var Token) =
       handleHexChar(L, xi, 4)
 
     addUnicodeCodePoint(tok.literal, xi)
-  of '0' .. '9':
-    if matchTwoChars(L, '0', {'0' .. '9'}):
+  of '0'..'9':
+    if matchTwoChars(L, '0', {'0'..'9'}):
       lexMessage(L, warnOctalEscape)
 
     var xi = 0
@@ -1039,7 +1039,7 @@ proc getCharacter(L: var Lexer; tok: var Token) =
 
   var c = L.buf[L.bufpos]
   case c
-  of '\0' .. pred(' '), '\'':
+  of '\0'..pred(' '), '\'':
     lexMessage(L, errGenerated, "invalid character literal")
 
     tok.literal = $c
@@ -1139,11 +1139,11 @@ proc getSymbol(L: var Lexer; tok: var Token) =
   while true:
     var c = L.buf[pos]
     case c
-    of 'a' .. 'z', '0' .. '9':
+    of 'a'..'z', '0'..'9':
       h = h !& ord(c)
 
       inc(pos)
-    of 'A' .. 'Z':
+    of 'A'..'Z':
       c = chr(ord(c) + (ord('a') - ord('A'))) # toLower()
       h = h !& ord(c)
 
@@ -1159,7 +1159,7 @@ proc getSymbol(L: var Lexer; tok: var Token) =
       inc(pos)
 
       suspicious = true
-    of '\x80' .. '\xFF':
+    of '\x80'..'\xFF':
       if c in UnicodeOperatorStartChars and unicodeOprLen(L.buf, pos)[0] != 0:
         break
       else:
@@ -1173,8 +1173,9 @@ proc getSymbol(L: var Lexer; tok: var Token) =
 
   h = !$h
   tok.ident = L.cache.getIdent(cast[cstring](addr(L.buf[L.bufpos])), pos - L.bufpos, h)
-  if (tok.ident.id < ord(tokKeywordLow) - ord(tkSymbol)) or
-      (tok.ident.id > ord(tokKeywordHigh) - ord(tkSymbol)):
+  if (tok.ident.id < ord(tokKeywordLow) - ord(tkSymbol)) or (
+    tok.ident.id > ord(tokKeywordHigh) - ord(tkSymbol)
+  ):
     tok.tokType = tkSymbol
   else:
     tok.tokType = TokType(tok.ident.id + ord(tkSymbol))
@@ -1211,7 +1212,7 @@ proc getOperator(L: var Lexer; tok: var Token) =
       if oprLen == 0:
         break
 
-      for i in 0 ..< oprLen:
+      for i in 0..<oprLen:
         h = h !& ord(L.buf[pos])
 
         inc pos
@@ -1566,7 +1567,7 @@ proc rawGetTok*(L: var Lexer; tok: var Token) =
       getCharacter(L, tok)
 
       tok.tokType = tkCharLit
-    of '0' .. '9':
+    of '0'..'9':
       getNumber(L, tok)
 
       let c = L.buf[L.bufpos]
@@ -1579,8 +1580,9 @@ proc rawGetTok*(L: var Lexer; tok: var Token) =
             "invalid token: no whitespace between number and identifier"
           )
     of '-':
-      if L.buf[L.bufpos + 1] in {'0' .. '9'} and
-          (L.bufpos - 1 == 0 or L.buf[L.bufpos - 1] in UnaryMinusWhitelist):
+      if L.buf[L.bufpos + 1] in {'0'..'9'} and (
+        L.bufpos - 1 == 0 or L.buf[L.bufpos - 1] in UnaryMinusWhitelist
+      ):
         # x)-23 # binary minus
         # ,-23  # unary minus
         # \n-78 # unary minus? Yes.
@@ -1643,7 +1645,7 @@ proc getPrecedence*(ident: PIdent): int =
   let
     tokType =
       if ident.id in
-        ord(tokKeywordLow) - ord(tkSymbol) .. ord(tokKeywordHigh) - ord(tkSymbol):
+        ord(tokKeywordLow) - ord(tkSymbol)..ord(tokKeywordHigh) - ord(tkSymbol):
         TokType(ident.id + ord(tkSymbol))
       else:
         tkOpr

--- a/src/phlineinfos.nim
+++ b/src/phlineinfos.nim
@@ -145,178 +145,176 @@ type TMsgKind* = enum
   hintMsgOrigin = "MsgOrigin" # since 1.3.5
   hintDeclaredLoc = "DeclaredLoc" # since 1.5.1
 
-const MsgKindToStr*: array[TMsgKind, string] =
-  [
-    errUnknown: "unknown error",
-    errFatal: "fatal error: $1",
-    errInternal: "internal error: $1",
-    errIllFormedAstX: "illformed AST: $1",
-    errCannotOpenFile: "cannot open '$1'",
-    errXExpected: "'$1' expected",
-    errRstMissingClosing: "$1",
-    errRstGridTableNotImplemented: "grid table is not implemented",
-    errRstMarkdownIllformedTable: "illformed delimiter row of a markdown table",
-    errRstIllformedTable: "Illformed table: $1",
-    errRstNewSectionExpected: "new section expected $1",
-    errRstGeneralParseError: "general parse error",
-    errRstInvalidDirectiveX: "invalid directive: '$1'",
-    errRstInvalidField: "invalid field: $1",
-    errRstFootnoteMismatch: "number of footnotes and their references don't match: $1",
-    errRstSandboxedDirective: "disabled directive: '$1'",
-    errProveInit: "Cannot prove that '$1' is initialized.", # deadcode
-    errGenerated: "$1",
-    errFailedMove: "$1",
-    errUser: "$1",
-    warnCannotOpenFile: "cannot open '$1'",
-    warnOctalEscape: "octal escape sequences do not exist; leading zero is ignored",
-    warnXIsNeverRead: "'$1' is never read",
-    warnXmightNotBeenInit: "'$1' might not have been initialized",
-    warnDeprecated: "$1",
-    warnConfigDeprecated: "config file '$1' is deprecated",
-    warnDotLikeOps: "$1",
-    warnSmallLshouldNotBeUsed:
-      "'l' should not be used as an identifier; may look like '1' (one)",
-    warnUnknownMagic: "unknown magic '$1' might crash the compiler",
-    warnRstRedefinitionOfLabel: "redefinition of label '$1'",
-    warnRstUnknownSubstitutionX: "unknown substitution '$1'",
-    warnRstAmbiguousLink: "ambiguous doc link $1",
-    warnRstBrokenLink: "broken link '$1'",
-    warnRstLanguageXNotSupported: "language '$1' not supported",
-    warnRstFieldXNotSupported: "field '$1' not supported",
-    warnRstUnusedImportdoc: "importdoc for '$1' is not used",
-    warnRstStyle: "RST style: $1",
-    warnCommentXIgnored: "comment '$1' ignored",
-    warnTypelessParam: "", # deadcode
-    warnUseBase: "use {.base.} for base methods; baseless methods are deprecated",
-    warnWriteToForeignHeap: "write to foreign heap",
-    warnUnsafeCode: "unsafe code: '$1'",
-    warnUnusedImportX: "imported and not used: '$1'",
-    warnInheritFromException:
-      "inherit from a more precise exception type like ValueError, " &
-        "IOError or OSError. If these don't suit, inherit from CatchableError or Defect.",
-    warnEachIdentIsTuple: "each identifier is a tuple",
-    warnUnsafeSetLen:
-      "setLen can potentially expand the sequence, " &
-        "but the element type '$1' doesn't have a valid default value",
-    warnUnsafeDefault: "The '$1' type doesn't have a valid default value",
-    warnProveInit:
-      "Cannot prove that '$1' is initialized. This will become a compile time error in the future.",
-    warnProveField: "cannot prove that field '$1' is accessible",
-    warnProveIndex: "cannot prove index '$1' is valid",
-    warnUnreachableElse: "unreachable else, all cases are already covered",
-    warnUnreachableCode:
-      "unreachable code after 'return' statement or '{.noReturn.}' proc",
-    warnStaticIndexCheck: "$1",
-    warnGcUnsafe: "not GC-safe: '$1'",
-    warnGcUnsafe2: "$1",
-    warnUninit: "use explicit initialization of '$1' for clarity",
-    warnGcMem: "'$1' uses GC'ed memory",
-    warnDestructor:
-      "usage of a type with a destructor in a non destructible context. This will become a compile time error in the future.",
-    warnLockLevel: "$1", # deadcode
-    warnResultShadowed: "Special variable 'result' is shadowed.",
-    warnInconsistentSpacing: "Number of spaces around '$#' is not consistent",
-    warnCaseTransition:
-      "Potential object case transition, instantiate new object instead",
-    warnCycleCreated: "$1",
-    warnObservableStores: "observable stores to '$1'",
-    warnStrictNotNil: "$1",
-    warnResultUsed: "used 'result' variable",
-    warnCannotOpen: "cannot open: $1",
-    warnFileChanged: "file changed: $1",
-    warnSuspiciousEnumConv: "$1",
-    warnAnyEnumConv: "$1",
-    warnHoleEnumConv: "$1",
-    warnCstringConv: "$1",
-    warnPtrToCstringConv:
-      "unsafe conversion to 'cstring' from '$1'; this will become a compile time error in the future",
-    warnEffect: "$1",
-    warnCastSizes: "$1", # deadcode
-    warnAboveMaxSizeSet: "$1",
-    warnImplicitTemplateRedefinition:
-      "template '$1' is implicitly redefined; this is deprecated, add an explicit .redefine pragma",
-    warnUnnamedBreak:
-      "Using an unnamed break in a block is deprecated; Use a named block with a named break instead",
-    warnStmtListLambda:
-      "statement list expression assumed to be anonymous proc; this is deprecated, use `do (): ...` or `proc () = ...` instead",
-    warnBareExcept: "$1",
-    warnImplicitDefaultValue: "$1",
-    warnUser: "$1",
-    hintSuccess: "operation successful: $#",
-    # keep in sync with `testament.isSuccess`
-    hintSuccessX: "$build\n$loc lines; ${sec}s; $mem; proj: $project; out: $output",
-    hintCC: "CC: $1",
-    hintXDeclaredButNotUsed: "'$1' is declared but not used",
-    hintDuplicateModuleImport: "$1",
-    hintXCannotRaiseY: "$1",
-    hintConvToBaseNotNeeded: "conversion to base object is not needed",
-    hintConvFromXtoItselfNotNeeded: "conversion from $1 to itself is pointless",
-    hintExprAlwaysX: "expression evaluates always to '$1'",
-    hintQuitCalled: "quit() called",
-    hintProcessing: "$1",
-    hintProcessingStmt: "$1",
-    hintCodeBegin: "generated code listing:",
-    hintCodeEnd: "end of listing",
-    hintConf: "used config file '$1'",
-    hintPath: "added path: '$1'",
-    hintConditionAlwaysTrue: "condition is always true: '$1'",
-    hintConditionAlwaysFalse: "condition is always false: '$1'",
-    hintName: "$1",
-    hintPattern: "$1",
-    hintExecuting: "$1",
-    hintLinking: "$1",
-    hintDependency: "$1",
-    hintSource: "$1",
-    hintPerformance: "$1",
-    hintStackTrace: "$1",
-    hintGCStats: "$1",
-    hintGlobalVar: "global variable declared here",
-    hintExpandMacro: "expanded macro: $1",
-    hintAmbiguousEnum: "$1",
-    hintUser: "$1",
-    hintUserRaw: "$1",
-    hintExtendedContext: "$1",
-    hintMsgOrigin: "$1",
-    hintDeclaredLoc: "$1"
-  ]
+const MsgKindToStr*: array[TMsgKind, string] = [
+  errUnknown: "unknown error",
+  errFatal: "fatal error: $1",
+  errInternal: "internal error: $1",
+  errIllFormedAstX: "illformed AST: $1",
+  errCannotOpenFile: "cannot open '$1'",
+  errXExpected: "'$1' expected",
+  errRstMissingClosing: "$1",
+  errRstGridTableNotImplemented: "grid table is not implemented",
+  errRstMarkdownIllformedTable: "illformed delimiter row of a markdown table",
+  errRstIllformedTable: "Illformed table: $1",
+  errRstNewSectionExpected: "new section expected $1",
+  errRstGeneralParseError: "general parse error",
+  errRstInvalidDirectiveX: "invalid directive: '$1'",
+  errRstInvalidField: "invalid field: $1",
+  errRstFootnoteMismatch: "number of footnotes and their references don't match: $1",
+  errRstSandboxedDirective: "disabled directive: '$1'",
+  errProveInit: "Cannot prove that '$1' is initialized.", # deadcode
+  errGenerated: "$1",
+  errFailedMove: "$1",
+  errUser: "$1",
+  warnCannotOpenFile: "cannot open '$1'",
+  warnOctalEscape: "octal escape sequences do not exist; leading zero is ignored",
+  warnXIsNeverRead: "'$1' is never read",
+  warnXmightNotBeenInit: "'$1' might not have been initialized",
+  warnDeprecated: "$1",
+  warnConfigDeprecated: "config file '$1' is deprecated",
+  warnDotLikeOps: "$1",
+  warnSmallLshouldNotBeUsed:
+    "'l' should not be used as an identifier; may look like '1' (one)",
+  warnUnknownMagic: "unknown magic '$1' might crash the compiler",
+  warnRstRedefinitionOfLabel: "redefinition of label '$1'",
+  warnRstUnknownSubstitutionX: "unknown substitution '$1'",
+  warnRstAmbiguousLink: "ambiguous doc link $1",
+  warnRstBrokenLink: "broken link '$1'",
+  warnRstLanguageXNotSupported: "language '$1' not supported",
+  warnRstFieldXNotSupported: "field '$1' not supported",
+  warnRstUnusedImportdoc: "importdoc for '$1' is not used",
+  warnRstStyle: "RST style: $1",
+  warnCommentXIgnored: "comment '$1' ignored",
+  warnTypelessParam: "", # deadcode
+  warnUseBase: "use {.base.} for base methods; baseless methods are deprecated",
+  warnWriteToForeignHeap: "write to foreign heap",
+  warnUnsafeCode: "unsafe code: '$1'",
+  warnUnusedImportX: "imported and not used: '$1'",
+  warnInheritFromException:
+    "inherit from a more precise exception type like ValueError, " &
+      "IOError or OSError. If these don't suit, inherit from CatchableError or Defect.",
+  warnEachIdentIsTuple: "each identifier is a tuple",
+  warnUnsafeSetLen:
+    "setLen can potentially expand the sequence, " &
+      "but the element type '$1' doesn't have a valid default value",
+  warnUnsafeDefault: "The '$1' type doesn't have a valid default value",
+  warnProveInit:
+    "Cannot prove that '$1' is initialized. This will become a compile time error in the future.",
+  warnProveField: "cannot prove that field '$1' is accessible",
+  warnProveIndex: "cannot prove index '$1' is valid",
+  warnUnreachableElse: "unreachable else, all cases are already covered",
+  warnUnreachableCode:
+    "unreachable code after 'return' statement or '{.noReturn.}' proc",
+  warnStaticIndexCheck: "$1",
+  warnGcUnsafe: "not GC-safe: '$1'",
+  warnGcUnsafe2: "$1",
+  warnUninit: "use explicit initialization of '$1' for clarity",
+  warnGcMem: "'$1' uses GC'ed memory",
+  warnDestructor:
+    "usage of a type with a destructor in a non destructible context. This will become a compile time error in the future.",
+  warnLockLevel: "$1", # deadcode
+  warnResultShadowed: "Special variable 'result' is shadowed.",
+  warnInconsistentSpacing: "Number of spaces around '$#' is not consistent",
+  warnCaseTransition: "Potential object case transition, instantiate new object instead",
+  warnCycleCreated: "$1",
+  warnObservableStores: "observable stores to '$1'",
+  warnStrictNotNil: "$1",
+  warnResultUsed: "used 'result' variable",
+  warnCannotOpen: "cannot open: $1",
+  warnFileChanged: "file changed: $1",
+  warnSuspiciousEnumConv: "$1",
+  warnAnyEnumConv: "$1",
+  warnHoleEnumConv: "$1",
+  warnCstringConv: "$1",
+  warnPtrToCstringConv:
+    "unsafe conversion to 'cstring' from '$1'; this will become a compile time error in the future",
+  warnEffect: "$1",
+  warnCastSizes: "$1", # deadcode
+  warnAboveMaxSizeSet: "$1",
+  warnImplicitTemplateRedefinition:
+    "template '$1' is implicitly redefined; this is deprecated, add an explicit .redefine pragma",
+  warnUnnamedBreak:
+    "Using an unnamed break in a block is deprecated; Use a named block with a named break instead",
+  warnStmtListLambda:
+    "statement list expression assumed to be anonymous proc; this is deprecated, use `do (): ...` or `proc () = ...` instead",
+  warnBareExcept: "$1",
+  warnImplicitDefaultValue: "$1",
+  warnUser: "$1",
+  hintSuccess: "operation successful: $#",
+  # keep in sync with `testament.isSuccess`
+  hintSuccessX: "$build\n$loc lines; ${sec}s; $mem; proj: $project; out: $output",
+  hintCC: "CC: $1",
+  hintXDeclaredButNotUsed: "'$1' is declared but not used",
+  hintDuplicateModuleImport: "$1",
+  hintXCannotRaiseY: "$1",
+  hintConvToBaseNotNeeded: "conversion to base object is not needed",
+  hintConvFromXtoItselfNotNeeded: "conversion from $1 to itself is pointless",
+  hintExprAlwaysX: "expression evaluates always to '$1'",
+  hintQuitCalled: "quit() called",
+  hintProcessing: "$1",
+  hintProcessingStmt: "$1",
+  hintCodeBegin: "generated code listing:",
+  hintCodeEnd: "end of listing",
+  hintConf: "used config file '$1'",
+  hintPath: "added path: '$1'",
+  hintConditionAlwaysTrue: "condition is always true: '$1'",
+  hintConditionAlwaysFalse: "condition is always false: '$1'",
+  hintName: "$1",
+  hintPattern: "$1",
+  hintExecuting: "$1",
+  hintLinking: "$1",
+  hintDependency: "$1",
+  hintSource: "$1",
+  hintPerformance: "$1",
+  hintStackTrace: "$1",
+  hintGCStats: "$1",
+  hintGlobalVar: "global variable declared here",
+  hintExpandMacro: "expanded macro: $1",
+  hintAmbiguousEnum: "$1",
+  hintUser: "$1",
+  hintUserRaw: "$1",
+  hintExtendedContext: "$1",
+  hintMsgOrigin: "$1",
+  hintDeclaredLoc: "$1"
+]
 
 const
-  fatalMsgs* = {errUnknown .. errInternal}
+  fatalMsgs* = {errUnknown..errInternal}
   errMin* = errUnknown
   errMax* = errUser
   warnMin* = warnCannotOpenFile
   warnMax* = pred(hintSuccess)
   hintMin* = hintSuccess
   hintMax* = high(TMsgKind)
-  rstWarnings* = {warnRstRedefinitionOfLabel .. warnRstStyle}
+  rstWarnings* = {warnRstRedefinitionOfLabel..warnRstStyle}
 
 type
-  TNoteKind* = range[warnMin .. hintMax] # "notes" are warnings or hints
+  TNoteKind* = range[warnMin..hintMax] # "notes" are warnings or hints
   TNoteKinds* = set[TNoteKind]
 
-proc computeNotesVerbosity(): array[0 .. 3, TNoteKinds] =
+proc computeNotesVerbosity(): array[0..3, TNoteKinds] =
   result[3] =
-    {low(TNoteKind) .. high(TNoteKind)} -
-      {warnObservableStores, warnResultUsed, warnAnyEnumConv, warnBareExcept}
+    {low(TNoteKind)..high(TNoteKind)} - {
+      warnObservableStores, warnResultUsed, warnAnyEnumConv, warnBareExcept
+    }
 
   result[2] =
-    result[3] -
-      {hintStackTrace, hintExtendedContext, hintDeclaredLoc, hintProcessingStmt}
+    result[3] - {
+      hintStackTrace, hintExtendedContext, hintDeclaredLoc, hintProcessingStmt
+    }
 
   result[1] =
-    result[2] -
-      {
-        warnProveField, warnProveIndex, warnGcUnsafe, hintPath, hintDependency,
-        hintCodeBegin, hintCodeEnd, hintSource, hintGlobalVar, hintGCStats,
-        hintMsgOrigin, hintPerformance
-      }
+    result[2] - {
+      warnProveField, warnProveIndex, warnGcUnsafe, hintPath, hintDependency,
+      hintCodeBegin, hintCodeEnd, hintSource, hintGlobalVar, hintGCStats, hintMsgOrigin,
+      hintPerformance
+    }
 
   result[0] =
-    result[1] -
-      {
-        hintSuccessX, hintSuccess, hintConf, hintProcessing, hintPattern, hintExecuting,
-        hintLinking, hintCC
-      }
+    result[1] - {
+      hintSuccessX, hintSuccess, hintConf, hintProcessing, hintPattern, hintExecuting,
+      hintLinking, hintCC
+    }
 
 const
   NotesVerbosity* = computeNotesVerbosity()

--- a/src/phmsgs.nim
+++ b/src/phmsgs.nim
@@ -47,7 +47,7 @@ proc flushDot*(conf: ConfigRef) =
 
 proc toCChar*(c: char; result: var string) {.inline.} =
   case c
-  of '\0' .. '\x1F', '\x7F' .. '\xFF':
+  of '\0'..'\x1F', '\x7F'..'\xFF':
     result.add '\\'
     result.add toOctal(c)
   of '\'', '\"', '\\', '?':
@@ -60,7 +60,7 @@ proc makeCString*(s: string): Rope =
   result = newStringOfCap(int(s.len.toFloat * 1.1) + 1)
 
   result.add("\"")
-  for i in 0 ..< s.len:
+  for i in 0..<s.len:
     # line wrapping of string litterals in cgen'd code was a bad idea, e.g. causes: bug #16265
     # It also makes reading c sources or grepping harder, for zero benefit.
     # const MaxLineLength = 64
@@ -274,11 +274,11 @@ proc toProjPath*(conf: ConfigRef; fileIdx: FileIndex): string =
 
 proc toFullPath*(conf: ConfigRef; fileIdx: FileIndex): string =
   if fileIdx.int32 < 0 or conf == nil:
-    result =
-      (if fileIdx == commandLineIdx:
+    result = (
+      if fileIdx == commandLineIdx:
         commandLineDesc
       else: "???"
-      )
+    )
   else:
     result = conf.m.fileInfos[fileIdx.int32].fullPath.string
 
@@ -525,7 +525,7 @@ proc quit(conf: ConfigRef; msg: TMsgKind) {.gcsafe.} =
           """
 No stack traceback available
 To create a stacktrace, rerun compilation with './koch temp $1 <file>', see $2 for details""" %
-            [conf.command, "intern.html#debugging-the-compiler".createDocLink],
+          [conf.command, "intern.html#debugging-the-compiler".createDocLink],
           conf.unitSep,
         )
 
@@ -540,8 +540,9 @@ proc handleError(
 
     quit(conf, msg)
 
-  if msg >= errMin and msg <= errMax or
-      (msg in warnMin .. hintMax and msg in conf.warningAsErrors and not ignoreMsg):
+  if msg >= errMin and msg <= errMax or (
+    msg in warnMin..hintMax and msg in conf.warningAsErrors and not ignoreMsg
+  ):
     inc(conf.errorCounter)
 
     conf.exitcode = 1'i8
@@ -565,7 +566,7 @@ proc writeContext(conf: ConfigRef; lastinfo: TLineInfo) =
   const instantiationOfFrom = "template/generic instantiation of `$1` from here"
 
   var info = lastinfo
-  for i in 0 ..< conf.m.msgContext.len:
+  for i in 0..<conf.m.msgContext.len:
     let context = conf.m.msgContext[i]
     if context.info != lastinfo and context.info != info:
       if conf.structuredErrorHook != nil:
@@ -627,9 +628,9 @@ proc getSurroundingSrc(conf: ConfigRef; info: TLineInfo): string =
 proc formatMsg*(conf: ConfigRef; info: TLineInfo; msg: TMsgKind; arg: string): string =
   let title =
     case msg
-    of warnMin .. warnMax:
+    of warnMin..warnMax:
       WarningTitle
-    of hintMin .. hintMax:
+    of hintMin..hintMax:
       HintTitle
     else:
       ErrorTitle
@@ -659,14 +660,14 @@ proc liMessage*(
     conf.m.errorOutputs = {eStdOut, eStdErr}
 
   let kind =
-    if msg in warnMin .. hintMax and msg != hintUserRaw:
+    if msg in warnMin..hintMax and msg != hintUserRaw:
       $msg
     else:
       ""
     # xxx not sure why hintUserRaw is special
 
   case msg
-  of errMin .. errMax:
+  of errMin..errMax:
     sev = Severity.Error
 
     writeContext(conf, info)
@@ -681,7 +682,7 @@ proc liMessage*(
 
     if info != unknownLineInfo:
       conf.m.lastError = info
-  of warnMin .. warnMax:
+  of warnMin..warnMax:
     sev = Severity.Warning
     ignoreMsg = not conf.hasWarn(msg)
     if not ignoreMsg and msg in conf.warningAsErrors:
@@ -695,7 +696,7 @@ proc liMessage*(
       writeContext(conf, info)
 
     inc(conf.warnCounter)
-  of hintMin .. hintMax:
+  of hintMin..hintMax:
     sev = Severity.Hint
     ignoreMsg = not conf.hasHint(msg)
     if not ignoreMsg and msg in conf.warningAsErrors:
@@ -859,23 +860,22 @@ template listMsg(title, r) =
   for a in r:
     msgWriteln(
       conf,
-      "  [$1] $2" %
-        [
-          if a in conf.notes:
-            "x"
-          else:
-            " "
-          ,
-          $a
-        ],
+      "  [$1] $2" % [
+        if a in conf.notes:
+          "x"
+        else:
+          " "
+        ,
+        $a
+      ],
       {msgNoUnitSep},
     )
 
 proc listWarnings*(conf: ConfigRef) =
-  listMsg("Warnings:", warnMin .. warnMax)
+  listMsg("Warnings:", warnMin..warnMax)
 
 proc listHints*(conf: ConfigRef) =
-  listMsg("Hints:", hintMin .. hintMax)
+  listMsg("Hints:", hintMin..hintMax)
 
 proc uniqueModuleName*(conf: ConfigRef; fid: FileIndex): string =
   ## The unique module name is guaranteed to only contain {'A'..'Z', 'a'..'z', '0'..'9', '_'}
@@ -894,10 +894,10 @@ proc uniqueModuleName*(conf: ConfigRef; fid: FileIndex): string =
       rel.len
 
   result = newStringOfCap(trunc)
-  for i in 0 ..< trunc:
+  for i in 0..<trunc:
     let c = rel[i]
     case c
-    of 'a' .. 'z':
+    of 'a'..'z':
       result.add c
     of {os.DirSep, os.AltSep}:
       result.add 'Z' # because it looks a bit like '/'

--- a/src/phoptions.nim
+++ b/src/phoptions.nim
@@ -197,10 +197,12 @@ type
       # old unused: cmdInterpret, cmdDef: def feature (find definition for IDEs)
 
 const
-  cmdBackends* =
-    {cmdCompileToC, cmdCompileToCpp, cmdCompileToOC, cmdCompileToJS, cmdCrun}
-  cmdDocLike* =
-    {cmdDoc0, cmdDoc, cmdDoc2tex, cmdJsondoc0, cmdJsondoc, cmdCtags, cmdBuildindex}
+  cmdBackends* = {
+    cmdCompileToC, cmdCompileToCpp, cmdCompileToOC, cmdCompileToJS, cmdCrun
+  }
+  cmdDocLike* = {
+    cmdDoc0, cmdDoc, cmdDoc2tex, cmdJsondoc0, cmdJsondoc, cmdCtags, cmdBuildindex
+  }
 
 type
   NimVer* = tuple[major: int, minor: int, patch: int]
@@ -330,7 +332,7 @@ type
     column*: int # Starts at 0
     doc*: string # Not escaped (yet)
     forth*: string # type
-    quality*: range[0 .. 100] # matching quality
+    quality*: range[0..100] # matching quality
     isGlobal*: bool # is a global variable
     contextFits*: bool # type/non-type context matches
     prefix*: PrefixMatch
@@ -553,18 +555,16 @@ when false:
 
 const oldExperimentalFeatures* = {dotOperators, callOperator, parallel}
 const
-  ChecksOptions* =
-    {
-      optObjCheck, optFieldCheck, optRangeCheck, optOverflowCheck, optBoundsCheck,
-      optAssert, optNaNCheck, optInfCheck, optStyleCheck
-    }
-  DefaultOptions* =
-    {
-      optObjCheck, optFieldCheck, optRangeCheck, optBoundsCheck, optOverflowCheck,
-      optAssert, optWarns, optRefCheck, optHints, optStackTrace, optLineTrace,
-      # consider adding `optStackTraceMsgs`
-      optTrMacros, optStyleCheck, optCursorInference
-    }
+  ChecksOptions* = {
+    optObjCheck, optFieldCheck, optRangeCheck, optOverflowCheck, optBoundsCheck,
+    optAssert, optNaNCheck, optInfCheck, optStyleCheck
+  }
+  DefaultOptions* = {
+    optObjCheck, optFieldCheck, optRangeCheck, optBoundsCheck, optOverflowCheck,
+    optAssert, optWarns, optRefCheck, optHints, optStackTrace, optLineTrace,
+    # consider adding `optStackTraceMsgs`
+    optTrMacros, optStyleCheck, optCursorInference
+  }
   DefaultGlobalOptions* = {optThreadAnalysis, optExcessiveStackTrace, optJsBigInt64}
 
 proc getSrcTimestamp(): DateTime =
@@ -596,8 +596,9 @@ template newPackageCache*(): untyped =
 proc newProfileData(): ProfileData =
   ProfileData(data: newTable[TLineInfo, ProfileInfo]())
 
-const foreignPackageNotesDefault* =
-  {hintProcessing, warnUnknownMagic, hintQuitCalled, hintExecuting, hintUser, warnUser}
+const foreignPackageNotesDefault* = {
+  hintProcessing, warnUnknownMagic, hintQuitCalled, hintExecuting, hintUser, warnUser
+}
 
 proc isDefined*(conf: ConfigRef; symbol: string): bool
 
@@ -719,13 +720,11 @@ proc isDefined*(conf: ConfigRef; symbol: string): bool =
       result = conf.target.targetCPU == cpuAmd64
     of "posix", "unix":
       result =
-        conf.target.targetOS in
-          {
-            osLinux, osMorphos, osSkyos, osIrix, osPalmos, osQnx, osAtari, osAix,
-            osHaiku, osVxWorks, osSolaris, osNetbsd, osFreebsd, osOpenbsd, osDragonfly,
-            osMacosx, osIos, osAndroid, osNintendoSwitch, osFreeRTOS, osCrossos,
-            osZephyr, osNuttX
-          }
+        conf.target.targetOS in {
+          osLinux, osMorphos, osSkyos, osIrix, osPalmos, osQnx, osAtari, osAix, osHaiku,
+          osVxWorks, osSolaris, osNetbsd, osFreebsd, osOpenbsd, osDragonfly, osMacosx,
+          osIos, osAndroid, osNintendoSwitch, osFreeRTOS, osCrossos, osZephyr, osNuttX
+        }
     of "linux":
       result = conf.target.targetOS in {osLinux, osAndroid}
     of "bsd":
@@ -767,8 +766,9 @@ proc isDefined*(conf: ConfigRef; symbol: string): bool =
       result = CPU[conf.target.targetCPU].bit == 64
     of "nimrawsetjmp":
       result =
-        conf.target.targetOS in
-          {osSolaris, osNetbsd, osFreebsd, osOpenbsd, osDragonfly, osMacosx}
+        conf.target.targetOS in {
+          osSolaris, osNetbsd, osFreebsd, osOpenbsd, osDragonfly, osMacosx
+        }
     else:
       discard
 
@@ -942,25 +942,24 @@ proc pathSubs*(conf: ConfigRef; p, config: string): string =
 
   result =
     unixToNativePath(
-      p %
-        [
-          "nim",
-          getPrefixDir(conf).string,
-          "lib",
-          conf.libpath.string,
-          "home",
-          home,
-          "config",
-          config,
-          "projectname",
-          conf.projectName,
-          "projectpath",
-          conf.projectPath.string,
-          "projectdir",
-          conf.projectPath.string,
-          "nimcache",
-          getNimcacheDir(conf).string
-        ],
+      p % [
+        "nim",
+        getPrefixDir(conf).string,
+        "lib",
+        conf.libpath.string,
+        "home",
+        home,
+        "config",
+        config,
+        "projectname",
+        conf.projectName,
+        "projectpath",
+        conf.projectPath.string,
+        "projectdir",
+        conf.projectPath.string,
+        "nimcache",
+        getNimcacheDir(conf).string
+      ],
     ).expandTilde
 
 iterator nimbleSubs*(conf: ConfigRef; p: string): string =
@@ -1023,12 +1022,11 @@ template patchModule(conf: ConfigRef) {.dirty.} =
       if ov.len > 0:
         result = AbsoluteFile(ov)
 
-const stdlibDirs* =
-  [
-    "pure", "core", "arch", "pure/collections", "pure/concurrency", "pure/unidecode",
-    "impure", "wrappers", "wrappers/linenoise", "windows", "posix", "js",
-    "deprecated/pure"
-  ]
+const stdlibDirs* = [
+  "pure", "core", "arch", "pure/collections", "pure/concurrency", "pure/unidecode",
+  "impure", "wrappers", "wrappers/linenoise", "windows", "posix", "js",
+  "deprecated/pure"
+]
 
 const
   pkgPrefix = "pkg/"

--- a/src/phparser.nim
+++ b/src/phparser.nim
@@ -238,7 +238,7 @@ proc drainSkipped(p: var Parser; indent: int): seq[Token] =
         result.add(c)
         p.lineNumberPrevious = int c.prevLine
 
-    p.skipped.delete(0 .. result.high)
+    p.skipped.delete(0..result.high)
 
 proc splitComments(
     comments: openArray[Token]; a: PNode; ind: int; commentLoc: CommentLoc
@@ -273,7 +273,7 @@ proc addSkipped(p: var Parser; n: PNode) =
     n.add c
     i += 1
 
-  p.skipped = tmp[i ..^ 1]
+  p.skipped = tmp[i..^1]
 
 proc indAndComment(
     p: var Parser; n: PNode; commentLoc = clPostfix; maybeMissEquals = false
@@ -370,11 +370,10 @@ proc isOperator(tok: Token): bool =
   #| operatorB = OP0 | OP1 | OP2 | OP3 | OP4 | OP5 | OP6 | OP7 | OP8 | OP9 |
   #|             'div' | 'mod' | 'shl' | 'shr' | 'in' | 'notin' |
   #|             'is' | 'isnot' | 'not' | 'of' | 'as' | 'from' | '..' | 'and' | 'or' | 'xor'
-  tok.tokType in
-    {
-      tkOpr, tkDiv, tkMod, tkShl, tkShr, tkIn, tkNotin, tkIs, tkIsnot, tkNot, tkOf,
-      tkAs, tkFrom, tkDotDot, tkAnd, tkOr, tkXor
-    }
+  tok.tokType in {
+    tkOpr, tkDiv, tkMod, tkShl, tkShr, tkIn, tkNotin, tkIs, tkIsnot, tkNot, tkOf, tkAs,
+    tkFrom, tkDotDot, tkAnd, tkOr, tkXor
+  }
 
 proc parseComStmt(p: var Parser; n: PNode; commentLoc = clPostfix): PNode =
   splitLookahead(p, n, commentLoc)
@@ -405,7 +404,7 @@ proc parseSymbol(p: var Parser; mode = smNormal): PNode =
     result = newIdentNodeP(p.tok.ident, p)
 
     getTok(p)
-  of tokKeywordLow .. tokKeywordHigh:
+  of tokKeywordLow..tokKeywordHigh:
     if p.tok.tokType in tkBuiltInMagics or mode == smAfterDot:
       # for backwards compatibility these 2 are always valid:
       result = newIdentNodeP(p.tok.ident, p)
@@ -431,10 +430,10 @@ proc parseSymbol(p: var Parser; mode = smNormal): PNode =
           parMessage(p, errIdentifierExpected, p.tok)
 
         break
-      of tkOpr, tkDot, tkDotDot, tkEquals, tkParLe .. tkParDotRi:
+      of tkOpr, tkDot, tkDotDot, tkEquals, tkParLe..tkParDotRi:
         var lineinfo = parLineInfo(p)
         var accm = ""
-        while p.tok.tokType in {tkOpr, tkDot, tkDotDot, tkEquals, tkParLe .. tkParDotRi}:
+        while p.tok.tokType in {tkOpr, tkDot, tkDotDot, tkEquals, tkParLe..tkParDotRi}:
           accm.add($p.tok)
           getTok(p)
 
@@ -443,7 +442,7 @@ proc parseSymbol(p: var Parser; mode = smNormal): PNode =
         node.ident = p.lex.cache.getIdent(accm)
 
         result.add(node)
-      of tokKeywordLow .. tokKeywordHigh, tkSymbol, tkIntLit .. tkCustomLit:
+      of tokKeywordLow..tokKeywordHigh, tkSymbol, tkIntLit..tkCustomLit:
         result.add(newIdentNodeP(p.lex.cache.getIdent($p.tok), p))
         getTok(p)
       else:
@@ -705,9 +704,7 @@ proc parseGStrLit(p: var Parser; a: PNode): PNode =
   setEndInfo()
 
 proc complexOrSimpleStmt(p: var Parser): PNode
-
 proc simpleExpr(p: var Parser; mode = pmNormal): PNode
-
 proc parseIfOrWhenExpr(p: var Parser; kind: TNodeKind): PNode
 
 proc semiStmtList(p: var Parser; result: PNode) =
@@ -764,11 +761,10 @@ proc parsePar(p: var Parser): PNode =
   getTok(p)
   optInd(p, result)
 
-  if p.tok.tokType in
-      {
-        tkDiscard, tkInclude, tkIf, tkWhile, tkCase, tkTry, tkDefer, tkFinally,
-        tkExcept, tkBlock, tkConst, tkLet, tkWhen, tkVar, tkFor, tkMixin
-      }:
+  if p.tok.tokType in {
+    tkDiscard, tkInclude, tkIf, tkWhile, tkCase, tkTry, tkDefer, tkFinally, tkExcept,
+    tkBlock, tkConst, tkLet, tkWhen, tkVar, tkFor, tkMixin
+  }:
     # XXX 'bind' used to be an expression, so we exclude it here;
     # tests/reject/tbind2 fails otherwise.
     semiStmtList(p, result)
@@ -1063,7 +1059,7 @@ proc primarySuffix(p: var Parser; r: PNode; baseIndent: int; mode: PrimaryMode):
     of
         tkSymbol,
         tkAccent,
-        tkIntLit .. tkCustomLit,
+        tkIntLit..tkCustomLit,
         tkNil,
         tkCast,
         tkOpr,
@@ -1521,7 +1517,7 @@ proc isExprStart(p: Parser): bool =
       tkParLe,
       tkBracketLe,
       tkCurlyLe,
-      tkIntLit .. tkCustomLit,
+      tkIntLit..tkCustomLit,
       tkVar,
       tkRef,
       tkPtr,
@@ -1655,9 +1651,7 @@ proc parseExpr(p: var Parser): PNode =
   setEndInfo()
 
 proc parseEnum(p: var Parser): PNode
-
 proc parseObject(p: var Parser): PNode
-
 proc parseTypeClass(p: var Parser): PNode
 
 proc primary(p: var Parser; mode: PrimaryMode): PNode =
@@ -1687,18 +1681,17 @@ proc primary(p: var Parser; mode: PrimaryMode): PNode =
     optInd(p, a)
 
     const identOrLiteralKinds =
-      tkBuiltInMagics +
-        {
-          tkSymbol,
-          tkAccent,
-          tkNil,
-          tkIntLit .. tkCustomLit,
-          tkCast,
-          tkOut,
-          tkParLe,
-          tkBracketLe,
-          tkCurlyLe
-        }
+      tkBuiltInMagics + {
+        tkSymbol,
+        tkAccent,
+        tkNil,
+        tkIntLit..tkCustomLit,
+        tkCast,
+        tkOut,
+        tkParLe,
+        tkBracketLe,
+        tkCurlyLe
+      }
 
     if isSigil and p.tok.tokType in identOrLiteralKinds:
       let baseInd = p.lex.currLineIndent
@@ -2473,7 +2466,7 @@ proc parseRoutine(p: var Parser; kind: TNodeKind): PNode =
   splitLookahead(p, result, clMid)
   optInd(p, result)
   if kind in {nkProcDef, nkLambda, nkIteratorDef, nkFuncDef} and
-      p.tok.tokType notin {tkSymbol, tokKeywordLow .. tokKeywordHigh, tkAccent}:
+      p.tok.tokType notin {tkSymbol, tokKeywordLow..tokKeywordHigh, tkAccent}:
     # no name; lambda or proc type
     # in every context that we can parse a routine, we can also parse these
     result =

--- a/tests/after/comments.nim
+++ b/tests/after/comments.nim
@@ -146,7 +146,7 @@ proc x() =
   if true:
     numberOfCharsRead -= 2 # handle Ctrl+Z as EOF
 
-    for i in 0 ..< numberOfCharsRead:
+    for i in 0..<numberOfCharsRead:
       discard
 
 proc x() =
@@ -184,7 +184,7 @@ finally:
   discard
 # finally last dedent line
 
-for i in 0 .. 1: # for colon line
+for i in 0..1: # for colon line
   # for first line
   discard
 
@@ -196,7 +196,7 @@ else: # case else colon line
   # case else first line
   discard
 
-f do -> int: # do colon line
+f do () -> int: # do colon line
   # do first line
   discard
   discard

--- a/tests/after/exprs.nim
+++ b/tests/after/exprs.nim
@@ -1,21 +1,21 @@
 var c3 =
-  row[p] +
-    (if runeA != runeB:
+  row[p] + (
+    if runeA != runeB:
       1
     else:
       0
-    )
+  )
 
 var c3 =
-  row[p] +
-    (if runeA != runeB: 1
+  row[p] + (
+    if runeA != runeB: 1
     else: 0
-    )
+  )
 
-for a in 0 ..< 1:
+for a in 0..<1:
   discard
 
-for a in 0 .. 1:
+for a in 0..1:
   discard
 
 # needs spaces
@@ -23,54 +23,81 @@ for a in ^1 .. ^2:
   discard
 
 template ttt*(): untyped =
-  (block:
-    xxx
+  (
+    block:
+      xxx
   )[]
+
+# single-line expressions with varying amounts of pars
+
+let
+  x0 = (
+    discard
+    false
+  )
+  x1 =
+    if (
+      discard
+      false
+    ):
+      0
+    else:
+      1
+  x2 = (
+    if (
+      discard
+      false
+    ): 0
+    else: 1
+  )
+  x3 = (
+    if (
+      discard
+      false
+    ): (0)
+    else: (1)
+  )
 
 # command syntax with colon
 discard xxxx "arg":
     yyy
 
-# TODO
-# (try: (discard rOk.tryError(); false) except ResultError[int]: true)
-
-res.add fff do:
-    yy()
-
-# we don't what `do` in let but need it in the above commend - this needs
-# more investigation - this is important for templates calls like Result.valueOr
-# which become ugly otherwise
-let xxx =
-  implicitdo:
-    return xxx
+(
+  try: (
+    discard rOk.tryError()
+    false
+  )
+  except ResultError[int]:
+    true
+)
 
 let shortInfix = a * b * c + d * e * f + (a + b) * g
 
-let longInfix =
-  (
-    a30 * a21 * a12 * a03 - a20 * a31 * a12 * a03 - a30 * a11 * a22 * a03 +
-    a10 * a31 * a22 * a03 + a20 * a11 * a32 * a03 - a10 * a21 * a32 * a03 -
-    a30 * a21 * a02 * a13 + a20 * a31 * a02 * a13 + a30 * a01 * a22 * a13 -
-    a00 * a31 * a22 * a13 - a20 * a01 * a32 * a13 + a00 * a21 * a32 * a13 +
-    a30 * a11 * a02 * a23 - a10 * a31 * a02 * a23 - a30 * a01 * a12 * a23 +
-    a00 * a31 * a12 * a23 + a10 * a01 * a32 * a23 - a00 * a11 * a32 * a23 -
-    a20 * a11 * a02 * a33 + a10 * a21 * a02 * a33 + a20 * a01 * a12 * a33 -
-    a00 * a21 * a12 * a33 - a10 * a01 * a22 * a33 + a00 * a11 * a22 * a33
-  )
+let longInfix = (
+  a30 * a21 * a12 * a03 - a20 * a31 * a12 * a03 - a30 * a11 * a22 * a03 +
+  a10 * a31 * a22 * a03 + a20 * a11 * a32 * a03 - a10 * a21 * a32 * a03 -
+  a30 * a21 * a02 * a13 + a20 * a31 * a02 * a13 + a30 * a01 * a22 * a13 -
+  a00 * a31 * a22 * a13 - a20 * a01 * a32 * a13 + a00 * a21 * a32 * a13 +
+  a30 * a11 * a02 * a23 - a10 * a31 * a02 * a23 - a30 * a01 * a12 * a23 +
+  a00 * a31 * a12 * a23 + a10 * a01 * a32 * a23 - a00 * a11 * a32 * a23 -
+  a20 * a11 * a02 * a33 + a10 * a21 * a02 * a33 + a20 * a01 * a12 * a33 -
+  a00 * a21 * a12 * a33 - a10 * a01 * a22 * a33 + a00 * a11 * a22 * a33
+)
 
 if aaaaaaaaaaaaaaaaaaaa and bbbbbbbbbbbbbbbbbbbbbbb and ccccccccccccccccccccccccc and
     ddddddddddddddddd and fffffffffffffffff:
   discard
 
-if (aaaaaaaaaaaaaaaa and bbbbbbbbbbbbbbbbbbbbbbbbbbbb) or
-    (ccccccccccccccccccccccccccc and ddddddddddddddddddddd):
+if (aaaaaaaaaaaaaaaa and bbbbbbbbbbbbbbbbbbbbbbbbbbbb) or (
+  ccccccccccccccccccccccccccc and ddddddddddddddddddddd
+):
   discard
-elif aaaaaaaaa and
-    (
-      bbbbbbbbbb or
-      cccccccccccc and
-      (dddddddddddddddd or eeeeeeeeeeeeeee or fffffffffffffff or gggggggggggggg)
-    ):
+elif aaaaaaaaa and (
+  bbbbbbbbbb or
+  cccccccccccc and (
+    dddddddddddddddd or eeeeeeeeeeeeeee or fffffffffffffff or gggggggggggggg
+  )
+):
   discard
 
 case aaaaaaaaaa
@@ -85,3 +112,14 @@ of aaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbb, cccccccccccccccccc
   discard
 else:
   discard
+
+discard a..b
+discard a..<b
+discard a..^b
+discard a..b
+discard a..^b
+discard a..<b
+discard a .. ^b
+discard a .. <b
+discard a .. -b
+discard -1 .. -2

--- a/tests/after/exprs.nim.nph.yaml
+++ b/tests/after/exprs.nim.nph.yaml
@@ -169,6 +169,100 @@ sons:
                           - kind: "nkIdent"
                             ident: "xxx"
   - kind: "nkCommentStmt"
+    "comment": "# single-line expressions with varying amounts of pars"
+  - kind: "nkLetSection"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "x0"
+          - kind: "nkEmpty"
+          - kind: "nkStmtListExpr"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+              - kind: "nkIdent"
+                ident: "false"
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "x1"
+          - kind: "nkEmpty"
+          - kind: "nkIfExpr"
+            sons:
+              - kind: "nkElifExpr"
+                sons:
+                  - kind: "nkStmtListExpr"
+                    sons:
+                      - kind: "nkDiscardStmt"
+                        sons:
+                          - kind: "nkEmpty"
+                      - kind: "nkIdent"
+                        ident: "false"
+                  - kind: "nkStmtList"
+                    sons:
+                      - kind: "nkIntLit"
+                        intVal: 0
+              - kind: "nkElseExpr"
+                sons:
+                  - kind: "nkStmtList"
+                    sons:
+                      - kind: "nkIntLit"
+                        intVal: 1
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "x2"
+          - kind: "nkEmpty"
+          - kind: "nkStmtListExpr"
+            sons:
+              - kind: "nkIfStmt"
+                sons:
+                  - kind: "nkElifExpr"
+                    sons:
+                      - kind: "nkStmtListExpr"
+                        sons:
+                          - kind: "nkDiscardStmt"
+                            sons:
+                              - kind: "nkEmpty"
+                          - kind: "nkIdent"
+                            ident: "false"
+                      - kind: "nkIntLit"
+                        intVal: 0
+                  - kind: "nkElseExpr"
+                    sons:
+                      - kind: "nkIntLit"
+                        intVal: 1
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "x3"
+          - kind: "nkEmpty"
+          - kind: "nkStmtListExpr"
+            sons:
+              - kind: "nkIfStmt"
+                sons:
+                  - kind: "nkElifExpr"
+                    sons:
+                      - kind: "nkStmtListExpr"
+                        sons:
+                          - kind: "nkDiscardStmt"
+                            sons:
+                              - kind: "nkEmpty"
+                          - kind: "nkIdent"
+                            ident: "false"
+                      - kind: "nkPar"
+                        sons:
+                          - kind: "nkIntLit"
+                            intVal: 0
+                  - kind: "nkElseExpr"
+                    sons:
+                      - kind: "nkPar"
+                        sons:
+                          - kind: "nkIntLit"
+                            intVal: 1
+  - kind: "nkCommentStmt"
     "comment": "# command syntax with colon"
   - kind: "nkDiscardStmt"
     sons:
@@ -182,51 +276,36 @@ sons:
             sons:
               - kind: "nkIdent"
                 ident: "yyy"
-  - kind: "nkCommentStmt"
-    "comment": "# TODO"
-  - kind: "nkCommentStmt"
-    "comment": "# (try: (discard rOk.tryError(); false) except ResultError[int]: true)"
-  - kind: "nkCommand"
+  - kind: "nkStmtListExpr"
     sons:
-      - kind: "nkDotExpr"
+      - kind: "nkTryStmt"
         sons:
-          - kind: "nkIdent"
-            ident: "res"
-          - kind: "nkIdent"
-            ident: "add"
-      - kind: "nkCall"
-        sons:
-          - kind: "nkIdent"
-            ident: "fff"
-          - kind: "nkStmtList"
+          - kind: "nkStmtListExpr"
             sons:
-              - kind: "nkCall"
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkCall"
+                    sons:
+                      - kind: "nkDotExpr"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "rOk"
+                          - kind: "nkIdent"
+                            ident: "tryError"
+              - kind: "nkIdent"
+                ident: "false"
+          - kind: "nkExceptBranch"
+            sons:
+              - kind: "nkBracketExpr"
                 sons:
                   - kind: "nkIdent"
-                    ident: "yy"
-  - kind: "nkCommentStmt"
-    "comment": "# we don't what `do` in let but need it in the above commend - this needs"
-  - kind: "nkCommentStmt"
-    "comment": "# more investigation - this is important for templates calls like Result.valueOr"
-  - kind: "nkCommentStmt"
-    "comment": "# which become ugly otherwise"
-  - kind: "nkLetSection"
-    sons:
-      - kind: "nkIdentDefs"
-        sons:
-          - kind: "nkIdent"
-            ident: "xxx"
-          - kind: "nkEmpty"
-          - kind: "nkCall"
-            sons:
-              - kind: "nkIdent"
-                ident: "implicitdo"
+                    ident: "ResultError"
+                  - kind: "nkIdent"
+                    ident: "int"
               - kind: "nkStmtList"
                 sons:
-                  - kind: "nkReturnStmt"
-                    sons:
-                      - kind: "nkIdent"
-                        ident: "xxx"
+                  - kind: "nkIdent"
+                    ident: "true"
   - kind: "nkLetSection"
     sons:
       - kind: "nkIdentDefs"
@@ -1042,3 +1121,115 @@ sons:
               - kind: "nkDiscardStmt"
                 sons:
                   - kind: "nkEmpty"
+  - kind: "nkDiscardStmt"
+    sons:
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: ".."
+          - kind: "nkIdent"
+            ident: "a"
+          - kind: "nkIdent"
+            ident: "b"
+  - kind: "nkDiscardStmt"
+    sons:
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: "..<"
+          - kind: "nkIdent"
+            ident: "a"
+          - kind: "nkIdent"
+            ident: "b"
+  - kind: "nkDiscardStmt"
+    sons:
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: "..^"
+          - kind: "nkIdent"
+            ident: "a"
+          - kind: "nkIdent"
+            ident: "b"
+  - kind: "nkDiscardStmt"
+    sons:
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: ".."
+          - kind: "nkIdent"
+            ident: "a"
+          - kind: "nkIdent"
+            ident: "b"
+  - kind: "nkDiscardStmt"
+    sons:
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: "..^"
+          - kind: "nkIdent"
+            ident: "a"
+          - kind: "nkIdent"
+            ident: "b"
+  - kind: "nkDiscardStmt"
+    sons:
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: "..<"
+          - kind: "nkIdent"
+            ident: "a"
+          - kind: "nkIdent"
+            ident: "b"
+  - kind: "nkDiscardStmt"
+    sons:
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: ".."
+          - kind: "nkIdent"
+            ident: "a"
+          - kind: "nkPrefix"
+            sons:
+              - kind: "nkIdent"
+                ident: "^"
+              - kind: "nkIdent"
+                ident: "b"
+  - kind: "nkDiscardStmt"
+    sons:
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: ".."
+          - kind: "nkIdent"
+            ident: "a"
+          - kind: "nkPrefix"
+            sons:
+              - kind: "nkIdent"
+                ident: "<"
+              - kind: "nkIdent"
+                ident: "b"
+  - kind: "nkDiscardStmt"
+    sons:
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: ".."
+          - kind: "nkIdent"
+            ident: "a"
+          - kind: "nkPrefix"
+            sons:
+              - kind: "nkIdent"
+                ident: "-"
+              - kind: "nkIdent"
+                ident: "b"
+  - kind: "nkDiscardStmt"
+    sons:
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: ".."
+          - kind: "nkIntLit"
+            intVal: -1
+          - kind: "nkIntLit"
+            intVal: -2

--- a/tests/after/import.nim
+++ b/tests/after/import.nim
@@ -9,11 +9,10 @@ import
   gggggggggggggggggg as hhhhhhhhhhhhhhhh
 
 import
-  "."/
-    [
-      tables, sets, long, modules, even, more, more, a_really_long_module_here, more,
-      more, more, more, more
-    ]
+  "."/[
+    tables, sets, long, modules, even, more, more, a_really_long_module_here, more,
+    more, more, more, more
+  ]
 
 import tables, sets
 

--- a/tests/after/postexprs.nim
+++ b/tests/after/postexprs.nim
@@ -1,0 +1,92 @@
+# How do is parsed is a bit of a mystery, so here are some test cases...
+
+command do ():
+  discard 0
+
+# These two forms _generally_ generate the same AST, significantly different from the one above
+command:
+  discard 1
+command:
+  discard 2
+
+command "param" do ():
+    discard 3
+# for some reason, this comes with an extra nkCall in the AST
+command "param" do:
+    discard 4
+command "param":
+  discard 5
+
+call do ():
+  discard 6
+call:
+  discard 7
+call:
+  discard 8
+
+call("param") do ():
+  discard 9
+call("param"):
+  discard 10
+call("param"):
+  discard 11
+
+call.dotExpr do ():
+  discard 12
+call.dotExpr:
+  discard 13
+call.dotExpr:
+  discard 14
+
+asgn =
+  command do ():
+    discard 15
+asgn =
+  command:
+    discard 16
+asgn =
+  command:
+    discard 17
+
+asgn =
+  command do ():
+    discard 18
+asgn =
+  command:
+    discard 19
+asgn =
+  command:
+    discard 20
+
+if false:
+  return command do ():
+      discard 21
+
+if false:
+  return command:
+      discard 22
+
+if false:
+  return command:
+      discard 23
+
+discard command do ():
+    discard 24
+
+discard command:
+    discard 25
+
+discard command:
+    discard 26
+
+call(
+  command do ():
+    27
+  ,
+)
+call(
+  command do:
+    28
+  ,
+)
+call(command: 29)

--- a/tests/after/postexprs.nim.nph.yaml
+++ b/tests/after/postexprs.nim.nph.yaml
@@ -1,0 +1,500 @@
+kind: "nkStmtList"
+sons:
+  - kind: "nkCommentStmt"
+    "comment": "# How do is parsed is a bit of a mystery, so here are some test cases..."
+  - kind: "nkCall"
+    sons:
+      - kind: "nkIdent"
+        ident: "command"
+      - kind: "nkDo"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkEmpty"
+          - kind: "nkEmpty"
+          - kind: "nkFormalParams"
+            sons:
+              - kind: "nkEmpty"
+          - kind: "nkEmpty"
+          - kind: "nkEmpty"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkIntLit"
+                    intVal: 0
+  - kind: "nkCommentStmt"
+    "comment": "# These two forms _generally_ generate the same AST, significantly different from the one above"
+  - kind: "nkCall"
+    sons:
+      - kind: "nkIdent"
+        ident: "command"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkIntLit"
+                intVal: 1
+  - kind: "nkCall"
+    sons:
+      - kind: "nkIdent"
+        ident: "command"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkIntLit"
+                intVal: 2
+  - kind: "nkCommand"
+    sons:
+      - kind: "nkIdent"
+        ident: "command"
+      - kind: "nkCall"
+        sons:
+          - kind: "nkStrLit"
+            strVal: "param"
+          - kind: "nkDo"
+            sons:
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkFormalParams"
+                sons:
+                  - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkStmtList"
+                sons:
+                  - kind: "nkDiscardStmt"
+                    sons:
+                      - kind: "nkIntLit"
+                        intVal: 3
+  - kind: "nkCommentStmt"
+    "comment": "# for some reason, this comes with an extra nkCall in the AST"
+  - kind: "nkCommand"
+    sons:
+      - kind: "nkIdent"
+        ident: "command"
+      - kind: "nkCall"
+        sons:
+          - kind: "nkStrLit"
+            strVal: "param"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkIntLit"
+                    intVal: 4
+  - kind: "nkCommand"
+    sons:
+      - kind: "nkIdent"
+        ident: "command"
+      - kind: "nkStrLit"
+        strVal: "param"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkIntLit"
+                intVal: 5
+  - kind: "nkCall"
+    sons:
+      - kind: "nkIdent"
+        ident: "call"
+      - kind: "nkDo"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkEmpty"
+          - kind: "nkEmpty"
+          - kind: "nkFormalParams"
+            sons:
+              - kind: "nkEmpty"
+          - kind: "nkEmpty"
+          - kind: "nkEmpty"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkIntLit"
+                    intVal: 6
+  - kind: "nkCall"
+    sons:
+      - kind: "nkIdent"
+        ident: "call"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkIntLit"
+                intVal: 7
+  - kind: "nkCall"
+    sons:
+      - kind: "nkIdent"
+        ident: "call"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkIntLit"
+                intVal: 8
+  - kind: "nkCall"
+    sons:
+      - kind: "nkIdent"
+        ident: "call"
+      - kind: "nkStrLit"
+        strVal: "param"
+      - kind: "nkDo"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkEmpty"
+          - kind: "nkEmpty"
+          - kind: "nkFormalParams"
+            sons:
+              - kind: "nkEmpty"
+          - kind: "nkEmpty"
+          - kind: "nkEmpty"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkIntLit"
+                    intVal: 9
+  - kind: "nkCall"
+    sons:
+      - kind: "nkIdent"
+        ident: "call"
+      - kind: "nkStrLit"
+        strVal: "param"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkIntLit"
+                intVal: 10
+  - kind: "nkCall"
+    sons:
+      - kind: "nkIdent"
+        ident: "call"
+      - kind: "nkStrLit"
+        strVal: "param"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkIntLit"
+                intVal: 11
+  - kind: "nkCall"
+    sons:
+      - kind: "nkDotExpr"
+        sons:
+          - kind: "nkIdent"
+            ident: "call"
+          - kind: "nkIdent"
+            ident: "dotExpr"
+      - kind: "nkDo"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkEmpty"
+          - kind: "nkEmpty"
+          - kind: "nkFormalParams"
+            sons:
+              - kind: "nkEmpty"
+          - kind: "nkEmpty"
+          - kind: "nkEmpty"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkIntLit"
+                    intVal: 12
+  - kind: "nkCall"
+    sons:
+      - kind: "nkDotExpr"
+        sons:
+          - kind: "nkIdent"
+            ident: "call"
+          - kind: "nkIdent"
+            ident: "dotExpr"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkIntLit"
+                intVal: 13
+  - kind: "nkCall"
+    sons:
+      - kind: "nkDotExpr"
+        sons:
+          - kind: "nkIdent"
+            ident: "call"
+          - kind: "nkIdent"
+            ident: "dotExpr"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkIntLit"
+                intVal: 14
+  - kind: "nkAsgn"
+    sons:
+      - kind: "nkIdent"
+        ident: "asgn"
+      - kind: "nkCall"
+        sons:
+          - kind: "nkIdent"
+            ident: "command"
+          - kind: "nkDo"
+            sons:
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkFormalParams"
+                sons:
+                  - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkStmtList"
+                sons:
+                  - kind: "nkDiscardStmt"
+                    sons:
+                      - kind: "nkIntLit"
+                        intVal: 15
+  - kind: "nkAsgn"
+    sons:
+      - kind: "nkIdent"
+        ident: "asgn"
+      - kind: "nkCall"
+        sons:
+          - kind: "nkIdent"
+            ident: "command"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkIntLit"
+                    intVal: 16
+  - kind: "nkAsgn"
+    sons:
+      - kind: "nkIdent"
+        ident: "asgn"
+      - kind: "nkCall"
+        sons:
+          - kind: "nkIdent"
+            ident: "command"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkIntLit"
+                    intVal: 17
+  - kind: "nkAsgn"
+    sons:
+      - kind: "nkIdent"
+        ident: "asgn"
+      - kind: "nkCall"
+        sons:
+          - kind: "nkIdent"
+            ident: "command"
+          - kind: "nkDo"
+            sons:
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkFormalParams"
+                sons:
+                  - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkStmtList"
+                sons:
+                  - kind: "nkDiscardStmt"
+                    sons:
+                      - kind: "nkIntLit"
+                        intVal: 18
+  - kind: "nkAsgn"
+    sons:
+      - kind: "nkIdent"
+        ident: "asgn"
+      - kind: "nkCall"
+        sons:
+          - kind: "nkIdent"
+            ident: "command"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkIntLit"
+                    intVal: 19
+  - kind: "nkAsgn"
+    sons:
+      - kind: "nkIdent"
+        ident: "asgn"
+      - kind: "nkCall"
+        sons:
+          - kind: "nkIdent"
+            ident: "command"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkIntLit"
+                    intVal: 20
+  - kind: "nkIfStmt"
+    sons:
+      - kind: "nkElifBranch"
+        sons:
+          - kind: "nkIdent"
+            ident: "false"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkReturnStmt"
+                sons:
+                  - kind: "nkCall"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "command"
+                      - kind: "nkDo"
+                        sons:
+                          - kind: "nkEmpty"
+                          - kind: "nkEmpty"
+                          - kind: "nkEmpty"
+                          - kind: "nkFormalParams"
+                            sons:
+                              - kind: "nkEmpty"
+                          - kind: "nkEmpty"
+                          - kind: "nkEmpty"
+                          - kind: "nkStmtList"
+                            sons:
+                              - kind: "nkDiscardStmt"
+                                sons:
+                                  - kind: "nkIntLit"
+                                    intVal: 21
+  - kind: "nkIfStmt"
+    sons:
+      - kind: "nkElifBranch"
+        sons:
+          - kind: "nkIdent"
+            ident: "false"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkReturnStmt"
+                sons:
+                  - kind: "nkCall"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "command"
+                      - kind: "nkStmtList"
+                        sons:
+                          - kind: "nkDiscardStmt"
+                            sons:
+                              - kind: "nkIntLit"
+                                intVal: 22
+  - kind: "nkIfStmt"
+    sons:
+      - kind: "nkElifBranch"
+        sons:
+          - kind: "nkIdent"
+            ident: "false"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkReturnStmt"
+                sons:
+                  - kind: "nkCall"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "command"
+                      - kind: "nkStmtList"
+                        sons:
+                          - kind: "nkDiscardStmt"
+                            sons:
+                              - kind: "nkIntLit"
+                                intVal: 23
+  - kind: "nkDiscardStmt"
+    sons:
+      - kind: "nkCall"
+        sons:
+          - kind: "nkIdent"
+            ident: "command"
+          - kind: "nkDo"
+            sons:
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkFormalParams"
+                sons:
+                  - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkStmtList"
+                sons:
+                  - kind: "nkDiscardStmt"
+                    sons:
+                      - kind: "nkIntLit"
+                        intVal: 24
+  - kind: "nkDiscardStmt"
+    sons:
+      - kind: "nkCall"
+        sons:
+          - kind: "nkIdent"
+            ident: "command"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkIntLit"
+                    intVal: 25
+  - kind: "nkDiscardStmt"
+    sons:
+      - kind: "nkCall"
+        sons:
+          - kind: "nkIdent"
+            ident: "command"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkIntLit"
+                    intVal: 26
+  - kind: "nkCall"
+    sons:
+      - kind: "nkIdent"
+        ident: "call"
+      - kind: "nkCall"
+        sons:
+          - kind: "nkIdent"
+            ident: "command"
+          - kind: "nkDo"
+            sons:
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkFormalParams"
+                sons:
+                  - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkStmtList"
+                sons:
+                  - kind: "nkIntLit"
+                    intVal: 27
+  - kind: "nkCall"
+    sons:
+      - kind: "nkIdent"
+        ident: "call"
+      - kind: "nkCall"
+        sons:
+          - kind: "nkIdent"
+            ident: "command"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkIntLit"
+                intVal: 28
+  - kind: "nkObjConstr"
+    sons:
+      - kind: "nkIdent"
+        ident: "call"
+      - kind: "nkExprColonExpr"
+        sons:
+          - kind: "nkIdent"
+            ident: "command"
+          - kind: "nkIntLit"
+            intVal: 29

--- a/tests/after/types.nim
+++ b/tests/after/types.nim
@@ -22,3 +22,26 @@ type CaseObject = object
     vfalse: int
   of true:
     vtrue: int
+
+type CaseObject = object
+  case f {.
+    aaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccc,
+    ddddddddddddddddddddd, eeeeeeeeeeeeeeeeeee
+  .}: bool
+  of false:
+    vfalse: int
+  of true:
+    vtrue: int
+
+type PragmaObject {.
+  objectPragma, aaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbb, cccccccccccccccccccccc,
+  dddddddddddddddddddd
+.} = object
+  vfalse {.fieldPragma.}: int
+  vpublic* {.fieldPragma.}: int
+
+  vfalse {.
+    fieldPragma, aaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbb,
+    cccccccccccccccccccccccccccc, dddddddddddddddddddddd
+  .}: int
+  vpublic* {.fieldPragma.}: int

--- a/tests/after/types.nim.nph.yaml
+++ b/tests/after/types.nim.nph.yaml
@@ -187,3 +187,160 @@ sons:
                                   - kind: "nkIdent"
                                     ident: "int"
                                   - kind: "nkEmpty"
+  - kind: "nkTypeSection"
+    sons:
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkIdent"
+            ident: "CaseObject"
+          - kind: "nkEmpty"
+          - kind: "nkObjectTy"
+            sons:
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkRecList"
+                sons:
+                  - kind: "nkRecCase"
+                    sons:
+                      - kind: "nkIdentDefs"
+                        sons:
+                          - kind: "nkPragmaExpr"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: "f"
+                              - kind: "nkPragma"
+                                sons:
+                                  - kind: "nkIdent"
+                                    ident: "aaaaaaaaaaaaaaaaaaaaaaaaa"
+                                  - kind: "nkIdent"
+                                    ident: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                                  - kind: "nkIdent"
+                                    ident: "cccccccccccccccccccc"
+                                  - kind: "nkIdent"
+                                    ident: "ddddddddddddddddddddd"
+                                  - kind: "nkIdent"
+                                    ident: "eeeeeeeeeeeeeeeeeee"
+                          - kind: "nkIdent"
+                            ident: "bool"
+                          - kind: "nkEmpty"
+                      - kind: "nkOfBranch"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "false"
+                          - kind: "nkRecList"
+                            sons:
+                              - kind: "nkIdentDefs"
+                                sons:
+                                  - kind: "nkIdent"
+                                    ident: "vfalse"
+                                  - kind: "nkIdent"
+                                    ident: "int"
+                                  - kind: "nkEmpty"
+                      - kind: "nkOfBranch"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "true"
+                          - kind: "nkRecList"
+                            sons:
+                              - kind: "nkIdentDefs"
+                                sons:
+                                  - kind: "nkIdent"
+                                    ident: "vtrue"
+                                  - kind: "nkIdent"
+                                    ident: "int"
+                                  - kind: "nkEmpty"
+  - kind: "nkTypeSection"
+    sons:
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkPragmaExpr"
+            sons:
+              - kind: "nkIdent"
+                ident: "PragmaObject"
+              - kind: "nkPragma"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "objectPragma"
+                  - kind: "nkIdent"
+                    ident: "aaaaaaaaaaaaaaaa"
+                  - kind: "nkIdent"
+                    ident: "bbbbbbbbbbbbbbbbbb"
+                  - kind: "nkIdent"
+                    ident: "cccccccccccccccccccccc"
+                  - kind: "nkIdent"
+                    ident: "dddddddddddddddddddd"
+          - kind: "nkEmpty"
+          - kind: "nkObjectTy"
+            sons:
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkRecList"
+                sons:
+                  - kind: "nkIdentDefs"
+                    sons:
+                      - kind: "nkPragmaExpr"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "vfalse"
+                          - kind: "nkPragma"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: "fieldPragma"
+                      - kind: "nkIdent"
+                        ident: "int"
+                      - kind: "nkEmpty"
+                  - kind: "nkIdentDefs"
+                    sons:
+                      - kind: "nkPragmaExpr"
+                        sons:
+                          - kind: "nkPostfix"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: "*"
+                              - kind: "nkIdent"
+                                ident: "vpublic"
+                          - kind: "nkPragma"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: "fieldPragma"
+                      - kind: "nkIdent"
+                        ident: "int"
+                      - kind: "nkEmpty"
+                  - kind: "nkIdentDefs"
+                    sons:
+                      - kind: "nkPragmaExpr"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "vfalse"
+                          - kind: "nkPragma"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: "fieldPragma"
+                              - kind: "nkIdent"
+                                ident: "aaaaaaaaaaaaaaaaaaaaaaaa"
+                              - kind: "nkIdent"
+                                ident: "bbbbbbbbbbbbbbbbbbbbbbbb"
+                              - kind: "nkIdent"
+                                ident: "cccccccccccccccccccccccccccc"
+                              - kind: "nkIdent"
+                                ident: "dddddddddddddddddddddd"
+                      - kind: "nkIdent"
+                        ident: "int"
+                      - kind: "nkEmpty"
+                  - kind: "nkIdentDefs"
+                    sons:
+                      - kind: "nkPragmaExpr"
+                        sons:
+                          - kind: "nkPostfix"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: "*"
+                              - kind: "nkIdent"
+                                ident: "vpublic"
+                          - kind: "nkPragma"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: "fieldPragma"
+                      - kind: "nkIdent"
+                        ident: "int"
+                      - kind: "nkEmpty"

--- a/tests/before/exprs.nim
+++ b/tests/before/exprs.nim
@@ -19,23 +19,19 @@ template ttt*: untyped =
   (block:
     xxx)[]
 
+# single-line expressions with varying amounts of pars
+
+let
+  x0 = (discard; false)
+  x1 = if (discard; false): 0 else: 1
+  x2 = (if (discard; false): 0 else: 1)
+  x3 = (if (discard; false): (0) else: (1))
 
 # command syntax with colon
 discard xxxx "arg":
   yyy
 
-# TODO
-# (try: (discard rOk.tryError(); false) except ResultError[int]: true)
-
-res.add (
-  fff() do:
-    yy() )
-
-# we don't what `do` in let but need it in the above commend - this needs
-# more investigation - this is important for templates calls like Result.valueOr
-# which become ugly otherwise
-let xxx = implicitdo:
-    return xxx
+(try: (discard rOk.tryError(); false) except ResultError[int]: true)
 
 let shortInfix = a*b*c+d*e*f+(a+b)*g
 
@@ -65,3 +61,13 @@ of aaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbb, cccccccccccccccccc
 else:
   discard
 
+discard a..b
+discard a..<b
+discard a..^b
+discard a .. b
+discard a ..^ b
+discard a ..< b
+discard a .. ^b
+discard a .. <b
+discard a .. -b
+discard -1.. -2

--- a/tests/before/exprs.nim.nph.yaml
+++ b/tests/before/exprs.nim.nph.yaml
@@ -169,6 +169,100 @@ sons:
                           - kind: "nkIdent"
                             ident: "xxx"
   - kind: "nkCommentStmt"
+    "comment": "# single-line expressions with varying amounts of pars"
+  - kind: "nkLetSection"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "x0"
+          - kind: "nkEmpty"
+          - kind: "nkStmtListExpr"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+              - kind: "nkIdent"
+                ident: "false"
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "x1"
+          - kind: "nkEmpty"
+          - kind: "nkIfExpr"
+            sons:
+              - kind: "nkElifExpr"
+                sons:
+                  - kind: "nkStmtListExpr"
+                    sons:
+                      - kind: "nkDiscardStmt"
+                        sons:
+                          - kind: "nkEmpty"
+                      - kind: "nkIdent"
+                        ident: "false"
+                  - kind: "nkStmtList"
+                    sons:
+                      - kind: "nkIntLit"
+                        intVal: 0
+              - kind: "nkElseExpr"
+                sons:
+                  - kind: "nkStmtList"
+                    sons:
+                      - kind: "nkIntLit"
+                        intVal: 1
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "x2"
+          - kind: "nkEmpty"
+          - kind: "nkStmtListExpr"
+            sons:
+              - kind: "nkIfStmt"
+                sons:
+                  - kind: "nkElifExpr"
+                    sons:
+                      - kind: "nkStmtListExpr"
+                        sons:
+                          - kind: "nkDiscardStmt"
+                            sons:
+                              - kind: "nkEmpty"
+                          - kind: "nkIdent"
+                            ident: "false"
+                      - kind: "nkIntLit"
+                        intVal: 0
+                  - kind: "nkElseExpr"
+                    sons:
+                      - kind: "nkIntLit"
+                        intVal: 1
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "x3"
+          - kind: "nkEmpty"
+          - kind: "nkStmtListExpr"
+            sons:
+              - kind: "nkIfStmt"
+                sons:
+                  - kind: "nkElifExpr"
+                    sons:
+                      - kind: "nkStmtListExpr"
+                        sons:
+                          - kind: "nkDiscardStmt"
+                            sons:
+                              - kind: "nkEmpty"
+                          - kind: "nkIdent"
+                            ident: "false"
+                      - kind: "nkPar"
+                        sons:
+                          - kind: "nkIntLit"
+                            intVal: 0
+                  - kind: "nkElseExpr"
+                    sons:
+                      - kind: "nkPar"
+                        sons:
+                          - kind: "nkIntLit"
+                            intVal: 1
+  - kind: "nkCommentStmt"
     "comment": "# command syntax with colon"
   - kind: "nkDiscardStmt"
     sons:
@@ -182,51 +276,34 @@ sons:
             sons:
               - kind: "nkIdent"
                 ident: "yyy"
-  - kind: "nkCommentStmt"
-    "comment": "# TODO"
-  - kind: "nkCommentStmt"
-    "comment": "# (try: (discard rOk.tryError(); false) except ResultError[int]: true)"
-  - kind: "nkCommand"
+  - kind: "nkStmtListExpr"
     sons:
-      - kind: "nkDotExpr"
+      - kind: "nkTryStmt"
         sons:
-          - kind: "nkIdent"
-            ident: "res"
-          - kind: "nkIdent"
-            ident: "add"
-      - kind: "nkCall"
-        sons:
-          - kind: "nkIdent"
-            ident: "fff"
-          - kind: "nkStmtList"
+          - kind: "nkStmtListExpr"
             sons:
-              - kind: "nkCall"
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkCall"
+                    sons:
+                      - kind: "nkDotExpr"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "rOk"
+                          - kind: "nkIdent"
+                            ident: "tryError"
+              - kind: "nkIdent"
+                ident: "false"
+          - kind: "nkExceptBranch"
+            sons:
+              - kind: "nkBracketExpr"
                 sons:
                   - kind: "nkIdent"
-                    ident: "yy"
-  - kind: "nkCommentStmt"
-    "comment": "# we don't what `do` in let but need it in the above commend - this needs"
-  - kind: "nkCommentStmt"
-    "comment": "# more investigation - this is important for templates calls like Result.valueOr"
-  - kind: "nkCommentStmt"
-    "comment": "# which become ugly otherwise"
-  - kind: "nkLetSection"
-    sons:
-      - kind: "nkIdentDefs"
-        sons:
-          - kind: "nkIdent"
-            ident: "xxx"
-          - kind: "nkEmpty"
-          - kind: "nkCall"
-            sons:
+                    ident: "ResultError"
+                  - kind: "nkIdent"
+                    ident: "int"
               - kind: "nkIdent"
-                ident: "implicitdo"
-              - kind: "nkStmtList"
-                sons:
-                  - kind: "nkReturnStmt"
-                    sons:
-                      - kind: "nkIdent"
-                        ident: "xxx"
+                ident: "true"
   - kind: "nkLetSection"
     sons:
       - kind: "nkIdentDefs"
@@ -1042,3 +1119,115 @@ sons:
               - kind: "nkDiscardStmt"
                 sons:
                   - kind: "nkEmpty"
+  - kind: "nkDiscardStmt"
+    sons:
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: ".."
+          - kind: "nkIdent"
+            ident: "a"
+          - kind: "nkIdent"
+            ident: "b"
+  - kind: "nkDiscardStmt"
+    sons:
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: "..<"
+          - kind: "nkIdent"
+            ident: "a"
+          - kind: "nkIdent"
+            ident: "b"
+  - kind: "nkDiscardStmt"
+    sons:
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: "..^"
+          - kind: "nkIdent"
+            ident: "a"
+          - kind: "nkIdent"
+            ident: "b"
+  - kind: "nkDiscardStmt"
+    sons:
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: ".."
+          - kind: "nkIdent"
+            ident: "a"
+          - kind: "nkIdent"
+            ident: "b"
+  - kind: "nkDiscardStmt"
+    sons:
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: "..^"
+          - kind: "nkIdent"
+            ident: "a"
+          - kind: "nkIdent"
+            ident: "b"
+  - kind: "nkDiscardStmt"
+    sons:
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: "..<"
+          - kind: "nkIdent"
+            ident: "a"
+          - kind: "nkIdent"
+            ident: "b"
+  - kind: "nkDiscardStmt"
+    sons:
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: ".."
+          - kind: "nkIdent"
+            ident: "a"
+          - kind: "nkPrefix"
+            sons:
+              - kind: "nkIdent"
+                ident: "^"
+              - kind: "nkIdent"
+                ident: "b"
+  - kind: "nkDiscardStmt"
+    sons:
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: ".."
+          - kind: "nkIdent"
+            ident: "a"
+          - kind: "nkPrefix"
+            sons:
+              - kind: "nkIdent"
+                ident: "<"
+              - kind: "nkIdent"
+                ident: "b"
+  - kind: "nkDiscardStmt"
+    sons:
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: ".."
+          - kind: "nkIdent"
+            ident: "a"
+          - kind: "nkPrefix"
+            sons:
+              - kind: "nkIdent"
+                ident: "-"
+              - kind: "nkIdent"
+                ident: "b"
+  - kind: "nkDiscardStmt"
+    sons:
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: ".."
+          - kind: "nkIntLit"
+            intVal: -1
+          - kind: "nkIntLit"
+            intVal: -2

--- a/tests/before/postexprs.nim
+++ b/tests/before/postexprs.nim
@@ -1,0 +1,88 @@
+# How do is parsed is a bit of a mystery, so here are some test cases...
+
+
+command do ():
+  discard 0
+
+# These two forms _generally_ generate the same AST, significantly different from the one above
+command do:
+  discard 1
+command:
+  discard 2
+
+command "param" do():
+  discard 3
+# for some reason, this comes with an extra nkCall in the AST
+command "param" do:
+  discard 4
+command "param":
+  discard 5
+
+call() do ():
+  discard 6
+call() do:
+  discard 7
+call():
+  discard 8
+
+call("param") do():
+  discard 9
+call("param") do:
+  discard 10
+call("param"):
+  discard 11
+
+
+call.dotExpr do():
+  discard 12
+call.dotExpr do:
+  discard 13
+call.dotExpr:
+  discard 14
+
+asgn = command do():
+  discard 15
+asgn = command do:
+  discard 16
+asgn = command:
+  discard 17
+
+asgn =
+  command do ():
+    discard 18
+asgn =
+  command:
+    discard 19
+asgn =
+  command:
+    discard 20
+
+if false:
+  return command do():
+    discard 21
+
+if false:
+  return command do:
+    discard 22
+
+if false:
+  return command:
+    discard 23
+
+discard command do():
+  discard 24
+
+discard command do:
+  discard 25
+
+discard command:
+  discard 26
+
+
+call(command do():
+  27)
+call(command do:
+  28)
+call(command:
+  29
+)

--- a/tests/before/postexprs.nim.nph.yaml
+++ b/tests/before/postexprs.nim.nph.yaml
@@ -1,0 +1,500 @@
+kind: "nkStmtList"
+sons:
+  - kind: "nkCommentStmt"
+    "comment": "# How do is parsed is a bit of a mystery, so here are some test cases..."
+  - kind: "nkCall"
+    sons:
+      - kind: "nkIdent"
+        ident: "command"
+      - kind: "nkDo"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkEmpty"
+          - kind: "nkEmpty"
+          - kind: "nkFormalParams"
+            sons:
+              - kind: "nkEmpty"
+          - kind: "nkEmpty"
+          - kind: "nkEmpty"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkIntLit"
+                    intVal: 0
+  - kind: "nkCommentStmt"
+    "comment": "# These two forms _generally_ generate the same AST, significantly different from the one above"
+  - kind: "nkCall"
+    sons:
+      - kind: "nkIdent"
+        ident: "command"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkIntLit"
+                intVal: 1
+  - kind: "nkCall"
+    sons:
+      - kind: "nkIdent"
+        ident: "command"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkIntLit"
+                intVal: 2
+  - kind: "nkCommand"
+    sons:
+      - kind: "nkIdent"
+        ident: "command"
+      - kind: "nkCall"
+        sons:
+          - kind: "nkStrLit"
+            strVal: "param"
+          - kind: "nkDo"
+            sons:
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkFormalParams"
+                sons:
+                  - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkStmtList"
+                sons:
+                  - kind: "nkDiscardStmt"
+                    sons:
+                      - kind: "nkIntLit"
+                        intVal: 3
+  - kind: "nkCommentStmt"
+    "comment": "# for some reason, this comes with an extra nkCall in the AST"
+  - kind: "nkCommand"
+    sons:
+      - kind: "nkIdent"
+        ident: "command"
+      - kind: "nkCall"
+        sons:
+          - kind: "nkStrLit"
+            strVal: "param"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkIntLit"
+                    intVal: 4
+  - kind: "nkCommand"
+    sons:
+      - kind: "nkIdent"
+        ident: "command"
+      - kind: "nkStrLit"
+        strVal: "param"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkIntLit"
+                intVal: 5
+  - kind: "nkCall"
+    sons:
+      - kind: "nkIdent"
+        ident: "call"
+      - kind: "nkDo"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkEmpty"
+          - kind: "nkEmpty"
+          - kind: "nkFormalParams"
+            sons:
+              - kind: "nkEmpty"
+          - kind: "nkEmpty"
+          - kind: "nkEmpty"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkIntLit"
+                    intVal: 6
+  - kind: "nkCall"
+    sons:
+      - kind: "nkIdent"
+        ident: "call"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkIntLit"
+                intVal: 7
+  - kind: "nkCall"
+    sons:
+      - kind: "nkIdent"
+        ident: "call"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkIntLit"
+                intVal: 8
+  - kind: "nkCall"
+    sons:
+      - kind: "nkIdent"
+        ident: "call"
+      - kind: "nkStrLit"
+        strVal: "param"
+      - kind: "nkDo"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkEmpty"
+          - kind: "nkEmpty"
+          - kind: "nkFormalParams"
+            sons:
+              - kind: "nkEmpty"
+          - kind: "nkEmpty"
+          - kind: "nkEmpty"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkIntLit"
+                    intVal: 9
+  - kind: "nkCall"
+    sons:
+      - kind: "nkIdent"
+        ident: "call"
+      - kind: "nkStrLit"
+        strVal: "param"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkIntLit"
+                intVal: 10
+  - kind: "nkCall"
+    sons:
+      - kind: "nkIdent"
+        ident: "call"
+      - kind: "nkStrLit"
+        strVal: "param"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkIntLit"
+                intVal: 11
+  - kind: "nkCall"
+    sons:
+      - kind: "nkDotExpr"
+        sons:
+          - kind: "nkIdent"
+            ident: "call"
+          - kind: "nkIdent"
+            ident: "dotExpr"
+      - kind: "nkDo"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkEmpty"
+          - kind: "nkEmpty"
+          - kind: "nkFormalParams"
+            sons:
+              - kind: "nkEmpty"
+          - kind: "nkEmpty"
+          - kind: "nkEmpty"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkIntLit"
+                    intVal: 12
+  - kind: "nkCall"
+    sons:
+      - kind: "nkDotExpr"
+        sons:
+          - kind: "nkIdent"
+            ident: "call"
+          - kind: "nkIdent"
+            ident: "dotExpr"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkIntLit"
+                intVal: 13
+  - kind: "nkCall"
+    sons:
+      - kind: "nkDotExpr"
+        sons:
+          - kind: "nkIdent"
+            ident: "call"
+          - kind: "nkIdent"
+            ident: "dotExpr"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkIntLit"
+                intVal: 14
+  - kind: "nkAsgn"
+    sons:
+      - kind: "nkIdent"
+        ident: "asgn"
+      - kind: "nkCall"
+        sons:
+          - kind: "nkIdent"
+            ident: "command"
+          - kind: "nkDo"
+            sons:
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkFormalParams"
+                sons:
+                  - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkStmtList"
+                sons:
+                  - kind: "nkDiscardStmt"
+                    sons:
+                      - kind: "nkIntLit"
+                        intVal: 15
+  - kind: "nkAsgn"
+    sons:
+      - kind: "nkIdent"
+        ident: "asgn"
+      - kind: "nkCall"
+        sons:
+          - kind: "nkIdent"
+            ident: "command"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkIntLit"
+                    intVal: 16
+  - kind: "nkAsgn"
+    sons:
+      - kind: "nkIdent"
+        ident: "asgn"
+      - kind: "nkCall"
+        sons:
+          - kind: "nkIdent"
+            ident: "command"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkIntLit"
+                    intVal: 17
+  - kind: "nkAsgn"
+    sons:
+      - kind: "nkIdent"
+        ident: "asgn"
+      - kind: "nkCall"
+        sons:
+          - kind: "nkIdent"
+            ident: "command"
+          - kind: "nkDo"
+            sons:
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkFormalParams"
+                sons:
+                  - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkStmtList"
+                sons:
+                  - kind: "nkDiscardStmt"
+                    sons:
+                      - kind: "nkIntLit"
+                        intVal: 18
+  - kind: "nkAsgn"
+    sons:
+      - kind: "nkIdent"
+        ident: "asgn"
+      - kind: "nkCall"
+        sons:
+          - kind: "nkIdent"
+            ident: "command"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkIntLit"
+                    intVal: 19
+  - kind: "nkAsgn"
+    sons:
+      - kind: "nkIdent"
+        ident: "asgn"
+      - kind: "nkCall"
+        sons:
+          - kind: "nkIdent"
+            ident: "command"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkIntLit"
+                    intVal: 20
+  - kind: "nkIfStmt"
+    sons:
+      - kind: "nkElifBranch"
+        sons:
+          - kind: "nkIdent"
+            ident: "false"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkReturnStmt"
+                sons:
+                  - kind: "nkCall"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "command"
+                      - kind: "nkDo"
+                        sons:
+                          - kind: "nkEmpty"
+                          - kind: "nkEmpty"
+                          - kind: "nkEmpty"
+                          - kind: "nkFormalParams"
+                            sons:
+                              - kind: "nkEmpty"
+                          - kind: "nkEmpty"
+                          - kind: "nkEmpty"
+                          - kind: "nkStmtList"
+                            sons:
+                              - kind: "nkDiscardStmt"
+                                sons:
+                                  - kind: "nkIntLit"
+                                    intVal: 21
+  - kind: "nkIfStmt"
+    sons:
+      - kind: "nkElifBranch"
+        sons:
+          - kind: "nkIdent"
+            ident: "false"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkReturnStmt"
+                sons:
+                  - kind: "nkCall"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "command"
+                      - kind: "nkStmtList"
+                        sons:
+                          - kind: "nkDiscardStmt"
+                            sons:
+                              - kind: "nkIntLit"
+                                intVal: 22
+  - kind: "nkIfStmt"
+    sons:
+      - kind: "nkElifBranch"
+        sons:
+          - kind: "nkIdent"
+            ident: "false"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkReturnStmt"
+                sons:
+                  - kind: "nkCall"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "command"
+                      - kind: "nkStmtList"
+                        sons:
+                          - kind: "nkDiscardStmt"
+                            sons:
+                              - kind: "nkIntLit"
+                                intVal: 23
+  - kind: "nkDiscardStmt"
+    sons:
+      - kind: "nkCall"
+        sons:
+          - kind: "nkIdent"
+            ident: "command"
+          - kind: "nkDo"
+            sons:
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkFormalParams"
+                sons:
+                  - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkStmtList"
+                sons:
+                  - kind: "nkDiscardStmt"
+                    sons:
+                      - kind: "nkIntLit"
+                        intVal: 24
+  - kind: "nkDiscardStmt"
+    sons:
+      - kind: "nkCall"
+        sons:
+          - kind: "nkIdent"
+            ident: "command"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkIntLit"
+                    intVal: 25
+  - kind: "nkDiscardStmt"
+    sons:
+      - kind: "nkCall"
+        sons:
+          - kind: "nkIdent"
+            ident: "command"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkIntLit"
+                    intVal: 26
+  - kind: "nkCall"
+    sons:
+      - kind: "nkIdent"
+        ident: "call"
+      - kind: "nkCall"
+        sons:
+          - kind: "nkIdent"
+            ident: "command"
+          - kind: "nkDo"
+            sons:
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkFormalParams"
+                sons:
+                  - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkStmtList"
+                sons:
+                  - kind: "nkIntLit"
+                    intVal: 27
+  - kind: "nkCall"
+    sons:
+      - kind: "nkIdent"
+        ident: "call"
+      - kind: "nkCall"
+        sons:
+          - kind: "nkIdent"
+            ident: "command"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkIntLit"
+                intVal: 28
+  - kind: "nkObjConstr"
+    sons:
+      - kind: "nkIdent"
+        ident: "call"
+      - kind: "nkExprColonExpr"
+        sons:
+          - kind: "nkIdent"
+            ident: "command"
+          - kind: "nkIntLit"
+            intVal: 29

--- a/tests/before/types.nim
+++ b/tests/before/types.nim
@@ -13,3 +13,18 @@ type CaseObject = object
     vfalse: int
   of true:
     vtrue: int
+
+type CaseObject = object
+  case f {.aaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccc, ddddddddddddddddddddd, eeeeeeeeeeeeeeeeeee.}: bool
+  of false:
+    vfalse: int
+  of true:
+    vtrue: int
+
+type PragmaObject {.objectPragma, aaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbb, cccccccccccccccccccccc, dddddddddddddddddddd.} = object
+  vfalse {.fieldPragma.}: int
+  vpublic* {.fieldPragma.}: int
+
+  vfalse {.fieldPragma, aaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccccccccccc, dddddddddddddddddddddd.}: int
+  vpublic* {.fieldPragma.}: int
+

--- a/tests/before/types.nim.nph.yaml
+++ b/tests/before/types.nim.nph.yaml
@@ -187,3 +187,160 @@ sons:
                                   - kind: "nkIdent"
                                     ident: "int"
                                   - kind: "nkEmpty"
+  - kind: "nkTypeSection"
+    sons:
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkIdent"
+            ident: "CaseObject"
+          - kind: "nkEmpty"
+          - kind: "nkObjectTy"
+            sons:
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkRecList"
+                sons:
+                  - kind: "nkRecCase"
+                    sons:
+                      - kind: "nkIdentDefs"
+                        sons:
+                          - kind: "nkPragmaExpr"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: "f"
+                              - kind: "nkPragma"
+                                sons:
+                                  - kind: "nkIdent"
+                                    ident: "aaaaaaaaaaaaaaaaaaaaaaaaa"
+                                  - kind: "nkIdent"
+                                    ident: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                                  - kind: "nkIdent"
+                                    ident: "cccccccccccccccccccc"
+                                  - kind: "nkIdent"
+                                    ident: "ddddddddddddddddddddd"
+                                  - kind: "nkIdent"
+                                    ident: "eeeeeeeeeeeeeeeeeee"
+                          - kind: "nkIdent"
+                            ident: "bool"
+                          - kind: "nkEmpty"
+                      - kind: "nkOfBranch"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "false"
+                          - kind: "nkRecList"
+                            sons:
+                              - kind: "nkIdentDefs"
+                                sons:
+                                  - kind: "nkIdent"
+                                    ident: "vfalse"
+                                  - kind: "nkIdent"
+                                    ident: "int"
+                                  - kind: "nkEmpty"
+                      - kind: "nkOfBranch"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "true"
+                          - kind: "nkRecList"
+                            sons:
+                              - kind: "nkIdentDefs"
+                                sons:
+                                  - kind: "nkIdent"
+                                    ident: "vtrue"
+                                  - kind: "nkIdent"
+                                    ident: "int"
+                                  - kind: "nkEmpty"
+  - kind: "nkTypeSection"
+    sons:
+      - kind: "nkTypeDef"
+        sons:
+          - kind: "nkPragmaExpr"
+            sons:
+              - kind: "nkIdent"
+                ident: "PragmaObject"
+              - kind: "nkPragma"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "objectPragma"
+                  - kind: "nkIdent"
+                    ident: "aaaaaaaaaaaaaaaa"
+                  - kind: "nkIdent"
+                    ident: "bbbbbbbbbbbbbbbbbb"
+                  - kind: "nkIdent"
+                    ident: "cccccccccccccccccccccc"
+                  - kind: "nkIdent"
+                    ident: "dddddddddddddddddddd"
+          - kind: "nkEmpty"
+          - kind: "nkObjectTy"
+            sons:
+              - kind: "nkEmpty"
+              - kind: "nkEmpty"
+              - kind: "nkRecList"
+                sons:
+                  - kind: "nkIdentDefs"
+                    sons:
+                      - kind: "nkPragmaExpr"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "vfalse"
+                          - kind: "nkPragma"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: "fieldPragma"
+                      - kind: "nkIdent"
+                        ident: "int"
+                      - kind: "nkEmpty"
+                  - kind: "nkIdentDefs"
+                    sons:
+                      - kind: "nkPragmaExpr"
+                        sons:
+                          - kind: "nkPostfix"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: "*"
+                              - kind: "nkIdent"
+                                ident: "vpublic"
+                          - kind: "nkPragma"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: "fieldPragma"
+                      - kind: "nkIdent"
+                        ident: "int"
+                      - kind: "nkEmpty"
+                  - kind: "nkIdentDefs"
+                    sons:
+                      - kind: "nkPragmaExpr"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "vfalse"
+                          - kind: "nkPragma"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: "fieldPragma"
+                              - kind: "nkIdent"
+                                ident: "aaaaaaaaaaaaaaaaaaaaaaaa"
+                              - kind: "nkIdent"
+                                ident: "bbbbbbbbbbbbbbbbbbbbbbbb"
+                              - kind: "nkIdent"
+                                ident: "cccccccccccccccccccccccccccc"
+                              - kind: "nkIdent"
+                                ident: "dddddddddddddddddddddd"
+                      - kind: "nkIdent"
+                        ident: "int"
+                      - kind: "nkEmpty"
+                  - kind: "nkIdentDefs"
+                    sons:
+                      - kind: "nkPragmaExpr"
+                        sons:
+                          - kind: "nkPostfix"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: "*"
+                              - kind: "nkIdent"
+                                ident: "vpublic"
+                          - kind: "nkPragma"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: "fieldPragma"
+                      - kind: "nkIdent"
+                        ident: "int"
+                      - kind: "nkEmpty"


### PR DESCRIPTION
Clean up expressions so that they look better, take less space and don't break as often.

* avoid placing `[`, `(` et al alone on a line
* avoid space around `..` et al
* consistently render stmt list expressions with parenthesis