### PR TITLE
`#!fmt: off` to locally disable formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,8 @@ jobs:
 
       - name: Check formatting
         run: |
-          ! ./nph --check tests/before
-          ./nph --check tests/after
+          ! ./nph --check tests/before || echo "Failed before check"
+          ./nph --check tests/after || echo "Failed after check"
 
           ./nph src
-          git diff --exit-code
+          git diff --exit-code || echo "Failed diff"

--- a/README.md
+++ b/README.md
@@ -29,6 +29,31 @@ nph --check somefile.nim || echo "Not formatted!"
 echo "echo 1" | nph -
 ```
 
+### Disabling formatting locally
+
+You can mark a code section with `#!fmt: off` and `#!fmt: on` to disable formatting locally:
+```nim
+proc      getsFormatted(a, b : int    ) = discard
+
+#!fmt: off
+let
+  myHandFormattedList
+        :
+   array[3, int]
+ =
+    [1, 2, 3]
+
+#!fmt: on
+proc hanging(indent: int,
+             isUgly = true) = discard
+```
+
+To disable formatting for a whole file, simply put `#!fmt: off` on top!
+
+*Note* Internally, `#!fmt: off` makes nph treat the section as a big multi-line
+comment that it copies over to the formatted code - as such, you must be careful
+with indent and adjust your code to the indent that `nph` will generate!
+
 ## Installation
 
 Download binaries from the [releases page](https://github.com/arnetheduck/nph/releases/tag/latest).

--- a/src/nph.nim
+++ b/src/nph.nim
@@ -76,7 +76,9 @@ proc prettyPrint(infile, outfile: string; debug, check, printTokens: bool): int 
   if conf.errorCounter > 0:
     return ErrParseFailed
 
-  let output = renderTree(node, conf) & "\n"
+  var output = renderTree(node, conf)
+  if not output.endsWith("\n"):
+    output.add "\n"
 
   if conf.errorCounter > 0:
     return ErrParseFailed

--- a/src/phoptions.nim
+++ b/src/phoptions.nim
@@ -560,10 +560,21 @@ const
     optAssert, optNaNCheck, optInfCheck, optStyleCheck
   }
   DefaultOptions* = {
-    optObjCheck, optFieldCheck, optRangeCheck, optBoundsCheck, optOverflowCheck,
-    optAssert, optWarns, optRefCheck, optHints, optStackTrace, optLineTrace,
+    optObjCheck,
+    optFieldCheck,
+    optRangeCheck,
+    optBoundsCheck,
+    optOverflowCheck,
+    optAssert,
+    optWarns,
+    optRefCheck,
+    optHints,
+    optStackTrace,
+    optLineTrace,
     # consider adding `optStackTraceMsgs`
-    optTrMacros, optStyleCheck, optCursorInference
+    optTrMacros,
+    optStyleCheck,
+    optCursorInference
   }
   DefaultGlobalOptions* = {optThreadAnalysis, optExcessiveStackTrace, optJsBigInt64}
 

--- a/src/phrenderer.nim
+++ b/src/phrenderer.nim
@@ -121,17 +121,20 @@ proc isExported(n: PNode): bool =
 
 proc isSimple(n: PNode; identDefs = false): bool =
   ## Simple nodes are those that are either identifiers or simple lists thereof
-  case n.kind
-  of nkCharLit..nkNilLit, nkIdent:
-    true
-  of nkStmtList, nkImportStmt, nkExportStmt:
-    n.allIt(isSimple(it))
-  of nkIdentDefs:
-    n.allIt(isSimple(it, true))
-  of nkPostfix:
-    identDefs and isExported(n)
-  else:
+  if n.prefix.len > 0 or n.mid.len > 0 or n.postfix.len > 0:
     false
+  else:
+    case n.kind
+    of nkCharLit..nkNilLit, nkIdent:
+      true
+    of nkStmtList, nkImportStmt, nkExportStmt:
+      n.allIt(isSimple(it))
+    of nkIdentDefs:
+      n.allIt(isSimple(it, true))
+    of nkPostfix:
+      identDefs and isExported(n)
+    else:
+      false
 
 # We render the source code in a two phases: The first
 # determines how long the subtree will likely be, the second

--- a/tests/after/fmtofffile.nim
+++ b/tests/after/fmtofffile.nim
@@ -1,0 +1,6 @@
+#!fmt: off
+
+proc uglyFormat(hangingIndent: int,
+                isVery: bool,
+                ugly = true)
+

--- a/tests/after/fmtofffile.nim
+++ b/tests/after/fmtofffile.nim
@@ -3,4 +3,3 @@
 proc uglyFormat(hangingIndent: int,
                 isVery: bool,
                 ugly = true)
-

--- a/tests/after/fmtofffile.nim.nph.yaml
+++ b/tests/after/fmtofffile.nim.nph.yaml
@@ -1,0 +1,4 @@
+kind: "nkStmtList"
+sons:
+  - kind: "nkCommentStmt"
+    "comment": "#!fmt: off\u000A\u000Aproc uglyFormat(hangingIndent: int,\u000A                isVery: bool,\u000A                ugly = true)\u000A\u000A"

--- a/tests/after/fmtofffile.nim.nph.yaml
+++ b/tests/after/fmtofffile.nim.nph.yaml
@@ -1,4 +1,4 @@
 kind: "nkStmtList"
 sons:
   - kind: "nkCommentStmt"
-    "comment": "#!fmt: off\u000A\u000Aproc uglyFormat(hangingIndent: int,\u000A                isVery: bool,\u000A                ugly = true)\u000A\u000A"
+    "comment": "#!fmt: off\u000A\u000Aproc uglyFormat(hangingIndent: int,\u000A                isVery: bool,\u000A                ugly = true)\u000A"

--- a/tests/after/fmton.nim
+++ b/tests/after/fmton.nim
@@ -1,0 +1,23 @@
+proc getsFormatted(a, b: int) =
+  discard
+
+#!fmt: off
+let
+  myHandFormattedList
+        :
+   array[3, int]
+ =
+    [1, 2, 3]
+
+#!fmt: on
+proc hanging(indent: int; isUgly = true) =
+  discard
+
+block:
+  #!fmt: off
+  if   true   :
+    discard
+  #!fmt: on
+
+  if false:
+    discard

--- a/tests/after/fmton.nim.nph.yaml
+++ b/tests/after/fmton.nim.nph.yaml
@@ -1,0 +1,77 @@
+kind: "nkStmtList"
+sons:
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "getsFormatted"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "a"
+              - kind: "nkIdent"
+                ident: "b"
+              - kind: "nkIdent"
+                ident: "int"
+              - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+  - kind: "nkCommentStmt"
+    "comment": "#!fmt: off\u000Alet\u000A  myHandFormattedList\u000A        :\u000A   array[3, int]\u000A =\u000A    [1, 2, 3]\u000A\u000A#!fmt: on"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "hanging"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "indent"
+              - kind: "nkIdent"
+                ident: "int"
+              - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "isUgly"
+              - kind: "nkEmpty"
+              - kind: "nkIdent"
+                ident: "true"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+  - kind: "nkBlockStmt"
+    sons:
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkCommentStmt"
+            "comment": "#!fmt: off\u000A  if   true   :\u000A    discard\u000A  #!fmt: on"
+          - kind: "nkIfStmt"
+            sons:
+              - kind: "nkElifBranch"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "false"
+                  - kind: "nkStmtList"
+                    sons:
+                      - kind: "nkDiscardStmt"
+                        sons:
+                          - kind: "nkEmpty"

--- a/tests/before/fmtofffile.nim
+++ b/tests/before/fmtofffile.nim
@@ -1,0 +1,5 @@
+#!fmt: off
+
+proc uglyFormat(hangingIndent: int,
+                isVery: bool,
+                ugly = true)

--- a/tests/before/fmtofffile.nim.nph.yaml
+++ b/tests/before/fmtofffile.nim.nph.yaml
@@ -1,0 +1,4 @@
+kind: "nkStmtList"
+sons:
+  - kind: "nkCommentStmt"
+    "comment": "#!fmt: off\u000A\u000Aproc uglyFormat(hangingIndent: int,\u000A                isVery: bool,\u000A                ugly = true)\u000A"

--- a/tests/before/fmton.nim
+++ b/tests/before/fmton.nim
@@ -1,0 +1,23 @@
+proc      getsFormatted(a, b : int    ) = discard
+
+#!fmt: off
+let
+  myHandFormattedList
+        :
+   array[3, int]
+ =
+    [1, 2, 3]
+
+#!fmt: on
+proc hanging(indent: int,
+             isUgly = true) = discard
+
+
+block:
+  #!fmt: off
+  if   true   :
+    discard
+  #!fmt: on
+
+  if   false   :
+    discard

--- a/tests/before/fmton.nim.nph.yaml
+++ b/tests/before/fmton.nim.nph.yaml
@@ -1,0 +1,77 @@
+kind: "nkStmtList"
+sons:
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "getsFormatted"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "a"
+              - kind: "nkIdent"
+                ident: "b"
+              - kind: "nkIdent"
+                ident: "int"
+              - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+  - kind: "nkCommentStmt"
+    "comment": "#!fmt: off\u000Alet\u000A  myHandFormattedList\u000A        :\u000A   array[3, int]\u000A =\u000A    [1, 2, 3]\u000A\u000A#!fmt: on"
+  - kind: "nkProcDef"
+    sons:
+      - kind: "nkIdent"
+        ident: "hanging"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkFormalParams"
+        sons:
+          - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "indent"
+              - kind: "nkIdent"
+                ident: "int"
+              - kind: "nkEmpty"
+          - kind: "nkIdentDefs"
+            sons:
+              - kind: "nkIdent"
+                ident: "isUgly"
+              - kind: "nkEmpty"
+              - kind: "nkIdent"
+                ident: "true"
+      - kind: "nkEmpty"
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkDiscardStmt"
+            sons:
+              - kind: "nkEmpty"
+  - kind: "nkBlockStmt"
+    sons:
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkCommentStmt"
+            "comment": "#!fmt: off\u000A  if   true   :\u000A    discard\u000A  #!fmt: on"
+          - kind: "nkIfStmt"
+            sons:
+              - kind: "nkElifBranch"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "false"
+                  - kind: "nkStmtList"
+                    sons:
+                      - kind: "nkDiscardStmt"
+                        sons:
+                          - kind: "nkEmpty"


### PR DESCRIPTION
we secretly support `#!nimpretty: off` too