### PR TITLE
fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,13 +110,13 @@ root of the project:
 cd myproject
 
 # Format all source code with nph
-find -name "*.nim" -exec nph {} \;
+git ls-files | grep ".nim$" | xargs -n1 nph
 
 # Create a single commit with all changes
-git add -A && git commit -m "Formatted code with nph"
+git commit -am "Formatted with nph $(nph --version)"
 
 # Record the commit hash in the blame file
-echo "# Formatted code with nph" >> .git-blame-ignore-revs
+echo "# Formatted with nph $(nph --version)" >> .git-blame-ignore-revs
 echo $(git rev-parse HEAD) >> .git-blame-ignore-revs
 ```
 

--- a/format-git-repo.sh
+++ b/format-git-repo.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Helper script that formats all Nim files in a repository and commits the changes
+
+set -eo pipefail
+
+git ls-files | grep ".nim$" | xargs -n1 nph
+
+git commit -am "Formatted with nph $(nph --version)"
+
+echo "Add the following two lines to .git-blame-ignore-revs to maintain git blame:"
+echo "# Formatted with nph $(nph --version)"
+echo "$(git rev-parse HEAD)"

--- a/src/astcmp.nim
+++ b/src/astcmp.nim
@@ -5,6 +5,8 @@
 
 import "$nim"/compiler/[ast, parser, idents, options], std/sequtils
 
+from std/math import isNaN
+
 type
   Equivalence* = enum
     Same
@@ -61,7 +63,7 @@ proc equivalent*(a, b: PNode): Outcome =
     of nkCharLit..nkUInt64Lit:
       a.intVal == b.intVal
     of nkFloatLit..nkFloat128Lit:
-      a.floatVal == b.floatVal
+      (isNaN(a.floatVal) and isNaN(b.floatVal)) or a.floatVal == b.floatVal
     of nkStrLit..nkTripleStrLit:
       a.strVal == b.strVal
     of nkSym:

--- a/src/astyaml.nim
+++ b/src/astyaml.nim
@@ -156,7 +156,7 @@ proc treeToYamlAux(
       if conf != nil:
         res.addf("\n$1info: $2", [istr, lineInfoToStr(conf, n.info)])
       case n.kind
-      of nkCharLit..nkInt64Lit:
+      of nkCharLit..nkUInt64Lit:
         res.addf("\n$1intVal: $2", [istr, $(n.intVal)])
       of nkFloatLit, nkFloat32Lit, nkFloat64Lit:
         res.addf("\n$1floatVal: $2", [istr, n.floatVal.toStrMaxPrecision])

--- a/src/nph.nim
+++ b/src/nph.nim
@@ -55,7 +55,6 @@ func isNimFile(file: string): bool =
   let (_, _, ext) = file.splitFile()
   ext in [".nim", ".nims", ".nimble"]
 
-
 proc prettyPrint(infile, outfile: string; debug, check, printTokens: bool): bool =
   let
     conf = newConfigRef()
@@ -103,7 +102,11 @@ proc prettyPrint(infile, outfile: string; debug, check, printTokens: bool): bool
     stderr.writeLine "--- POST ---"
     stderr.writeLine treeToYaml(nil, eq.b)
 
-    rawMessage(conf, errGenerated, "Formatted output does not match input, report bug!")
+    internalError(
+      conf,
+      TLineInfo(fileIndex: FileIndex(0)),
+      "Formatted output does not match input, report bug!",
+    )
     if infile != outfile or infile == "-":
       # Write unformatted content
       if not check:

--- a/src/phast.nim
+++ b/src/phast.nim
@@ -1401,7 +1401,8 @@ template id*(a: PIdObj): int =
 
   (x.itemId.module.int shl moduleShift) + x.itemId.item.int
 
-type IdGenerator* = ref object # unfortunately, we really need the 'shared mutable' aspect here.
+type IdGenerator* = ref object
+  # unfortunately, we really need the 'shared mutable' aspect here.
   module*: int32
   symId*: int32
   typeId*: int32

--- a/src/phlexer.nim
+++ b/src/phlexer.nim
@@ -1463,9 +1463,12 @@ proc rawGetTok*(L: var Lexer; tok: var Token) =
       else:
         getOperator(L, tok)
     of ',':
+      tokenBegin(tok, L.bufpos)
       tok.tokType = tkComma
 
       inc(L.bufpos)
+
+      tokenEnd(tok, L.bufpos - 1)
     of 'r', 'R':
       if L.buf[L.bufpos + 1] == '\"':
         inc(L.bufpos)
@@ -1473,6 +1476,7 @@ proc rawGetTok*(L: var Lexer; tok: var Token) =
       else:
         getSymbol(L, tok)
     of '(':
+      tokenBegin(tok, L.bufpos)
       inc(L.bufpos)
       if L.buf[L.bufpos] == '.' and L.buf[L.bufpos + 1] != '.':
         tok.tokType = tkParDotLe
@@ -1480,11 +1484,17 @@ proc rawGetTok*(L: var Lexer; tok: var Token) =
         inc(L.bufpos)
       else:
         tok.tokType = tkParLe
+
+      tokenEnd(tok, L.bufpos - 1)
     of ')':
+      tokenBegin(tok, L.bufpos)
       tok.tokType = tkParRi
 
       inc(L.bufpos)
+
+      tokenEnd(tok, L.bufpos - 1)
     of '[':
+      tokenBegin(tok, L.bufpos)
       inc(L.bufpos)
       if L.buf[L.bufpos] == '.' and L.buf[L.bufpos + 1] != '.':
         tok.tokType = tkBracketDotLe
@@ -1496,26 +1506,38 @@ proc rawGetTok*(L: var Lexer; tok: var Token) =
         inc(L.bufpos)
       else:
         tok.tokType = tkBracketLe
+
+      tokenEnd(tok, L.bufpos - 1)
     of ']':
+      tokenBegin(tok, L.bufpos)
       tok.tokType = tkBracketRi
 
       inc(L.bufpos)
+      tokenEnd(tok, L.bufpos - 1)
     of '.':
       if L.buf[L.bufpos + 1] == ']':
+        tokenBegin(tok, L.bufpos)
         tok.tokType = tkBracketDotRi
 
         inc(L.bufpos, 2)
+
+        tokenEnd(tok, L.bufpos - 1)
       elif L.buf[L.bufpos + 1] == '}':
+        tokenBegin(tok, L.bufpos)
         tok.tokType = tkCurlyDotRi
 
         inc(L.bufpos, 2)
+        tokenEnd(tok, L.bufpos - 1)
       elif L.buf[L.bufpos + 1] == ')':
+        tokenBegin(tok, L.bufpos)
         tok.tokType = tkParDotRi
 
         inc(L.bufpos, 2)
+        tokenEnd(tok, L.bufpos - 1)
       else:
         getOperator(L, tok)
     of '{':
+      tokenBegin(tok, L.bufpos)
       inc(L.bufpos)
       if L.buf[L.bufpos] == '.' and L.buf[L.bufpos + 1] != '.':
         tok.tokType = tkCurlyDotLe
@@ -1523,18 +1545,25 @@ proc rawGetTok*(L: var Lexer; tok: var Token) =
         inc(L.bufpos)
       else:
         tok.tokType = tkCurlyLe
+      tokenEnd(tok, L.bufpos - 1)
     of '}':
+      tokenBegin(tok, L.bufpos)
       tok.tokType = tkCurlyRi
 
       inc(L.bufpos)
+      tokenEnd(tok, L.bufpos - 1)
     of ';':
+      tokenBegin(tok, L.bufpos)
       tok.tokType = tkSemiColon
 
       inc(L.bufpos)
+      tokenEnd(tok, L.bufpos - 1)
     of '`':
+      tokenBegin(tok, L.bufpos)
       tok.tokType = tkAccent
 
       inc(L.bufpos)
+      tokenEnd(tok, L.bufpos - 1)
     of '_':
       tokenBegin(tok, L.bufpos)
       inc(L.bufpos)

--- a/tests/after/comments.nim
+++ b/tests/after/comments.nim
@@ -273,6 +273,22 @@ var
   # var first line indented
   v = 53 # after v
 
+let # let eol
+  v # let ident after symbol
+  : # let ident after colon
+    int =
+    # let ident after type
+    # let ident after equals
+    42 # let ident after value
+
+const # const eol
+  v # const ident after symbol
+  : # const ident after colon
+    int =
+    # const ident after type
+    # const ident after equals
+    42 # const ident after value
+
 discard
   # discard eol
   # discard first line
@@ -297,6 +313,13 @@ proc f(): bool =
       (true or false)
     else:
       false
+
+proc f() =
+  ## Doc comment only
+
+proc f() =
+  ## Doc comment only
+  ## even two lines
 
 command "a", "b", "c" # command eol comment
 

--- a/tests/after/comments.nim.nph.yaml
+++ b/tests/after/comments.nim.nph.yaml
@@ -1072,6 +1072,48 @@ sons:
             intVal: 53
         postfix:
           - "# after v"
+  - kind: "nkLetSection"
+    mid:
+      - "# let eol"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "v"
+            postfix:
+              - "# let ident after symbol"
+          - kind: "nkIdent"
+            prefix:
+              - "# let ident after colon"
+            ident: "int"
+          - kind: "nkIntLit"
+            prefix:
+              - "# let ident after type"
+              - "# let ident after equals"
+            intVal: 42
+        postfix:
+          - "# let ident after value"
+  - kind: "nkConstSection"
+    mid:
+      - "# const eol"
+    sons:
+      - kind: "nkConstDef"
+        sons:
+          - kind: "nkIdent"
+            ident: "v"
+            postfix:
+              - "# const ident after symbol"
+          - kind: "nkIdent"
+            prefix:
+              - "# const ident after colon"
+            ident: "int"
+          - kind: "nkIntLit"
+            prefix:
+              - "# const ident after type"
+              - "# const ident after equals"
+            intVal: 42
+        postfix:
+          - "# const ident after value"
   - kind: "nkDiscardStmt"
     sons:
       - kind: "nkIntLit"
@@ -1173,6 +1215,35 @@ sons:
                                 sons:
                                   - kind: "nkIdent"
                                     ident: "false"
+  - kind: "nkProcDef"
+    mid:
+      - "## Doc comment only"
+    sons:
+      - kind: "nkIdent"
+        ident: "f"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+  - kind: "nkProcDef"
+    mid:
+      - "## Doc comment only"
+      - "## even two lines"
+    sons:
+      - kind: "nkIdent"
+        ident: "f"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
   - kind: "nkCommand"
     sons:
       - kind: "nkIdent"

--- a/tests/after/procs.nim
+++ b/tests/after/procs.nim
@@ -111,3 +111,12 @@ type Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa =
     eeeeeeeeeeeee: Ffffffffffffffff;
     gggggggggggggg: Hhhhhhhhhhhhhhhhhhhh;
   )
+
+proc `.()`() =
+  discard
+
+proc `[]`() =
+  discard
+
+proc `[`() =
+  discard

--- a/tests/after/procs.nim.nph.yaml
+++ b/tests/after/procs.nim.nph.yaml
@@ -816,3 +816,57 @@ sons:
                         ident: "Hhhhhhhhhhhhhhhhhhhh"
                       - kind: "nkEmpty"
               - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkAccQuoted"
+        sons:
+          - kind: "nkIdent"
+            ident: ".()"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkAccQuoted"
+        sons:
+          - kind: "nkIdent"
+            ident: "[]"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkAccQuoted"
+        sons:
+          - kind: "nkIdent"
+            ident: "["
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"

--- a/tests/before/comments.nim
+++ b/tests/before/comments.nim
@@ -273,6 +273,20 @@ var
   # var first line indented
   v = 53 # after v
 
+let # let eol
+  v # let ident after symbol
+ : # let ident after colon
+    int # let ident after type
+ = # let ident after equals
+    42 # let ident after value
+
+const # const eol
+  v # const ident after symbol
+ : # const ident after colon
+    int # const ident after type
+ = # const ident after equals
+    42 # const ident after value
+
 discard # discard eol
   # discard first line
   54 # discard value
@@ -296,6 +310,13 @@ proc f: bool =
       (true or false)
     else:
       false
+
+proc f =
+  ## Doc comment only
+
+proc f =
+  ## Doc comment only
+  ## even two lines
 
 command "a", "b", "c" # command eol comment
 

--- a/tests/before/comments.nim.nph.yaml
+++ b/tests/before/comments.nim.nph.yaml
@@ -1075,6 +1075,48 @@ sons:
             intVal: 53
         postfix:
           - "# after v"
+  - kind: "nkLetSection"
+    mid:
+      - "# let eol"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "v"
+            postfix:
+              - "# let ident after symbol"
+          - kind: "nkIdent"
+            prefix:
+              - "# let ident after colon"
+            ident: "int"
+          - kind: "nkIntLit"
+            prefix:
+              - "# let ident after type"
+              - "# let ident after equals"
+            intVal: 42
+        postfix:
+          - "# let ident after value"
+  - kind: "nkConstSection"
+    mid:
+      - "# const eol"
+    sons:
+      - kind: "nkConstDef"
+        sons:
+          - kind: "nkIdent"
+            ident: "v"
+            postfix:
+              - "# const ident after symbol"
+          - kind: "nkIdent"
+            prefix:
+              - "# const ident after colon"
+            ident: "int"
+          - kind: "nkIntLit"
+            prefix:
+              - "# const ident after type"
+              - "# const ident after equals"
+            intVal: 42
+        postfix:
+          - "# const ident after value"
   - kind: "nkDiscardStmt"
     sons:
       - kind: "nkIntLit"
@@ -1176,6 +1218,35 @@ sons:
                                 sons:
                                   - kind: "nkIdent"
                                     ident: "false"
+  - kind: "nkProcDef"
+    mid:
+      - "## Doc comment only"
+    sons:
+      - kind: "nkIdent"
+        ident: "f"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+  - kind: "nkProcDef"
+    mid:
+      - "## Doc comment only"
+      - "## even two lines"
+    sons:
+      - kind: "nkIdent"
+        ident: "f"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
   - kind: "nkCommand"
     sons:
       - kind: "nkIdent"

--- a/tests/before/procs.nim
+++ b/tests/before/procs.nim
@@ -42,3 +42,7 @@ type Ep = proc {.nimcall.}
 type Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = proc {.bbbbbbbbbbbbbbbbbbbbbbbb.}
 type Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = proc (aaaaaaaa: Bbbbbbb, ccccccccc: Dddddddddddd, eeeeee: Ffffff)
 type Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = proc (aaaaaaaa: Bbbbbbb, ccccccccc: Dddddddddddd, eeeeeeeeeeeee: Ffffffffffffffff, gggggggggggggg: Hhhhhhhhhhhhhhhhhhhh)
+
+proc `.()`() = discard
+proc `[]`() = discard
+proc `[`() = discard

--- a/tests/before/procs.nim.nph.yaml
+++ b/tests/before/procs.nim.nph.yaml
@@ -816,3 +816,57 @@ sons:
                         ident: "Hhhhhhhhhhhhhhhhhhhh"
                       - kind: "nkEmpty"
               - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkAccQuoted"
+        sons:
+          - kind: "nkIdent"
+            ident: ".()"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkAccQuoted"
+        sons:
+          - kind: "nkIdent"
+            ident: "[]"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkAccQuoted"
+        sons:
+          - kind: "nkIdent"
+            ident: "["
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"


### PR DESCRIPTION
General fixes to deal with odd parsing found here and there

* two NaN are equal regardless what the standard says
* fix uint yaml again
* avoid overlong mid comments
* fix dot operator parsing
* improve identdefs comment handling
* minimal handling for comment-only proc with an equals
* fix concept rendering (oh boy, these are ugly)