### PR TITLE
Remove nim 2.0.0 restriction

### DIFF
--- a/nph.nimble
+++ b/nph.nimble
@@ -12,7 +12,7 @@ bin           = @["nph"]
 # TODO https://github.com/nim-lang/nimble/issues/1166
 # Using exact version here and adding path manually :facepalm:
 # run `nimble setup -l` to hopefully make it work
-requires "nim == 2.0.0",
+requires "nim >= 2.0.0",
          "compiler"
 
 proc build() =

--- a/src/nph.nim
+++ b/src/nph.nim
@@ -12,10 +12,6 @@ import "$nim"/compiler/idents
 
 import std/[parseopt, strutils, os, sequtils]
 
-static:
-  doAssert (NimMajor, NimMinor, NimPatch) == (2, 0, 0),
-    "nph needs to be compiled with nim 2.0.0 exactly for now"
-
 const
   Version = gorge("git describe --long --dirty --always --tags")
   Usage =


### PR DESCRIPTION
Hello! Thanks for nph! 
Is it possible to remove the restriction on nim 2.0.0 since it compiles without problems at the moment, or could it interfere in the future?

