### PR TITLE
Chain long dot-calls (fixes #28)

### DIFF
--- a/src/phast.nim
+++ b/src/phast.nim
@@ -75,10 +75,6 @@ type
     nkComesFrom
       # "comes from" template/macro information for
       # better stack trace generation
-    nkDotCall
-      # used to temporarily flag a nkCall node;
-      # this is used
-      # for transforming ``s.len`` to ``len(s)``
     nkCommand # a call like ``p 2, 4`` without parenthesis
     nkCall # a call like p(x, y) or an operation like +(a, b)
     nkCallStrLit

--- a/tests/after/exprs.nim
+++ b/tests/after/exprs.nim
@@ -137,3 +137,17 @@ discard a .. ^b
 discard a .. <b
 discard a .. -b
 discard -1 .. -2
+
+aaaaaaa.bbbbbbbbb
+.longdotcall().ccccccccc.dddddddddd.eeeeeeeee
+.sdcsd(a0000000, b000000, c000000).fffffff.ggggggg.hhhhhhhh.csdcsdcs.sdcsdcsd.csdcsdcsdcsd.csdcsdcs.dcsdcsdcsdcs.sdc
+
+mynums =
+  myNums
+  .replace1("one", "o1ne")
+  .replace2("two", "t2wo")
+  .replace3("three", "t3hree")
+  .replace5("four", "f4our")
+  .replace5("five", "f5ive")
+  .replace6("six", "s6ix")
+  .replace7("seven", "s7even")

--- a/tests/after/exprs.nim.nph.yaml
+++ b/tests/after/exprs.nim.nph.yaml
@@ -1589,3 +1589,151 @@ sons:
             intVal: -1
           - kind: "nkIntLit"
             intVal: -2
+  - kind: "nkDotExpr"
+    sons:
+      - kind: "nkDotExpr"
+        sons:
+          - kind: "nkDotExpr"
+            sons:
+              - kind: "nkDotExpr"
+                sons:
+                  - kind: "nkDotExpr"
+                    sons:
+                      - kind: "nkDotExpr"
+                        sons:
+                          - kind: "nkDotExpr"
+                            sons:
+                              - kind: "nkDotExpr"
+                                sons:
+                                  - kind: "nkDotExpr"
+                                    sons:
+                                      - kind: "nkCall"
+                                        sons:
+                                          - kind: "nkDotExpr"
+                                            sons:
+                                              - kind: "nkDotExpr"
+                                                sons:
+                                                  - kind: "nkDotExpr"
+                                                    sons:
+                                                      - kind: "nkDotExpr"
+                                                        sons:
+                                                          - kind: "nkCall"
+                                                            sons:
+                                                              - kind: "nkDotExpr"
+                                                                sons:
+                                                                  - kind: "nkDotExpr"
+                                                                    sons:
+                                                                      - kind: "nkIdent"
+                                                                        ident: "aaaaaaa"
+                                                                      - kind: "nkIdent"
+                                                                        ident: "bbbbbbbbb"
+                                                                  - kind: "nkIdent"
+                                                                    ident: "longdotcall"
+                                                          - kind: "nkIdent"
+                                                            ident: "ccccccccc"
+                                                      - kind: "nkIdent"
+                                                        ident: "dddddddddd"
+                                                  - kind: "nkIdent"
+                                                    ident: "eeeeeeeee"
+                                              - kind: "nkIdent"
+                                                ident: "sdcsd"
+                                          - kind: "nkIdent"
+                                            ident: "a0000000"
+                                          - kind: "nkIdent"
+                                            ident: "b000000"
+                                          - kind: "nkIdent"
+                                            ident: "c000000"
+                                      - kind: "nkIdent"
+                                        ident: "fffffff"
+                                  - kind: "nkIdent"
+                                    ident: "ggggggg"
+                              - kind: "nkIdent"
+                                ident: "hhhhhhhh"
+                          - kind: "nkIdent"
+                            ident: "csdcsdcs"
+                      - kind: "nkIdent"
+                        ident: "sdcsdcsd"
+                  - kind: "nkIdent"
+                    ident: "csdcsdcsdcsd"
+              - kind: "nkIdent"
+                ident: "csdcsdcs"
+          - kind: "nkIdent"
+            ident: "dcsdcsdcsdcs"
+      - kind: "nkIdent"
+        ident: "sdc"
+  - kind: "nkAsgn"
+    sons:
+      - kind: "nkIdent"
+        ident: "mynums"
+      - kind: "nkCall"
+        sons:
+          - kind: "nkDotExpr"
+            sons:
+              - kind: "nkCall"
+                sons:
+                  - kind: "nkDotExpr"
+                    sons:
+                      - kind: "nkCall"
+                        sons:
+                          - kind: "nkDotExpr"
+                            sons:
+                              - kind: "nkCall"
+                                sons:
+                                  - kind: "nkDotExpr"
+                                    sons:
+                                      - kind: "nkCall"
+                                        sons:
+                                          - kind: "nkDotExpr"
+                                            sons:
+                                              - kind: "nkCall"
+                                                sons:
+                                                  - kind: "nkDotExpr"
+                                                    sons:
+                                                      - kind: "nkCall"
+                                                        sons:
+                                                          - kind: "nkDotExpr"
+                                                            sons:
+                                                              - kind: "nkIdent"
+                                                                ident: "myNums"
+                                                              - kind: "nkIdent"
+                                                                ident: "replace1"
+                                                          - kind: "nkStrLit"
+                                                            strVal: "one"
+                                                          - kind: "nkStrLit"
+                                                            strVal: "o1ne"
+                                                      - kind: "nkIdent"
+                                                        ident: "replace2"
+                                                  - kind: "nkStrLit"
+                                                    strVal: "two"
+                                                  - kind: "nkStrLit"
+                                                    strVal: "t2wo"
+                                              - kind: "nkIdent"
+                                                ident: "replace3"
+                                          - kind: "nkStrLit"
+                                            strVal: "three"
+                                          - kind: "nkStrLit"
+                                            strVal: "t3hree"
+                                      - kind: "nkIdent"
+                                        ident: "replace5"
+                                  - kind: "nkStrLit"
+                                    strVal: "four"
+                                  - kind: "nkStrLit"
+                                    strVal: "f4our"
+                              - kind: "nkIdent"
+                                ident: "replace5"
+                          - kind: "nkStrLit"
+                            strVal: "five"
+                          - kind: "nkStrLit"
+                            strVal: "f5ive"
+                      - kind: "nkIdent"
+                        ident: "replace6"
+                  - kind: "nkStrLit"
+                    strVal: "six"
+                  - kind: "nkStrLit"
+                    strVal: "s6ix"
+              - kind: "nkIdent"
+                ident: "replace7"
+          - kind: "nkStrLit"
+            strVal: "seven"
+          - kind: "nkStrLit"
+            strVal: "s7even"

--- a/tests/before/exprs.nim
+++ b/tests/before/exprs.nim
@@ -97,3 +97,7 @@ discard a .. ^b
 discard a .. <b
 discard a .. -b
 discard -1.. -2
+
+aaaaaaa.bbbbbbbbb.longdotcall().ccccccccc.dddddddddd.eeeeeeeee.sdcsd(a0000000, b000000, c000000).fffffff.ggggggg.hhhhhhhh.csdcsdcs.sdcsdcsd.csdcsdcsdcsd.csdcsdcs.dcsdcsdcsdcs.sdc
+
+mynums = myNums.replace1("one", "o1ne").replace2("two", "t2wo").replace3("three", "t3hree").replace5("four", "f4our").replace5("five", "f5ive").replace6("six", "s6ix").replace7("seven", "s7even")

--- a/tests/before/exprs.nim.nph.yaml
+++ b/tests/before/exprs.nim.nph.yaml
@@ -1589,3 +1589,151 @@ sons:
             intVal: -1
           - kind: "nkIntLit"
             intVal: -2
+  - kind: "nkDotExpr"
+    sons:
+      - kind: "nkDotExpr"
+        sons:
+          - kind: "nkDotExpr"
+            sons:
+              - kind: "nkDotExpr"
+                sons:
+                  - kind: "nkDotExpr"
+                    sons:
+                      - kind: "nkDotExpr"
+                        sons:
+                          - kind: "nkDotExpr"
+                            sons:
+                              - kind: "nkDotExpr"
+                                sons:
+                                  - kind: "nkDotExpr"
+                                    sons:
+                                      - kind: "nkCall"
+                                        sons:
+                                          - kind: "nkDotExpr"
+                                            sons:
+                                              - kind: "nkDotExpr"
+                                                sons:
+                                                  - kind: "nkDotExpr"
+                                                    sons:
+                                                      - kind: "nkDotExpr"
+                                                        sons:
+                                                          - kind: "nkCall"
+                                                            sons:
+                                                              - kind: "nkDotExpr"
+                                                                sons:
+                                                                  - kind: "nkDotExpr"
+                                                                    sons:
+                                                                      - kind: "nkIdent"
+                                                                        ident: "aaaaaaa"
+                                                                      - kind: "nkIdent"
+                                                                        ident: "bbbbbbbbb"
+                                                                  - kind: "nkIdent"
+                                                                    ident: "longdotcall"
+                                                          - kind: "nkIdent"
+                                                            ident: "ccccccccc"
+                                                      - kind: "nkIdent"
+                                                        ident: "dddddddddd"
+                                                  - kind: "nkIdent"
+                                                    ident: "eeeeeeeee"
+                                              - kind: "nkIdent"
+                                                ident: "sdcsd"
+                                          - kind: "nkIdent"
+                                            ident: "a0000000"
+                                          - kind: "nkIdent"
+                                            ident: "b000000"
+                                          - kind: "nkIdent"
+                                            ident: "c000000"
+                                      - kind: "nkIdent"
+                                        ident: "fffffff"
+                                  - kind: "nkIdent"
+                                    ident: "ggggggg"
+                              - kind: "nkIdent"
+                                ident: "hhhhhhhh"
+                          - kind: "nkIdent"
+                            ident: "csdcsdcs"
+                      - kind: "nkIdent"
+                        ident: "sdcsdcsd"
+                  - kind: "nkIdent"
+                    ident: "csdcsdcsdcsd"
+              - kind: "nkIdent"
+                ident: "csdcsdcs"
+          - kind: "nkIdent"
+            ident: "dcsdcsdcsdcs"
+      - kind: "nkIdent"
+        ident: "sdc"
+  - kind: "nkAsgn"
+    sons:
+      - kind: "nkIdent"
+        ident: "mynums"
+      - kind: "nkCall"
+        sons:
+          - kind: "nkDotExpr"
+            sons:
+              - kind: "nkCall"
+                sons:
+                  - kind: "nkDotExpr"
+                    sons:
+                      - kind: "nkCall"
+                        sons:
+                          - kind: "nkDotExpr"
+                            sons:
+                              - kind: "nkCall"
+                                sons:
+                                  - kind: "nkDotExpr"
+                                    sons:
+                                      - kind: "nkCall"
+                                        sons:
+                                          - kind: "nkDotExpr"
+                                            sons:
+                                              - kind: "nkCall"
+                                                sons:
+                                                  - kind: "nkDotExpr"
+                                                    sons:
+                                                      - kind: "nkCall"
+                                                        sons:
+                                                          - kind: "nkDotExpr"
+                                                            sons:
+                                                              - kind: "nkIdent"
+                                                                ident: "myNums"
+                                                              - kind: "nkIdent"
+                                                                ident: "replace1"
+                                                          - kind: "nkStrLit"
+                                                            strVal: "one"
+                                                          - kind: "nkStrLit"
+                                                            strVal: "o1ne"
+                                                      - kind: "nkIdent"
+                                                        ident: "replace2"
+                                                  - kind: "nkStrLit"
+                                                    strVal: "two"
+                                                  - kind: "nkStrLit"
+                                                    strVal: "t2wo"
+                                              - kind: "nkIdent"
+                                                ident: "replace3"
+                                          - kind: "nkStrLit"
+                                            strVal: "three"
+                                          - kind: "nkStrLit"
+                                            strVal: "t3hree"
+                                      - kind: "nkIdent"
+                                        ident: "replace5"
+                                  - kind: "nkStrLit"
+                                    strVal: "four"
+                                  - kind: "nkStrLit"
+                                    strVal: "f4our"
+                              - kind: "nkIdent"
+                                ident: "replace5"
+                          - kind: "nkStrLit"
+                            strVal: "five"
+                          - kind: "nkStrLit"
+                            strVal: "f5ive"
+                      - kind: "nkIdent"
+                        ident: "replace6"
+                  - kind: "nkStrLit"
+                    strVal: "six"
+                  - kind: "nkStrLit"
+                    strVal: "s6ix"
+              - kind: "nkIdent"
+                ident: "replace7"
+          - kind: "nkStrLit"
+            strVal: "seven"
+          - kind: "nkStrLit"
+            strVal: "s7even"


### PR DESCRIPTION
When multiple dot-separated calls don't fit on a single line, use a long format similar to lists to put each on a new line.