### PR TITLE
the stable comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,8 @@ jobs:
 
       - name: Check formatting
         run: |
-          find src tests/after -name "*.nim" -print0 | xargs -0 -n1 ./nph
-          git diff
-          # find -name "*.nim"  ! -path "./tests/before/*" ! -path "./nimbledeps/*" -print0 | xargs -0 -n1 ./nph --check
+          ! ./nph --check tests/before
+          ./nph --check tests/after
+
+          ./nph src
+          git diff --exit-code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,10 @@ jobs:
     name: CI '${{ matrix.target.name }}'
     runs-on: ${{ matrix.builder }}
     steps:
+      - name: Set git to use LF
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
       - name: Checkout
         uses: actions/checkout@v3
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ nimbledeps
 /nph
 nimble.develop
 nimble.paths
+*.exe

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 nimbledeps
 /nph
+nimble.develop
+nimble.paths

--- a/src/phastyaml.nim
+++ b/src/phastyaml.nim
@@ -11,9 +11,10 @@
 
 # * yaml formatting for the nph-specific fields
 
-import "."/[phast, phlexer, phlineinfos, phoptions, phmsgs]
-import "$nim"/compiler/[rodutils]
-import std/[intsets, strutils]
+import
+  "."/[phast, phlexer, phlineinfos, phoptions, phmsgs],
+  "$nim"/compiler/[rodutils],
+  std/[intsets, strutils]
 
 proc addYamlString*(res: var string; s: string) =
   # We have to split long strings into many ropes. Otherwise

--- a/tests/after/comments.nim
+++ b/tests/after/comments.nim
@@ -68,6 +68,11 @@ type
     fiiiiiiiiiiiiiiiiiiiiiiiieeeeeeeeeld: int
       # loooooooooooooooooooong comment past the max line length
 
+    docfield, ## Doc comment after comma
+      docfield2, ## Doc comment again
+        ## Multiline
+      docfield3: int ## here came the type
+
   # and here
   NewlineObject = object
     field: int ## doc comment after field
@@ -91,7 +96,8 @@ type
   SomeAlias2 {.nodecl.} = int ## alias2 eol
 
   SomeAlias3 # alias after symbol
-    [T] = # alias after equals
+    [T] =
+      # alias after equals
       int # alias after type
 
   SomeAlias4 = SomeAlias3[int]
@@ -118,6 +124,16 @@ when defined(somecond): # when colon line
 else: # else colon line
   # else first line
   discard
+
+if true:
+  ## doc-comment-only if
+
+block:
+  if true:
+    ## doc-comment-only if nested
+
+while false:
+  ## doc-comment-only while
 
 if true:
   # if next line
@@ -203,8 +219,7 @@ static: # static colon line
   # static first line
   discard
 
-discard Object(
-    # object eol
+discard Object( # object eol
     # object first line
     field: 0, # field line
     field2:
@@ -222,17 +237,21 @@ block:
 ## Doc comment after indented statement
 ## needs to be double
 
-abc and # dedented comment in infix
+abc and
+# dedented comment in infix
 def
 
-abc and # indented comment in infix
+abc and
+# indented comment in infix
 def
 
-if abc and # dedented comment in infix
+if abc and
+# dedented comment in infix
 def:
   discard
 
-if abc and # indented comment in infix
+if abc and
+# indented comment in infix
 def:
   discard
 
@@ -258,7 +277,8 @@ var
 
 let # let eol
   v # let ident after symbol
-  : # let ident after colon
+  :
+    # let ident after colon
     int =
     # let ident after type
     # let ident after equals
@@ -266,7 +286,8 @@ let # let eol
 
 const # const eol
   v # const ident after symbol
-  : # const ident after colon
+  :
+    # const ident after colon
     int =
     # const ident after type
     # const ident after equals
@@ -333,8 +354,8 @@ proc a(v #[block]#
 
 command "a", "b", "c" # command eol comment
 
-command "first arg" # first arg comment
-, "second arg", # second arg comment
+command "first arg", # first arg comment
+  "second arg", # second arg comment
   "third arg" # third arg comment
 
 command "first arg"

--- a/tests/after/comments.nim.nph.yaml
+++ b/tests/after/comments.nim.nph.yaml
@@ -199,6 +199,24 @@ sons:
                       - kind: "nkEmpty"
                     postfix:
                       - "# loooooooooooooooooooong comment past the max line length"
+                  - kind: "nkIdentDefs"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "docfield"
+                        postfix:
+                          - "## Doc comment after comma"
+                      - kind: "nkIdent"
+                        ident: "docfield2"
+                        postfix:
+                          - "## Doc comment again"
+                          - "## Multiline"
+                      - kind: "nkIdent"
+                        ident: "docfield3"
+                      - kind: "nkIdent"
+                        ident: "int"
+                      - kind: "nkEmpty"
+                    postfix:
+                      - "## here came the type"
       - kind: "nkTypeDef"
         prefix:
           - "# and here"
@@ -460,6 +478,37 @@ sons:
               - kind: "nkDiscardStmt"
                 sons:
                   - kind: "nkEmpty"
+  - kind: "nkIfStmt"
+    sons:
+      - kind: "nkElifBranch"
+        mid:
+          - "## doc-comment-only if"
+        sons:
+          - kind: "nkIdent"
+            ident: "true"
+          - kind: "nkStmtList"
+  - kind: "nkBlockStmt"
+    sons:
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkIfStmt"
+            sons:
+              - kind: "nkElifBranch"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "true"
+                  - kind: "nkStmtList"
+                    sons:
+                      - kind: "nkCommentStmt"
+                        "comment": "## doc-comment-only if nested"
+  - kind: "nkWhileStmt"
+    mid:
+      - "## doc-comment-only while"
+    sons:
+      - kind: "nkIdent"
+        ident: "false"
+      - kind: "nkStmtList"
   - kind: "nkIfStmt"
     sons:
       - kind: "nkElifBranch"
@@ -765,6 +814,8 @@ sons:
   - kind: "nkDiscardStmt"
     sons:
       - kind: "nkObjConstr"
+        mid:
+          - "# object eol"
         sons:
           - kind: "nkIdent"
             ident: "Object"
@@ -772,7 +823,6 @@ sons:
             sons:
               - kind: "nkIdent"
                 prefix:
-                  - "# object eol"
                   - "# object first line"
                 ident: "field"
               - kind: "nkIntLit"
@@ -819,21 +869,21 @@ sons:
     sons:
       - kind: "nkIdent"
         ident: "and"
-        postfix:
-          - "# dedented comment in infix"
       - kind: "nkIdent"
         ident: "abc"
       - kind: "nkIdent"
+        prefix:
+          - "# dedented comment in infix"
         ident: "def"
   - kind: "nkInfix"
     sons:
       - kind: "nkIdent"
         ident: "and"
-        postfix:
-          - "# indented comment in infix"
       - kind: "nkIdent"
         ident: "abc"
       - kind: "nkIdent"
+        prefix:
+          - "# indented comment in infix"
         ident: "def"
   - kind: "nkIfStmt"
     sons:
@@ -843,11 +893,11 @@ sons:
             sons:
               - kind: "nkIdent"
                 ident: "and"
-                postfix:
-                  - "# dedented comment in infix"
               - kind: "nkIdent"
                 ident: "abc"
               - kind: "nkIdent"
+                prefix:
+                  - "# dedented comment in infix"
                 ident: "def"
           - kind: "nkStmtList"
             sons:
@@ -862,11 +912,11 @@ sons:
             sons:
               - kind: "nkIdent"
                 ident: "and"
-                postfix:
-                  - "# indented comment in infix"
               - kind: "nkIdent"
                 ident: "abc"
               - kind: "nkIdent"
+                prefix:
+                  - "# indented comment in infix"
                 ident: "def"
           - kind: "nkStmtList"
             sons:

--- a/tests/after/exprs.nim
+++ b/tests/after/exprs.nim
@@ -12,6 +12,21 @@ var c3 =
     else: 0
   )
 
+while (;
+  node = node.next
+
+  node != nil
+):
+  discard
+
+while (
+  var a = 0
+  inc a
+  a += 42
+  a > 0
+):
+  discard
+
 for a in 0..<1:
   discard
 

--- a/tests/after/exprs.nim.nph.yaml
+++ b/tests/after/exprs.nim.nph.yaml
@@ -78,6 +78,72 @@ sons:
                         sons:
                           - kind: "nkIntLit"
                             intVal: 0
+  - kind: "nkWhileStmt"
+    sons:
+      - kind: "nkStmtListExpr"
+        sons:
+          - kind: "nkAsgn"
+            sons:
+              - kind: "nkIdent"
+                ident: "node"
+              - kind: "nkDotExpr"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "node"
+                  - kind: "nkIdent"
+                    ident: "next"
+          - kind: "nkInfix"
+            sons:
+              - kind: "nkIdent"
+                ident: "!="
+              - kind: "nkIdent"
+                ident: "node"
+              - kind: "nkNilLit"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+  - kind: "nkWhileStmt"
+    sons:
+      - kind: "nkStmtListExpr"
+        sons:
+          - kind: "nkVarSection"
+            sons:
+              - kind: "nkIdentDefs"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "a"
+                  - kind: "nkEmpty"
+                  - kind: "nkIntLit"
+                    intVal: 0
+          - kind: "nkCommand"
+            sons:
+              - kind: "nkIdent"
+                ident: "inc"
+              - kind: "nkIdent"
+                ident: "a"
+          - kind: "nkInfix"
+            sons:
+              - kind: "nkIdent"
+                ident: "+="
+              - kind: "nkIdent"
+                ident: "a"
+              - kind: "nkIntLit"
+                intVal: 42
+          - kind: "nkInfix"
+            sons:
+              - kind: "nkIdent"
+                ident: ">"
+              - kind: "nkIdent"
+                ident: "a"
+              - kind: "nkIntLit"
+                intVal: 0
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
   - kind: "nkForStmt"
     sons:
       - kind: "nkIdent"

--- a/tests/before/comments.nim
+++ b/tests/before/comments.nim
@@ -64,6 +64,11 @@ type
     # comment between fields
     field2: int ## Field comment again
     fiiiiiiiiiiiiiiiiiiiiiiiieeeeeeeeeld: int # loooooooooooooooooooong comment past the max line length
+
+    docfield, ## Doc comment after comma
+      docfield2, ## Doc comment again
+                 ## Multiline
+      docfield3: int ## here came the type
   # and here
 
   NewlineObject = object
@@ -113,6 +118,16 @@ when defined(somecond): # when colon line
 else: # else colon line
   # else first line
   discard
+
+if true:
+  ## doc-comment-only if
+
+block:
+  if true:
+    ## doc-comment-only if nested
+
+while false:
+  ## doc-comment-only while
 
 if true:
   # if next line

--- a/tests/before/comments.nim.nph.yaml
+++ b/tests/before/comments.nim.nph.yaml
@@ -199,6 +199,24 @@ sons:
                       - kind: "nkEmpty"
                     postfix:
                       - "# loooooooooooooooooooong comment past the max line length"
+                  - kind: "nkIdentDefs"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "docfield"
+                        postfix:
+                          - "## Doc comment after comma"
+                      - kind: "nkIdent"
+                        ident: "docfield2"
+                        postfix:
+                          - "## Doc comment again"
+                          - "## Multiline"
+                      - kind: "nkIdent"
+                        ident: "docfield3"
+                      - kind: "nkIdent"
+                        ident: "int"
+                      - kind: "nkEmpty"
+                    postfix:
+                      - "## here came the type"
       - kind: "nkTypeDef"
         prefix:
           - "# and here"
@@ -465,6 +483,37 @@ sons:
   - kind: "nkIfStmt"
     sons:
       - kind: "nkElifBranch"
+        mid:
+          - "## doc-comment-only if"
+        sons:
+          - kind: "nkIdent"
+            ident: "true"
+          - kind: "nkStmtList"
+  - kind: "nkBlockStmt"
+    sons:
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkIfStmt"
+            sons:
+              - kind: "nkElifBranch"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "true"
+                  - kind: "nkStmtList"
+                    sons:
+                      - kind: "nkCommentStmt"
+                        "comment": "## doc-comment-only if nested"
+  - kind: "nkWhileStmt"
+    mid:
+      - "## doc-comment-only while"
+    sons:
+      - kind: "nkIdent"
+        ident: "false"
+      - kind: "nkStmtList"
+  - kind: "nkIfStmt"
+    sons:
+      - kind: "nkElifBranch"
         sons:
           - kind: "nkIdent"
             ident: "true"
@@ -514,9 +563,9 @@ sons:
             ident: "true"
           - kind: "nkStmtList"
             sons:
-              - kind: "nkCommentStmt"
-                "comment": "# if dedented colon line"
               - kind: "nkDiscardStmt"
+                prefix:
+                  - "# if dedented colon line"
                 sons:
                   - kind: "nkEmpty"
       - kind: "nkElse"
@@ -587,11 +636,11 @@ sons:
     sons:
       - kind: "nkStmtList"
         sons:
-          - kind: "nkCommentStmt"
-            "comment": "# try first dedent line"
           - kind: "nkCall"
             sons:
               - kind: "nkIdent"
+                prefix:
+                  - "# try first dedent line"
                 ident: "f"
       - kind: "nkExceptBranch"
         prefix:
@@ -599,9 +648,9 @@ sons:
         sons:
           - kind: "nkStmtList"
             sons:
-              - kind: "nkCommentStmt"
-                "comment": "# except dedent first line"
               - kind: "nkDiscardStmt"
+                prefix:
+                  - "# except dedent first line"
                 sons:
                   - kind: "nkEmpty"
       - kind: "nkFinally"
@@ -610,9 +659,9 @@ sons:
         sons:
           - kind: "nkStmtList"
             sons:
-              - kind: "nkCommentStmt"
-                "comment": "# finally first dedent line"
               - kind: "nkDiscardStmt"
+                prefix:
+                  - "# finally first dedent line"
                 sons:
                   - kind: "nkEmpty"
   - kind: "nkCommentStmt"

--- a/tests/before/exprs.nim
+++ b/tests/before/exprs.nim
@@ -5,6 +5,12 @@ var c3 = row[p] + (if runeA != runeB:
 
 var c3 = row[p] + (if runeA != runeB: 1 else: 0)
 
+while (node = node.next; node != nil):
+  discard
+
+while (var a = 0; inc a; a += 42; a > 0):
+  discard
+
 for a in 0..<1:
   discard
 

--- a/tests/before/exprs.nim.nph.yaml
+++ b/tests/before/exprs.nim.nph.yaml
@@ -78,6 +78,73 @@ sons:
                         sons:
                           - kind: "nkIntLit"
                             intVal: 0
+  - kind: "nkWhileStmt"
+    sons:
+      - kind: "nkStmtListExpr"
+        sons:
+          - kind: "nkAsgn"
+            sons:
+              - kind: "nkIdent"
+                ident: "node"
+              - kind: "nkDotExpr"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "node"
+                  - kind: "nkIdent"
+                    ident: "next"
+          - kind: "nkEmpty"
+          - kind: "nkInfix"
+            sons:
+              - kind: "nkIdent"
+                ident: "!="
+              - kind: "nkIdent"
+                ident: "node"
+              - kind: "nkNilLit"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+  - kind: "nkWhileStmt"
+    sons:
+      - kind: "nkStmtListExpr"
+        sons:
+          - kind: "nkVarSection"
+            sons:
+              - kind: "nkIdentDefs"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "a"
+                  - kind: "nkEmpty"
+                  - kind: "nkIntLit"
+                    intVal: 0
+          - kind: "nkCommand"
+            sons:
+              - kind: "nkIdent"
+                ident: "inc"
+              - kind: "nkIdent"
+                ident: "a"
+          - kind: "nkInfix"
+            sons:
+              - kind: "nkIdent"
+                ident: "+="
+              - kind: "nkIdent"
+                ident: "a"
+              - kind: "nkIntLit"
+                intVal: 42
+          - kind: "nkInfix"
+            sons:
+              - kind: "nkIdent"
+                ident: ">"
+              - kind: "nkIdent"
+                ident: "a"
+              - kind: "nkIntLit"
+                intVal: 0
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
   - kind: "nkForStmt"
     sons:
       - kind: "nkIdent"


### PR DESCRIPTION
These changes allow `nph` to maintain formatting stability between one run and the other - important when formatting all of a codebase before committing to git so that we don't get spurious reformats.

* better support for doc-comment-only statement lists
* more empty line stability fixes
* support comments in nkidentdefs symbol lists
* check for formatting instability in CI
* format all given files even if some formatting fails