### PR TITLE
Keep section beginning on same line even if entry is long

### DIFF
--- a/src/astcmp.nim
+++ b/src/astcmp.nim
@@ -90,41 +90,39 @@ proc equivalent*(a, b: PNode): Outcome =
 
     return Outcome(kind: Different, a: a, b: b)
 
-  let
-    eq =
-      case a.kind
-      of nkCharLit .. nkUInt64Lit:
-        a.intVal == b.intVal
-      of nkFloatLit .. nkFloat128Lit:
-        (isNaN(a.floatVal) and isNaN(b.floatVal)) or a.floatVal == b.floatVal
-      of nkStrLit .. nkTripleStrLit:
-        a.strVal == b.strVal
-      of nkSym:
-        raiseAssert "Shouldn't eixst in parser"
-      of nkIdent:
-        a.ident.s == b.ident.s
-      else:
-        let
-          skipped =
-            if a.kind == nkStmtListExpr:
-              # When inserting a `;`, we might get some extra empty statements (?)
-              {nkEmpty, nkCommentStmt}
-            else:
-              {nkCommentStmt}
-        # TODO don't break comments!
-        let
-          af = a.sons.filterIt(it.kind notin skipped)
-          bf = b.sons.filterIt(it.kind notin skipped)
-
-        if af.len() != bf.len():
-          false
+  let eq =
+    case a.kind
+    of nkCharLit .. nkUInt64Lit:
+      a.intVal == b.intVal
+    of nkFloatLit .. nkFloat128Lit:
+      (isNaN(a.floatVal) and isNaN(b.floatVal)) or a.floatVal == b.floatVal
+    of nkStrLit .. nkTripleStrLit:
+      a.strVal == b.strVal
+    of nkSym:
+      raiseAssert "Shouldn't eixst in parser"
+    of nkIdent:
+      a.ident.s == b.ident.s
+    else:
+      let skipped =
+        if a.kind == nkStmtListExpr:
+          # When inserting a `;`, we might get some extra empty statements (?)
+          {nkEmpty, nkCommentStmt}
         else:
-          for (aa, bb) in zip(af, bf):
-            let eq = equivalent(aa, bb)
-            if eq.kind == Different:
-              return eq
+          {nkCommentStmt}
+      # TODO don't break comments!
+      let
+        af = a.sons.filterIt(it.kind notin skipped)
+        bf = b.sons.filterIt(it.kind notin skipped)
 
-          true
+      if af.len() != bf.len():
+        false
+      else:
+        for (aa, bb) in zip(af, bf):
+          let eq = equivalent(aa, bb)
+          if eq.kind == Different:
+            return eq
+
+        true
 
   if not eq:
     Outcome(kind: Different, a: a, b: b)

--- a/src/phast.nim
+++ b/src/phast.nim
@@ -25,19 +25,18 @@ import phlexer
 
 export int128
 
-type
-  TCallingConvention* = enum
-    ccNimCall = "nimcall" # nimcall, also the default
-    ccStdCall = "stdcall" # procedure is stdcall
-    ccCDecl = "cdecl" # cdecl
-    ccSafeCall = "safecall" # safecall
-    ccSysCall = "syscall" # system call
-    ccInline = "inline" # proc should be inlined
-    ccNoInline = "noinline" # proc should not be inlined
-    ccFastCall = "fastcall" # fastcall (pass parameters in registers)
-    ccThisCall = "thiscall" # thiscall (parameters are pushed right-to-left)
-    ccClosure = "closure" # proc has a closure
-    ccNoConvention = "noconv" # needed for generating proper C procs sometimes
+type TCallingConvention* = enum
+  ccNimCall = "nimcall" # nimcall, also the default
+  ccStdCall = "stdcall" # procedure is stdcall
+  ccCDecl = "cdecl" # cdecl
+  ccSafeCall = "safecall" # safecall
+  ccSysCall = "syscall" # system call
+  ccInline = "inline" # proc should be inlined
+  ccNoInline = "noinline" # proc should not be inlined
+  ccFastCall = "fastcall" # fastcall (pass parameters in registers)
+  ccThisCall = "thiscall" # thiscall (parameters are pushed right-to-left)
+  ccClosure = "closure" # proc has a closure
+  ccNoConvention = "noconv" # needed for generating proper C procs sometimes
 
 type
   TNodeKind* = enum
@@ -383,108 +382,107 @@ const
   nkLastBlockStmts* = {nkRaiseStmt, nkReturnStmt, nkBreakStmt, nkContinueStmt}
     # these must be last statements in a block
 
-type
-  TTypeKind* = enum
-    # order is important!
-    # Don't forget to change hti.nim if you make a change here
-    # XXX put this into an include file to avoid this issue!
-    # several types are no longer used (guess which), but a
-    # spot in the sequence is kept for backwards compatibility
-    # (apparently something with bootstrapping)
-    # if you need to add a type, they can apparently be reused
-    tyNone
-    tyBool
-    tyChar
-    tyEmpty
-    tyAlias
-    tyNil
-    tyUntyped
-    tyTyped
-    tyTypeDesc
-    tyGenericInvocation # ``T[a, b]`` for types to invoke
-    tyGenericBody # ``T[a, b, body]`` last parameter is the body
-    tyGenericInst
-      # ``T[a, b, realInstance]`` instantiated generic type
-      # realInstance will be a concrete type like tyObject
-      # unless this is an instance of a generic alias type.
-      # then realInstance will be the tyGenericInst of the
-      # completely (recursively) resolved alias.
-    tyGenericParam # ``a`` in the above patterns
-    tyDistinct
-    tyEnum
-    tyOrdinal # integer types (including enums and boolean)
-    tyArray
-    tyObject
-    tyTuple
-    tySet
-    tyRange
-    tyPtr
-    tyRef
-    tyVar
-    tySequence
-    tyProc
-    tyPointer
-    tyOpenArray
-    tyString
-    tyCstring
-    tyForward
-    tyInt
-    tyInt8
-    tyInt16
-    tyInt32
-    tyInt64 # signed integers
-    tyFloat
-    tyFloat32
-    tyFloat64
-    tyFloat128
-    tyUInt
-    tyUInt8
-    tyUInt16
-    tyUInt32
-    tyUInt64
-    tyOwned
-    tySink
-    tyLent
-    tyVarargs
-    tyUncheckedArray # An array with boundaries [0,+∞]
-    tyProxy # used as errornous type (for idetools)
-    tyBuiltInTypeClass # Type such as the catch-all object, tuple, seq, etc
-    tyUserTypeClass # the body of a user-defined type class
-    tyUserTypeClassInst
-      # Instance of a parametric user-defined type class.
-      # Structured similarly to tyGenericInst.
-      # tyGenericInst represents concrete types, while
-      # this is still a "generic param" that will bind types
-      # and resolves them during sigmatch and instantiation.
-    tyCompositeTypeClass
-      # Type such as seq[Number]
-      # The notes for tyUserTypeClassInst apply here as well
-      # sons[0]: the original expression used by the user.
-      # sons[1]: fully expanded and instantiated meta type
-      # (potentially following aliases)
-    tyInferred
-      # In the initial state `base` stores a type class constraining
-      # the types that can be inferred. After a candidate type is
-      # selected, it's stored in `lastSon`. Between `base` and `lastSon`
-      # there may be 0, 2 or more types that were also considered as
-      # possible candidates in the inference process (i.e. lastSon will
-      # be updated to store a type best conforming to all candidates)
-    tyAnd
-    tyOr
-    tyNot
-      # boolean type classes such as `string|int`,`not seq`,
-      # `Sortable and Enumable`, etc
-    tyAnything # a type class matching any type
-    tyStatic # a value known at compile type (the underlying type is .base)
-    tyFromExpr
-      # This is a type representing an expression that depends
-      # on generic parameters (the expression is stored in t.n)
-      # It will be converted to a real type only during generic
-      # instantiation and prior to this it has the potential to
-      # be any type.
-    tyConcept # new style concept.
-    tyVoid # now different from tyEmpty, hurray!
-    tyIterable
+type TTypeKind* = enum
+  # order is important!
+  # Don't forget to change hti.nim if you make a change here
+  # XXX put this into an include file to avoid this issue!
+  # several types are no longer used (guess which), but a
+  # spot in the sequence is kept for backwards compatibility
+  # (apparently something with bootstrapping)
+  # if you need to add a type, they can apparently be reused
+  tyNone
+  tyBool
+  tyChar
+  tyEmpty
+  tyAlias
+  tyNil
+  tyUntyped
+  tyTyped
+  tyTypeDesc
+  tyGenericInvocation # ``T[a, b]`` for types to invoke
+  tyGenericBody # ``T[a, b, body]`` last parameter is the body
+  tyGenericInst
+    # ``T[a, b, realInstance]`` instantiated generic type
+    # realInstance will be a concrete type like tyObject
+    # unless this is an instance of a generic alias type.
+    # then realInstance will be the tyGenericInst of the
+    # completely (recursively) resolved alias.
+  tyGenericParam # ``a`` in the above patterns
+  tyDistinct
+  tyEnum
+  tyOrdinal # integer types (including enums and boolean)
+  tyArray
+  tyObject
+  tyTuple
+  tySet
+  tyRange
+  tyPtr
+  tyRef
+  tyVar
+  tySequence
+  tyProc
+  tyPointer
+  tyOpenArray
+  tyString
+  tyCstring
+  tyForward
+  tyInt
+  tyInt8
+  tyInt16
+  tyInt32
+  tyInt64 # signed integers
+  tyFloat
+  tyFloat32
+  tyFloat64
+  tyFloat128
+  tyUInt
+  tyUInt8
+  tyUInt16
+  tyUInt32
+  tyUInt64
+  tyOwned
+  tySink
+  tyLent
+  tyVarargs
+  tyUncheckedArray # An array with boundaries [0,+∞]
+  tyProxy # used as errornous type (for idetools)
+  tyBuiltInTypeClass # Type such as the catch-all object, tuple, seq, etc
+  tyUserTypeClass # the body of a user-defined type class
+  tyUserTypeClassInst
+    # Instance of a parametric user-defined type class.
+    # Structured similarly to tyGenericInst.
+    # tyGenericInst represents concrete types, while
+    # this is still a "generic param" that will bind types
+    # and resolves them during sigmatch and instantiation.
+  tyCompositeTypeClass
+    # Type such as seq[Number]
+    # The notes for tyUserTypeClassInst apply here as well
+    # sons[0]: the original expression used by the user.
+    # sons[1]: fully expanded and instantiated meta type
+    # (potentially following aliases)
+  tyInferred
+    # In the initial state `base` stores a type class constraining
+    # the types that can be inferred. After a candidate type is
+    # selected, it's stored in `lastSon`. Between `base` and `lastSon`
+    # there may be 0, 2 or more types that were also considered as
+    # possible candidates in the inference process (i.e. lastSon will
+    # be updated to store a type best conforming to all candidates)
+  tyAnd
+  tyOr
+  tyNot
+    # boolean type classes such as `string|int`,`not seq`,
+    # `Sortable and Enumable`, etc
+  tyAnything # a type class matching any type
+  tyStatic # a value known at compile type (the underlying type is .base)
+  tyFromExpr
+    # This is a type representing an expression that depends
+    # on generic parameters (the expression is stored in t.n)
+    # It will be converted to a real type only during generic
+    # instantiation and prior to this it has the potential to
+    # be any type.
+  tyConcept # new style concept.
+  tyVoid # now different from tyEmpty, hurray!
+  tyIterable
 
 static:
   # remind us when TTypeKind stops to fit in a single 64-bit word
@@ -685,296 +683,294 @@ const
   tfReturnsNew* = tfInheritable
   skError* = skUnknown
 
-var
-  eqTypeFlags* = {
-    tfIterator, tfNotNil, tfVarIsPtr, tfGcSafe, tfNoSideEffect, tfIsOutParam, tfSendable
-  }
-    ## type flags that are essential for type equality.
-    ## This is now a variable because for emulation of version:1.0 we
-    ## might exclude {tfGcSafe, tfNoSideEffect}.
+var eqTypeFlags* = {
+  tfIterator, tfNotNil, tfVarIsPtr, tfGcSafe, tfNoSideEffect, tfIsOutParam, tfSendable
+}
+  ## type flags that are essential for type equality.
+  ## This is now a variable because for emulation of version:1.0 we
+  ## might exclude {tfGcSafe, tfNoSideEffect}.
 
-type
-  TMagic* = enum # symbols that require compiler magic:
-    mNone
-    mDefined
-    mDeclared
-    mDeclaredInScope
-    mCompiles
-    mArrGet
-    mArrPut
-    mAsgn
-    mLow
-    mHigh
-    mSizeOf
-    mAlignOf
-    mOffsetOf
-    mTypeTrait
-    mIs
-    mOf
-    mAddr
-    mType
-    mTypeOf
-    mPlugin
-    mEcho
-    mShallowCopy
-    mSlurp
-    mStaticExec
-    mStatic
-    mParseExprToAst
-    mParseStmtToAst
-    mExpandToAst
-    mQuoteAst
-    mInc
-    mDec
-    mOrd
-    mNew
-    mNewFinalize
-    mNewSeq
-    mNewSeqOfCap
-    mLengthOpenArray
-    mLengthStr
-    mLengthArray
-    mLengthSeq
-    mIncl
-    mExcl
-    mCard
-    mChr
-    mGCref
-    mGCunref
-    mAddI
-    mSubI
-    mMulI
-    mDivI
-    mModI
-    mSucc
-    mPred
-    mAddF64
-    mSubF64
-    mMulF64
-    mDivF64
-    mShrI
-    mShlI
-    mAshrI
-    mBitandI
-    mBitorI
-    mBitxorI
-    mMinI
-    mMaxI
-    mAddU
-    mSubU
-    mMulU
-    mDivU
-    mModU
-    mEqI
-    mLeI
-    mLtI
-    mEqF64
-    mLeF64
-    mLtF64
-    mLeU
-    mLtU
-    mEqEnum
-    mLeEnum
-    mLtEnum
-    mEqCh
-    mLeCh
-    mLtCh
-    mEqB
-    mLeB
-    mLtB
-    mEqRef
-    mLePtr
-    mLtPtr
-    mXor
-    mEqCString
-    mEqProc
-    mUnaryMinusI
-    mUnaryMinusI64
-    mAbsI
-    mNot
-    mUnaryPlusI
-    mBitnotI
-    mUnaryPlusF64
-    mUnaryMinusF64
-    mCharToStr
-    mBoolToStr
-    mIntToStr
-    mInt64ToStr
-    mFloatToStr # for compiling nimStdlibVersion < 1.5.1 (not bootstrapping)
-    mCStrToStr
-    mStrToStr
-    mEnumToStr
-    mAnd
-    mOr
-    mImplies
-    mIff
-    mExists
-    mForall
-    mOld
-    mEqStr
-    mLeStr
-    mLtStr
-    mEqSet
-    mLeSet
-    mLtSet
-    mMulSet
-    mPlusSet
-    mMinusSet
-    mConStrStr
-    mSlice
-    mDotDot # this one is only necessary to give nice compile time warnings
-    mFields
-    mFieldPairs
-    mOmpParFor
-    mAppendStrCh
-    mAppendStrStr
-    mAppendSeqElem
-    mInSet
-    mRepr
-    mExit
-    mSetLengthStr
-    mSetLengthSeq
-    mIsPartOf
-    mAstToStr
-    mParallel
-    mSwap
-    mIsNil
-    mArrToSeq
-    mOpenArrayToSeq
-    mNewString
-    mNewStringOfCap
-    mParseBiggestFloat
-    mMove
-    mEnsureMove
-    mWasMoved
-    mDup
-    mDestroy
-    mTrace
-    mDefault
-    mUnown
-    mFinished
-    mIsolate
-    mAccessEnv
-    mAccessTypeField
-    mReset
-    mArray
-    mOpenArray
-    mRange
-    mSet
-    mSeq
-    mVarargs
-    mRef
-    mPtr
-    mVar
-    mDistinct
-    mVoid
-    mTuple
-    mOrdinal
-    mIterableType
-    mInt
-    mInt8
-    mInt16
-    mInt32
-    mInt64
-    mUInt
-    mUInt8
-    mUInt16
-    mUInt32
-    mUInt64
-    mFloat
-    mFloat32
-    mFloat64
-    mFloat128
-    mBool
-    mChar
-    mString
-    mCstring
-    mPointer
-    mNil
-    mExpr
-    mStmt
-    mTypeDesc
-    mVoidType
-    mPNimrodNode
-    mSpawn
-    mDeepCopy
-    mIsMainModule
-    mCompileDate
-    mCompileTime
-    mProcCall
-    mCpuEndian
-    mHostOS
-    mHostCPU
-    mBuildOS
-    mBuildCPU
-    mAppType
-    mCompileOption
-    mCompileOptionArg
-    mNLen
-    mNChild
-    mNSetChild
-    mNAdd
-    mNAddMultiple
-    mNDel
-    mNKind
-    mNSymKind
-    mNccValue
-    mNccInc
-    mNcsAdd
-    mNcsIncl
-    mNcsLen
-    mNcsAt
-    mNctPut
-    mNctLen
-    mNctGet
-    mNctHasNext
-    mNctNext
-    mNIntVal
-    mNFloatVal
-    mNSymbol
-    mNIdent
-    mNGetType
-    mNStrVal
-    mNSetIntVal
-    mNSetFloatVal
-    mNSetSymbol
-    mNSetIdent
-    mNSetStrVal
-    mNLineInfo
-    mNNewNimNode
-    mNCopyNimNode
-    mNCopyNimTree
-    mStrToIdent
-    mNSigHash
-    mNSizeOf
-    mNBindSym
-    mNCallSite
-    mEqIdent
-    mEqNimrodNode
-    mSameNodeType
-    mGetImpl
-    mNGenSym
-    mNHint
-    mNWarning
-    mNError
-    mInstantiationInfo
-    mGetTypeInfo
-    mGetTypeInfoV2
-    mNimvm
-    mIntDefine
-    mStrDefine
-    mBoolDefine
-    mGenericDefine
-    mRunnableExamples
-    mException
-    mBuiltinType
-    mSymOwner
-    mUncheckedArray
-    mGetImplTransf
-    mSymIsInstantiationOf
-    mNodeId
-    mPrivateAccess
-    mZeroDefault
+type TMagic* = enum # symbols that require compiler magic:
+  mNone
+  mDefined
+  mDeclared
+  mDeclaredInScope
+  mCompiles
+  mArrGet
+  mArrPut
+  mAsgn
+  mLow
+  mHigh
+  mSizeOf
+  mAlignOf
+  mOffsetOf
+  mTypeTrait
+  mIs
+  mOf
+  mAddr
+  mType
+  mTypeOf
+  mPlugin
+  mEcho
+  mShallowCopy
+  mSlurp
+  mStaticExec
+  mStatic
+  mParseExprToAst
+  mParseStmtToAst
+  mExpandToAst
+  mQuoteAst
+  mInc
+  mDec
+  mOrd
+  mNew
+  mNewFinalize
+  mNewSeq
+  mNewSeqOfCap
+  mLengthOpenArray
+  mLengthStr
+  mLengthArray
+  mLengthSeq
+  mIncl
+  mExcl
+  mCard
+  mChr
+  mGCref
+  mGCunref
+  mAddI
+  mSubI
+  mMulI
+  mDivI
+  mModI
+  mSucc
+  mPred
+  mAddF64
+  mSubF64
+  mMulF64
+  mDivF64
+  mShrI
+  mShlI
+  mAshrI
+  mBitandI
+  mBitorI
+  mBitxorI
+  mMinI
+  mMaxI
+  mAddU
+  mSubU
+  mMulU
+  mDivU
+  mModU
+  mEqI
+  mLeI
+  mLtI
+  mEqF64
+  mLeF64
+  mLtF64
+  mLeU
+  mLtU
+  mEqEnum
+  mLeEnum
+  mLtEnum
+  mEqCh
+  mLeCh
+  mLtCh
+  mEqB
+  mLeB
+  mLtB
+  mEqRef
+  mLePtr
+  mLtPtr
+  mXor
+  mEqCString
+  mEqProc
+  mUnaryMinusI
+  mUnaryMinusI64
+  mAbsI
+  mNot
+  mUnaryPlusI
+  mBitnotI
+  mUnaryPlusF64
+  mUnaryMinusF64
+  mCharToStr
+  mBoolToStr
+  mIntToStr
+  mInt64ToStr
+  mFloatToStr # for compiling nimStdlibVersion < 1.5.1 (not bootstrapping)
+  mCStrToStr
+  mStrToStr
+  mEnumToStr
+  mAnd
+  mOr
+  mImplies
+  mIff
+  mExists
+  mForall
+  mOld
+  mEqStr
+  mLeStr
+  mLtStr
+  mEqSet
+  mLeSet
+  mLtSet
+  mMulSet
+  mPlusSet
+  mMinusSet
+  mConStrStr
+  mSlice
+  mDotDot # this one is only necessary to give nice compile time warnings
+  mFields
+  mFieldPairs
+  mOmpParFor
+  mAppendStrCh
+  mAppendStrStr
+  mAppendSeqElem
+  mInSet
+  mRepr
+  mExit
+  mSetLengthStr
+  mSetLengthSeq
+  mIsPartOf
+  mAstToStr
+  mParallel
+  mSwap
+  mIsNil
+  mArrToSeq
+  mOpenArrayToSeq
+  mNewString
+  mNewStringOfCap
+  mParseBiggestFloat
+  mMove
+  mEnsureMove
+  mWasMoved
+  mDup
+  mDestroy
+  mTrace
+  mDefault
+  mUnown
+  mFinished
+  mIsolate
+  mAccessEnv
+  mAccessTypeField
+  mReset
+  mArray
+  mOpenArray
+  mRange
+  mSet
+  mSeq
+  mVarargs
+  mRef
+  mPtr
+  mVar
+  mDistinct
+  mVoid
+  mTuple
+  mOrdinal
+  mIterableType
+  mInt
+  mInt8
+  mInt16
+  mInt32
+  mInt64
+  mUInt
+  mUInt8
+  mUInt16
+  mUInt32
+  mUInt64
+  mFloat
+  mFloat32
+  mFloat64
+  mFloat128
+  mBool
+  mChar
+  mString
+  mCstring
+  mPointer
+  mNil
+  mExpr
+  mStmt
+  mTypeDesc
+  mVoidType
+  mPNimrodNode
+  mSpawn
+  mDeepCopy
+  mIsMainModule
+  mCompileDate
+  mCompileTime
+  mProcCall
+  mCpuEndian
+  mHostOS
+  mHostCPU
+  mBuildOS
+  mBuildCPU
+  mAppType
+  mCompileOption
+  mCompileOptionArg
+  mNLen
+  mNChild
+  mNSetChild
+  mNAdd
+  mNAddMultiple
+  mNDel
+  mNKind
+  mNSymKind
+  mNccValue
+  mNccInc
+  mNcsAdd
+  mNcsIncl
+  mNcsLen
+  mNcsAt
+  mNctPut
+  mNctLen
+  mNctGet
+  mNctHasNext
+  mNctNext
+  mNIntVal
+  mNFloatVal
+  mNSymbol
+  mNIdent
+  mNGetType
+  mNStrVal
+  mNSetIntVal
+  mNSetFloatVal
+  mNSetSymbol
+  mNSetIdent
+  mNSetStrVal
+  mNLineInfo
+  mNNewNimNode
+  mNCopyNimNode
+  mNCopyNimTree
+  mStrToIdent
+  mNSigHash
+  mNSizeOf
+  mNBindSym
+  mNCallSite
+  mEqIdent
+  mEqNimrodNode
+  mSameNodeType
+  mGetImpl
+  mNGenSym
+  mNHint
+  mNWarning
+  mNError
+  mInstantiationInfo
+  mGetTypeInfo
+  mGetTypeInfoV2
+  mNimvm
+  mIntDefine
+  mStrDefine
+  mBoolDefine
+  mGenericDefine
+  mRunnableExamples
+  mException
+  mBuiltinType
+  mSymOwner
+  mUncheckedArray
+  mGetImplTransf
+  mSymIsInstantiationOf
+  mNodeId
+  mPrivateAccess
+  mZeroDefault
 
 const
   # things that we can evaluate safely at compile time, even if not asked for it:
@@ -994,10 +990,9 @@ const
   generatedMagics* = {mNone, mIsolate, mFinished, mOpenArrayToSeq}
     ## magics that are generated as normal procs in the backend
 
-type
-  ItemId* = object
-    module*: int32
-    item*: int32
+type ItemId* = object
+  module*: int32
+  item*: int32
 
 proc `$`*(x: ItemId): string =
   "(module: " & $x.module & ", item: " & $x.item & ")"
@@ -1288,11 +1283,10 @@ type
     impNo
     impYes
 
-type
-  Gconfig = object
-    # we put comments in a side channel to avoid increasing `sizeof(TNode)`, which
-    # reduces memory usage given that `PNode` is the most allocated type by far.
-    useIc*: bool
+type Gconfig = object
+  # we put comments in a side channel to avoid increasing `sizeof(TNode)`, which
+  # reduces memory usage given that `PNode` is the most allocated type by far.
+  useIc*: bool
 
 var gconfig {.threadvar.}: Gconfig
 
@@ -1400,14 +1394,13 @@ template id*(a: PIdObj): int =
 
   (x.itemId.module.int shl moduleShift) + x.itemId.item.int
 
-type
-  IdGenerator* = ref object
-    # unfortunately, we really need the 'shared mutable' aspect here.
-    module*: int32
-    symId*: int32
-    typeId*: int32
-    sealed*: bool
-    disambTable*: CountTable[PIdent]
+type IdGenerator* = ref object
+  # unfortunately, we really need the 'shared mutable' aspect here.
+  module*: int32
+  symId*: int32
+  typeId*: int32
+  sealed*: bool
+  disambTable*: CountTable[PIdent]
 
 const PackageModuleId* = -3'i32
 
@@ -1862,10 +1855,9 @@ proc newProcNode*(
   result = newNodeI(kind, info)
   result.sons = @[name, pattern, genericParams, params, pragmas, exceptions, body]
 
-const
-  AttachedOpToStr*: array[TTypeAttachedOp, string] = [
-    "=wasMoved", "=destroy", "=copy", "=dup", "=sink", "=trace", "=deepcopy"
-  ]
+const AttachedOpToStr*: array[TTypeAttachedOp, string] = [
+  "=wasMoved", "=destroy", "=copy", "=dup", "=sink", "=trace", "=deepcopy"
+]
 
 proc `$`*(s: PSym): string =
   if s != nil:
@@ -2467,10 +2459,9 @@ proc addParam*(procType: PType, param: PSym) =
 
   rawAddSon(procType, param.typ)
 
-const
-  magicsThatCanRaise = {
-    mNone, mSlurp, mStaticExec, mParseExprToAst, mParseStmtToAst, mEcho
-  }
+const magicsThatCanRaise = {
+  mNone, mSlurp, mStaticExec, mParseExprToAst, mParseStmtToAst, mEcho
+}
 
 proc canRaiseConservative*(fn: PNode): bool =
   if fn.kind == nkSym and fn.sym.magic notin magicsThatCanRaise:
@@ -2527,29 +2518,28 @@ proc isNewStyleConcept*(n: PNode): bool {.inline.} =
 proc isOutParam*(t: PType): bool {.inline.} =
   tfIsOutParam in t.flags
 
-const
-  nodesToIgnoreSet* = {
-    nkNone .. pred(nkSym),
-    succ(nkSym) .. nkNilLit,
-    nkTypeSection,
-    nkProcDef,
-    nkConverterDef,
-    nkMethodDef,
-    nkIteratorDef,
-    nkMacroDef,
-    nkTemplateDef,
-    nkLambda,
-    nkDo,
-    nkFuncDef,
-    nkConstSection,
-    nkConstDef,
-    nkIncludeStmt,
-    nkImportStmt,
-    nkExportStmt,
-    nkPragma,
-    nkCommentStmt,
-    nkBreakState,
-    nkTypeOfExpr,
-    nkMixinStmt,
-    nkBindStmt
-  }
+const nodesToIgnoreSet* = {
+  nkNone .. pred(nkSym),
+  succ(nkSym) .. nkNilLit,
+  nkTypeSection,
+  nkProcDef,
+  nkConverterDef,
+  nkMethodDef,
+  nkIteratorDef,
+  nkMacroDef,
+  nkTemplateDef,
+  nkLambda,
+  nkDo,
+  nkFuncDef,
+  nkConstSection,
+  nkConstDef,
+  nkIncludeStmt,
+  nkImportStmt,
+  nkExportStmt,
+  nkPragma,
+  nkCommentStmt,
+  nkBreakState,
+  nkTypeOfExpr,
+  nkMixinStmt,
+  nkBindStmt
+}

--- a/src/phlexer.nim
+++ b/src/phlexer.nim
@@ -669,19 +669,18 @@ proc getNumber(L: var Lexer, result: var Token) =
           internalError(L.config, getLineInfo(L), "getNumber")
 
         if result.tokType notin floatTypes:
-          let
-            outOfRange =
-              case result.tokType
-              of tkUInt8Lit, tkUInt16Lit, tkUInt32Lit:
-                result.iNumber != xi
-              of tkInt8Lit:
-                (xi > BiggestInt(uint8.high))
-              of tkInt16Lit:
-                (xi > BiggestInt(uint16.high))
-              of tkInt32Lit:
-                (xi > BiggestInt(uint32.high))
-              else:
-                false
+          let outOfRange =
+            case result.tokType
+            of tkUInt8Lit, tkUInt16Lit, tkUInt32Lit:
+              result.iNumber != xi
+            of tkInt8Lit:
+              (xi > BiggestInt(uint8.high))
+            of tkInt16Lit:
+              (xi > BiggestInt(uint16.high))
+            of tkInt32Lit:
+              (xi > BiggestInt(uint32.high))
+            else:
+              false
 
           if outOfRange:
             #echo "out of range num: ", result.iNumber, " vs ", xi
@@ -715,23 +714,22 @@ proc getNumber(L: var Lexer, result: var Token) =
 
           result.iNumber = iNumber
 
-        let
-          outOfRange =
-            case result.tokType
-            of tkInt8Lit:
-              result.iNumber > int8.high or result.iNumber < int8.low
-            of tkUInt8Lit:
-              result.iNumber > BiggestInt(uint8.high) or result.iNumber < 0
-            of tkInt16Lit:
-              result.iNumber > int16.high or result.iNumber < int16.low
-            of tkUInt16Lit:
-              result.iNumber > BiggestInt(uint16.high) or result.iNumber < 0
-            of tkInt32Lit:
-              result.iNumber > int32.high or result.iNumber < int32.low
-            of tkUInt32Lit:
-              result.iNumber > BiggestInt(uint32.high) or result.iNumber < 0
-            else:
-              false
+        let outOfRange =
+          case result.tokType
+          of tkInt8Lit:
+            result.iNumber > int8.high or result.iNumber < int8.low
+          of tkUInt8Lit:
+            result.iNumber > BiggestInt(uint8.high) or result.iNumber < 0
+          of tkInt16Lit:
+            result.iNumber > int16.high or result.iNumber < int16.low
+          of tkUInt16Lit:
+            result.iNumber > BiggestInt(uint16.high) or result.iNumber < 0
+          of tkInt32Lit:
+            result.iNumber > int32.high or result.iNumber < int32.low
+          of tkUInt32Lit:
+            result.iNumber > BiggestInt(uint32.high) or result.iNumber < 0
+          else:
+            false
 
         if outOfRange:
           lexMessageLitNum(L, "number out of range: '$1'", startpos)
@@ -936,11 +934,10 @@ proc handleCRLF(L: var Lexer, pos: int): int =
   else:
     result = pos
 
-type
-  StringMode = enum
-    normal
-    raw
-    generalized
+type StringMode = enum
+  normal
+  raw
+  generalized
 
 proc getString(L: var Lexer, tok: var Token, mode: StringMode) =
   var pos = L.bufpos
@@ -1073,10 +1070,9 @@ const UnicodeOperatorStartChars = {'\226', '\194', '\195'}
 # the allowed unicode characters ("∙ ∘ × ★ ⊗ ⊘ ⊙ ⊛ ⊠ ⊡ ∩ ∧ ⊓ ± ⊕ ⊖ ⊞ ⊟ ∪ ∨ ⊔")
 # all start with one of these.
 
-type
-  UnicodeOprPred = enum
-    Mul
-    Add
+type UnicodeOprPred = enum
+  Mul
+  Add
 
 proc unicodeOprLen(buf: cstring, pos: int): (int8, UnicodeOprPred) =
   template m(len): untyped =
@@ -1586,9 +1582,8 @@ proc rawGetTok*(L: var Lexer, tok: var Token) =
       tokenEnd(tok, L.bufpos - 1)
     of '\"':
       # check for generalized raw string literal:
-      let
-        mode =
-          if L.bufpos > 0 and L.buf[L.bufpos - 1] in SymChars: generalized else: normal
+      let mode =
+        if L.bufpos > 0 and L.buf[L.bufpos - 1] in SymChars: generalized else: normal
 
       getString(L, tok, mode)
       if mode == generalized:

--- a/src/phlineinfos.nim
+++ b/src/phlineinfos.nim
@@ -25,261 +25,258 @@ proc createDocLink*(urlSuffix: string): string =
   else:
     result.add "/" & urlSuffix
 
-type
-  TMsgKind* = enum
-    # fatal errors
-    errUnknown
-    errFatal
-    errInternal # non-fatal errors
-    errIllFormedAstX
-    errCannotOpenFile
-    errXExpected
-    errRstMissingClosing
-    errRstGridTableNotImplemented
-    errRstMarkdownIllformedTable
-    errRstIllformedTable
-    errRstNewSectionExpected
-    errRstGeneralParseError
-    errRstInvalidDirectiveX
-    errRstInvalidField
-    errRstFootnoteMismatch
-    errRstSandboxedDirective
-    errProveInit # deadcode
-    errGenerated
-    errFailedMove
-    errUser # warnings
-    warnCannotOpenFile = "CannotOpenFile"
-    warnOctalEscape = "OctalEscape"
-    warnXIsNeverRead = "XIsNeverRead"
-    warnXmightNotBeenInit = "XmightNotBeenInit"
-    warnDeprecated = "Deprecated"
-    warnConfigDeprecated = "ConfigDeprecated"
-    warnDotLikeOps = "DotLikeOps"
-    warnSmallLshouldNotBeUsed = "SmallLshouldNotBeUsed"
-    warnUnknownMagic = "UnknownMagic"
-    warnRstRedefinitionOfLabel = "RedefinitionOfLabel"
-    warnRstUnknownSubstitutionX = "UnknownSubstitutionX"
-    warnRstAmbiguousLink = "AmbiguousLink"
-    warnRstBrokenLink = "BrokenLink"
-    warnRstLanguageXNotSupported = "LanguageXNotSupported"
-    warnRstFieldXNotSupported = "FieldXNotSupported"
-    warnRstUnusedImportdoc = "UnusedImportdoc"
-    warnRstStyle = "warnRstStyle"
-    warnCommentXIgnored = "CommentXIgnored"
-    warnTypelessParam = "TypelessParam"
-    warnUseBase = "UseBase"
-    warnWriteToForeignHeap = "WriteToForeignHeap"
-    warnUnsafeCode = "UnsafeCode"
-    warnUnusedImportX = "UnusedImport"
-    warnInheritFromException = "InheritFromException"
-    warnEachIdentIsTuple = "EachIdentIsTuple"
-    warnUnsafeSetLen = "UnsafeSetLen"
-    warnUnsafeDefault = "UnsafeDefault"
-    warnProveInit = "ProveInit"
-    warnProveField = "ProveField"
-    warnProveIndex = "ProveIndex"
-    warnUnreachableElse = "UnreachableElse"
-    warnUnreachableCode = "UnreachableCode"
-    warnStaticIndexCheck = "IndexCheck"
-    warnGcUnsafe = "GcUnsafe"
-    warnGcUnsafe2 = "GcUnsafe2"
-    warnUninit = "Uninit"
-    warnGcMem = "GcMem"
-    warnDestructor = "Destructor"
-    warnLockLevel = "LockLevel" # deadcode
-    warnResultShadowed = "ResultShadowed"
-    warnInconsistentSpacing = "Spacing"
-    warnCaseTransition = "CaseTransition"
-    warnCycleCreated = "CycleCreated"
-    warnObservableStores = "ObservableStores"
-    warnStrictNotNil = "StrictNotNil"
-    warnResultUsed = "ResultUsed"
-    warnCannotOpen = "CannotOpen"
-    warnFileChanged = "FileChanged"
-    warnSuspiciousEnumConv = "EnumConv"
-    warnAnyEnumConv = "AnyEnumConv"
-    warnHoleEnumConv = "HoleEnumConv"
-    warnCstringConv = "CStringConv"
-    warnPtrToCstringConv = "PtrToCstringConv"
-    warnEffect = "Effect"
-    warnCastSizes = "CastSizes" # deadcode
-    warnAboveMaxSizeSet = "AboveMaxSizeSet"
-    warnImplicitTemplateRedefinition = "ImplicitTemplateRedefinition"
-    warnUnnamedBreak = "UnnamedBreak"
-    warnStmtListLambda = "StmtListLambda"
-    warnBareExcept = "BareExcept"
-    warnImplicitDefaultValue = "ImplicitDefaultValue"
-    warnUser = "User" # hints
-    hintSuccess = "Success"
-    hintSuccessX = "SuccessX"
-    hintCC = "CC"
-    hintXDeclaredButNotUsed = "XDeclaredButNotUsed"
-    hintDuplicateModuleImport = "DuplicateModuleImport"
-    hintXCannotRaiseY = "XCannotRaiseY"
-    hintConvToBaseNotNeeded = "ConvToBaseNotNeeded"
-    hintConvFromXtoItselfNotNeeded = "ConvFromXtoItselfNotNeeded"
-    hintExprAlwaysX = "ExprAlwaysX"
-    hintQuitCalled = "QuitCalled"
-    hintProcessing = "Processing"
-    hintProcessingStmt = "ProcessingStmt"
-    hintCodeBegin = "CodeBegin"
-    hintCodeEnd = "CodeEnd"
-    hintConf = "Conf"
-    hintPath = "Path"
-    hintConditionAlwaysTrue = "CondTrue"
-    hintConditionAlwaysFalse = "CondFalse"
-    hintName = "Name"
-    hintPattern = "Pattern"
-    hintExecuting = "Exec"
-    hintLinking = "Link"
-    hintDependency = "Dependency"
-    hintSource = "Source"
-    hintPerformance = "Performance"
-    hintStackTrace = "StackTrace"
-    hintGCStats = "GCStats"
-    hintGlobalVar = "GlobalVar"
-    hintExpandMacro = "ExpandMacro"
-    hintAmbiguousEnum = "AmbiguousEnum"
-    hintUser = "User"
-    hintUserRaw = "UserRaw"
-    hintExtendedContext = "ExtendedContext"
-    hintMsgOrigin = "MsgOrigin" # since 1.3.5
-    hintDeclaredLoc = "DeclaredLoc" # since 1.5.1
+type TMsgKind* = enum
+  # fatal errors
+  errUnknown
+  errFatal
+  errInternal # non-fatal errors
+  errIllFormedAstX
+  errCannotOpenFile
+  errXExpected
+  errRstMissingClosing
+  errRstGridTableNotImplemented
+  errRstMarkdownIllformedTable
+  errRstIllformedTable
+  errRstNewSectionExpected
+  errRstGeneralParseError
+  errRstInvalidDirectiveX
+  errRstInvalidField
+  errRstFootnoteMismatch
+  errRstSandboxedDirective
+  errProveInit # deadcode
+  errGenerated
+  errFailedMove
+  errUser # warnings
+  warnCannotOpenFile = "CannotOpenFile"
+  warnOctalEscape = "OctalEscape"
+  warnXIsNeverRead = "XIsNeverRead"
+  warnXmightNotBeenInit = "XmightNotBeenInit"
+  warnDeprecated = "Deprecated"
+  warnConfigDeprecated = "ConfigDeprecated"
+  warnDotLikeOps = "DotLikeOps"
+  warnSmallLshouldNotBeUsed = "SmallLshouldNotBeUsed"
+  warnUnknownMagic = "UnknownMagic"
+  warnRstRedefinitionOfLabel = "RedefinitionOfLabel"
+  warnRstUnknownSubstitutionX = "UnknownSubstitutionX"
+  warnRstAmbiguousLink = "AmbiguousLink"
+  warnRstBrokenLink = "BrokenLink"
+  warnRstLanguageXNotSupported = "LanguageXNotSupported"
+  warnRstFieldXNotSupported = "FieldXNotSupported"
+  warnRstUnusedImportdoc = "UnusedImportdoc"
+  warnRstStyle = "warnRstStyle"
+  warnCommentXIgnored = "CommentXIgnored"
+  warnTypelessParam = "TypelessParam"
+  warnUseBase = "UseBase"
+  warnWriteToForeignHeap = "WriteToForeignHeap"
+  warnUnsafeCode = "UnsafeCode"
+  warnUnusedImportX = "UnusedImport"
+  warnInheritFromException = "InheritFromException"
+  warnEachIdentIsTuple = "EachIdentIsTuple"
+  warnUnsafeSetLen = "UnsafeSetLen"
+  warnUnsafeDefault = "UnsafeDefault"
+  warnProveInit = "ProveInit"
+  warnProveField = "ProveField"
+  warnProveIndex = "ProveIndex"
+  warnUnreachableElse = "UnreachableElse"
+  warnUnreachableCode = "UnreachableCode"
+  warnStaticIndexCheck = "IndexCheck"
+  warnGcUnsafe = "GcUnsafe"
+  warnGcUnsafe2 = "GcUnsafe2"
+  warnUninit = "Uninit"
+  warnGcMem = "GcMem"
+  warnDestructor = "Destructor"
+  warnLockLevel = "LockLevel" # deadcode
+  warnResultShadowed = "ResultShadowed"
+  warnInconsistentSpacing = "Spacing"
+  warnCaseTransition = "CaseTransition"
+  warnCycleCreated = "CycleCreated"
+  warnObservableStores = "ObservableStores"
+  warnStrictNotNil = "StrictNotNil"
+  warnResultUsed = "ResultUsed"
+  warnCannotOpen = "CannotOpen"
+  warnFileChanged = "FileChanged"
+  warnSuspiciousEnumConv = "EnumConv"
+  warnAnyEnumConv = "AnyEnumConv"
+  warnHoleEnumConv = "HoleEnumConv"
+  warnCstringConv = "CStringConv"
+  warnPtrToCstringConv = "PtrToCstringConv"
+  warnEffect = "Effect"
+  warnCastSizes = "CastSizes" # deadcode
+  warnAboveMaxSizeSet = "AboveMaxSizeSet"
+  warnImplicitTemplateRedefinition = "ImplicitTemplateRedefinition"
+  warnUnnamedBreak = "UnnamedBreak"
+  warnStmtListLambda = "StmtListLambda"
+  warnBareExcept = "BareExcept"
+  warnImplicitDefaultValue = "ImplicitDefaultValue"
+  warnUser = "User" # hints
+  hintSuccess = "Success"
+  hintSuccessX = "SuccessX"
+  hintCC = "CC"
+  hintXDeclaredButNotUsed = "XDeclaredButNotUsed"
+  hintDuplicateModuleImport = "DuplicateModuleImport"
+  hintXCannotRaiseY = "XCannotRaiseY"
+  hintConvToBaseNotNeeded = "ConvToBaseNotNeeded"
+  hintConvFromXtoItselfNotNeeded = "ConvFromXtoItselfNotNeeded"
+  hintExprAlwaysX = "ExprAlwaysX"
+  hintQuitCalled = "QuitCalled"
+  hintProcessing = "Processing"
+  hintProcessingStmt = "ProcessingStmt"
+  hintCodeBegin = "CodeBegin"
+  hintCodeEnd = "CodeEnd"
+  hintConf = "Conf"
+  hintPath = "Path"
+  hintConditionAlwaysTrue = "CondTrue"
+  hintConditionAlwaysFalse = "CondFalse"
+  hintName = "Name"
+  hintPattern = "Pattern"
+  hintExecuting = "Exec"
+  hintLinking = "Link"
+  hintDependency = "Dependency"
+  hintSource = "Source"
+  hintPerformance = "Performance"
+  hintStackTrace = "StackTrace"
+  hintGCStats = "GCStats"
+  hintGlobalVar = "GlobalVar"
+  hintExpandMacro = "ExpandMacro"
+  hintAmbiguousEnum = "AmbiguousEnum"
+  hintUser = "User"
+  hintUserRaw = "UserRaw"
+  hintExtendedContext = "ExtendedContext"
+  hintMsgOrigin = "MsgOrigin" # since 1.3.5
+  hintDeclaredLoc = "DeclaredLoc" # since 1.5.1
 
-const
-  MsgKindToStr*: array[TMsgKind, string] = [
-    errUnknown: "unknown error",
-    errFatal: "fatal error: $1",
-    errInternal: "internal error: $1",
-    errIllFormedAstX: "illformed AST: $1",
-    errCannotOpenFile: "cannot open '$1'",
-    errXExpected: "'$1' expected",
-    errRstMissingClosing: "$1",
-    errRstGridTableNotImplemented: "grid table is not implemented",
-    errRstMarkdownIllformedTable: "illformed delimiter row of a markdown table",
-    errRstIllformedTable: "Illformed table: $1",
-    errRstNewSectionExpected: "new section expected $1",
-    errRstGeneralParseError: "general parse error",
-    errRstInvalidDirectiveX: "invalid directive: '$1'",
-    errRstInvalidField: "invalid field: $1",
-    errRstFootnoteMismatch: "number of footnotes and their references don't match: $1",
-    errRstSandboxedDirective: "disabled directive: '$1'",
-    errProveInit: "Cannot prove that '$1' is initialized.", # deadcode
-    errGenerated: "$1",
-    errFailedMove: "$1",
-    errUser: "$1",
-    warnCannotOpenFile: "cannot open '$1'",
-    warnOctalEscape: "octal escape sequences do not exist; leading zero is ignored",
-    warnXIsNeverRead: "'$1' is never read",
-    warnXmightNotBeenInit: "'$1' might not have been initialized",
-    warnDeprecated: "$1",
-    warnConfigDeprecated: "config file '$1' is deprecated",
-    warnDotLikeOps: "$1",
-    warnSmallLshouldNotBeUsed:
-      "'l' should not be used as an identifier; may look like '1' (one)",
-    warnUnknownMagic: "unknown magic '$1' might crash the compiler",
-    warnRstRedefinitionOfLabel: "redefinition of label '$1'",
-    warnRstUnknownSubstitutionX: "unknown substitution '$1'",
-    warnRstAmbiguousLink: "ambiguous doc link $1",
-    warnRstBrokenLink: "broken link '$1'",
-    warnRstLanguageXNotSupported: "language '$1' not supported",
-    warnRstFieldXNotSupported: "field '$1' not supported",
-    warnRstUnusedImportdoc: "importdoc for '$1' is not used",
-    warnRstStyle: "RST style: $1",
-    warnCommentXIgnored: "comment '$1' ignored",
-    warnTypelessParam: "", # deadcode
-    warnUseBase: "use {.base.} for base methods; baseless methods are deprecated",
-    warnWriteToForeignHeap: "write to foreign heap",
-    warnUnsafeCode: "unsafe code: '$1'",
-    warnUnusedImportX: "imported and not used: '$1'",
-    warnInheritFromException:
-      "inherit from a more precise exception type like ValueError, " &
-      "IOError or OSError. If these don't suit, inherit from CatchableError or Defect.",
-    warnEachIdentIsTuple: "each identifier is a tuple",
-    warnUnsafeSetLen:
-      "setLen can potentially expand the sequence, " &
-      "but the element type '$1' doesn't have a valid default value",
-    warnUnsafeDefault: "The '$1' type doesn't have a valid default value",
-    warnProveInit:
-      "Cannot prove that '$1' is initialized. This will become a compile time error in the future.",
-    warnProveField: "cannot prove that field '$1' is accessible",
-    warnProveIndex: "cannot prove index '$1' is valid",
-    warnUnreachableElse: "unreachable else, all cases are already covered",
-    warnUnreachableCode:
-      "unreachable code after 'return' statement or '{.noReturn.}' proc",
-    warnStaticIndexCheck: "$1",
-    warnGcUnsafe: "not GC-safe: '$1'",
-    warnGcUnsafe2: "$1",
-    warnUninit: "use explicit initialization of '$1' for clarity",
-    warnGcMem: "'$1' uses GC'ed memory",
-    warnDestructor:
-      "usage of a type with a destructor in a non destructible context. This will become a compile time error in the future.",
-    warnLockLevel: "$1", # deadcode
-    warnResultShadowed: "Special variable 'result' is shadowed.",
-    warnInconsistentSpacing: "Number of spaces around '$#' is not consistent",
-    warnCaseTransition:
-      "Potential object case transition, instantiate new object instead",
-    warnCycleCreated: "$1",
-    warnObservableStores: "observable stores to '$1'",
-    warnStrictNotNil: "$1",
-    warnResultUsed: "used 'result' variable",
-    warnCannotOpen: "cannot open: $1",
-    warnFileChanged: "file changed: $1",
-    warnSuspiciousEnumConv: "$1",
-    warnAnyEnumConv: "$1",
-    warnHoleEnumConv: "$1",
-    warnCstringConv: "$1",
-    warnPtrToCstringConv:
-      "unsafe conversion to 'cstring' from '$1'; this will become a compile time error in the future",
-    warnEffect: "$1",
-    warnCastSizes: "$1", # deadcode
-    warnAboveMaxSizeSet: "$1",
-    warnImplicitTemplateRedefinition:
-      "template '$1' is implicitly redefined; this is deprecated, add an explicit .redefine pragma",
-    warnUnnamedBreak:
-      "Using an unnamed break in a block is deprecated; Use a named block with a named break instead",
-    warnStmtListLambda:
-      "statement list expression assumed to be anonymous proc; this is deprecated, use `do (): ...` or `proc () = ...` instead",
-    warnBareExcept: "$1",
-    warnImplicitDefaultValue: "$1",
-    warnUser: "$1",
-    hintSuccess: "operation successful: $#",
-    # keep in sync with `testament.isSuccess`
-    hintSuccessX: "$build\n$loc lines; ${sec}s; $mem; proj: $project; out: $output",
-    hintCC: "CC: $1",
-    hintXDeclaredButNotUsed: "'$1' is declared but not used",
-    hintDuplicateModuleImport: "$1",
-    hintXCannotRaiseY: "$1",
-    hintConvToBaseNotNeeded: "conversion to base object is not needed",
-    hintConvFromXtoItselfNotNeeded: "conversion from $1 to itself is pointless",
-    hintExprAlwaysX: "expression evaluates always to '$1'",
-    hintQuitCalled: "quit() called",
-    hintProcessing: "$1",
-    hintProcessingStmt: "$1",
-    hintCodeBegin: "generated code listing:",
-    hintCodeEnd: "end of listing",
-    hintConf: "used config file '$1'",
-    hintPath: "added path: '$1'",
-    hintConditionAlwaysTrue: "condition is always true: '$1'",
-    hintConditionAlwaysFalse: "condition is always false: '$1'",
-    hintName: "$1",
-    hintPattern: "$1",
-    hintExecuting: "$1",
-    hintLinking: "$1",
-    hintDependency: "$1",
-    hintSource: "$1",
-    hintPerformance: "$1",
-    hintStackTrace: "$1",
-    hintGCStats: "$1",
-    hintGlobalVar: "global variable declared here",
-    hintExpandMacro: "expanded macro: $1",
-    hintAmbiguousEnum: "$1",
-    hintUser: "$1",
-    hintUserRaw: "$1",
-    hintExtendedContext: "$1",
-    hintMsgOrigin: "$1",
-    hintDeclaredLoc: "$1"
-  ]
+const MsgKindToStr*: array[TMsgKind, string] = [
+  errUnknown: "unknown error",
+  errFatal: "fatal error: $1",
+  errInternal: "internal error: $1",
+  errIllFormedAstX: "illformed AST: $1",
+  errCannotOpenFile: "cannot open '$1'",
+  errXExpected: "'$1' expected",
+  errRstMissingClosing: "$1",
+  errRstGridTableNotImplemented: "grid table is not implemented",
+  errRstMarkdownIllformedTable: "illformed delimiter row of a markdown table",
+  errRstIllformedTable: "Illformed table: $1",
+  errRstNewSectionExpected: "new section expected $1",
+  errRstGeneralParseError: "general parse error",
+  errRstInvalidDirectiveX: "invalid directive: '$1'",
+  errRstInvalidField: "invalid field: $1",
+  errRstFootnoteMismatch: "number of footnotes and their references don't match: $1",
+  errRstSandboxedDirective: "disabled directive: '$1'",
+  errProveInit: "Cannot prove that '$1' is initialized.", # deadcode
+  errGenerated: "$1",
+  errFailedMove: "$1",
+  errUser: "$1",
+  warnCannotOpenFile: "cannot open '$1'",
+  warnOctalEscape: "octal escape sequences do not exist; leading zero is ignored",
+  warnXIsNeverRead: "'$1' is never read",
+  warnXmightNotBeenInit: "'$1' might not have been initialized",
+  warnDeprecated: "$1",
+  warnConfigDeprecated: "config file '$1' is deprecated",
+  warnDotLikeOps: "$1",
+  warnSmallLshouldNotBeUsed:
+    "'l' should not be used as an identifier; may look like '1' (one)",
+  warnUnknownMagic: "unknown magic '$1' might crash the compiler",
+  warnRstRedefinitionOfLabel: "redefinition of label '$1'",
+  warnRstUnknownSubstitutionX: "unknown substitution '$1'",
+  warnRstAmbiguousLink: "ambiguous doc link $1",
+  warnRstBrokenLink: "broken link '$1'",
+  warnRstLanguageXNotSupported: "language '$1' not supported",
+  warnRstFieldXNotSupported: "field '$1' not supported",
+  warnRstUnusedImportdoc: "importdoc for '$1' is not used",
+  warnRstStyle: "RST style: $1",
+  warnCommentXIgnored: "comment '$1' ignored",
+  warnTypelessParam: "", # deadcode
+  warnUseBase: "use {.base.} for base methods; baseless methods are deprecated",
+  warnWriteToForeignHeap: "write to foreign heap",
+  warnUnsafeCode: "unsafe code: '$1'",
+  warnUnusedImportX: "imported and not used: '$1'",
+  warnInheritFromException:
+    "inherit from a more precise exception type like ValueError, " &
+    "IOError or OSError. If these don't suit, inherit from CatchableError or Defect.",
+  warnEachIdentIsTuple: "each identifier is a tuple",
+  warnUnsafeSetLen:
+    "setLen can potentially expand the sequence, " &
+    "but the element type '$1' doesn't have a valid default value",
+  warnUnsafeDefault: "The '$1' type doesn't have a valid default value",
+  warnProveInit:
+    "Cannot prove that '$1' is initialized. This will become a compile time error in the future.",
+  warnProveField: "cannot prove that field '$1' is accessible",
+  warnProveIndex: "cannot prove index '$1' is valid",
+  warnUnreachableElse: "unreachable else, all cases are already covered",
+  warnUnreachableCode:
+    "unreachable code after 'return' statement or '{.noReturn.}' proc",
+  warnStaticIndexCheck: "$1",
+  warnGcUnsafe: "not GC-safe: '$1'",
+  warnGcUnsafe2: "$1",
+  warnUninit: "use explicit initialization of '$1' for clarity",
+  warnGcMem: "'$1' uses GC'ed memory",
+  warnDestructor:
+    "usage of a type with a destructor in a non destructible context. This will become a compile time error in the future.",
+  warnLockLevel: "$1", # deadcode
+  warnResultShadowed: "Special variable 'result' is shadowed.",
+  warnInconsistentSpacing: "Number of spaces around '$#' is not consistent",
+  warnCaseTransition: "Potential object case transition, instantiate new object instead",
+  warnCycleCreated: "$1",
+  warnObservableStores: "observable stores to '$1'",
+  warnStrictNotNil: "$1",
+  warnResultUsed: "used 'result' variable",
+  warnCannotOpen: "cannot open: $1",
+  warnFileChanged: "file changed: $1",
+  warnSuspiciousEnumConv: "$1",
+  warnAnyEnumConv: "$1",
+  warnHoleEnumConv: "$1",
+  warnCstringConv: "$1",
+  warnPtrToCstringConv:
+    "unsafe conversion to 'cstring' from '$1'; this will become a compile time error in the future",
+  warnEffect: "$1",
+  warnCastSizes: "$1", # deadcode
+  warnAboveMaxSizeSet: "$1",
+  warnImplicitTemplateRedefinition:
+    "template '$1' is implicitly redefined; this is deprecated, add an explicit .redefine pragma",
+  warnUnnamedBreak:
+    "Using an unnamed break in a block is deprecated; Use a named block with a named break instead",
+  warnStmtListLambda:
+    "statement list expression assumed to be anonymous proc; this is deprecated, use `do (): ...` or `proc () = ...` instead",
+  warnBareExcept: "$1",
+  warnImplicitDefaultValue: "$1",
+  warnUser: "$1",
+  hintSuccess: "operation successful: $#",
+  # keep in sync with `testament.isSuccess`
+  hintSuccessX: "$build\n$loc lines; ${sec}s; $mem; proj: $project; out: $output",
+  hintCC: "CC: $1",
+  hintXDeclaredButNotUsed: "'$1' is declared but not used",
+  hintDuplicateModuleImport: "$1",
+  hintXCannotRaiseY: "$1",
+  hintConvToBaseNotNeeded: "conversion to base object is not needed",
+  hintConvFromXtoItselfNotNeeded: "conversion from $1 to itself is pointless",
+  hintExprAlwaysX: "expression evaluates always to '$1'",
+  hintQuitCalled: "quit() called",
+  hintProcessing: "$1",
+  hintProcessingStmt: "$1",
+  hintCodeBegin: "generated code listing:",
+  hintCodeEnd: "end of listing",
+  hintConf: "used config file '$1'",
+  hintPath: "added path: '$1'",
+  hintConditionAlwaysTrue: "condition is always true: '$1'",
+  hintConditionAlwaysFalse: "condition is always false: '$1'",
+  hintName: "$1",
+  hintPattern: "$1",
+  hintExecuting: "$1",
+  hintLinking: "$1",
+  hintDependency: "$1",
+  hintSource: "$1",
+  hintPerformance: "$1",
+  hintStackTrace: "$1",
+  hintGCStats: "$1",
+  hintGlobalVar: "global variable declared here",
+  hintExpandMacro: "expanded macro: $1",
+  hintAmbiguousEnum: "$1",
+  hintUser: "$1",
+  hintUserRaw: "$1",
+  hintExtendedContext: "$1",
+  hintMsgOrigin: "$1",
+  hintDeclaredLoc: "$1"
+]
 
 const
   fatalMsgs* = {errUnknown .. errInternal}
@@ -386,11 +383,10 @@ const
   InvalidFileIdx* = FileIndex(-1)
   unknownLineInfo* = TLineInfo(line: 0, col: -1, fileIndex: InvalidFileIdx)
 
-type
-  Severity* {.pure.} = enum ## VS Code only supports these three
-    Hint
-    Warning
-    Error
+type Severity* {.pure.} = enum ## VS Code only supports these three
+  Hint
+  Warning
+  Error
 
 const
   trackPosInvalidFileIdx* = FileIndex(-2)
@@ -398,19 +394,18 @@ const
     # are produced within comments and string literals
   commandLineIdx* = FileIndex(-3)
 
-type
-  MsgConfig* = object ## does not need to be stored in the incremental cache
-    trackPos*: TLineInfo
-    trackPosAttached*: bool
-      ## whether the tracking position was attached to
-      ## some close token.
+type MsgConfig* = object ## does not need to be stored in the incremental cache
+  trackPos*: TLineInfo
+  trackPosAttached*: bool
+    ## whether the tracking position was attached to
+    ## some close token.
 
-    errorOutputs*: TErrorOutputs
-    msgContext*: seq[tuple[info: TLineInfo, detail: string]]
-    lastError*: TLineInfo
-    filenameToIndexTbl*: Table[string, FileIndex]
-    fileInfos*: seq[TFileInfo]
-    systemFileIdx*: FileIndex
+  errorOutputs*: TErrorOutputs
+  msgContext*: seq[tuple[info: TLineInfo, detail: string]]
+  lastError*: TLineInfo
+  filenameToIndexTbl*: Table[string, FileIndex]
+  fileInfos*: seq[TFileInfo]
+  systemFileIdx*: FileIndex
 
 proc initMsgConfig*(): MsgConfig =
   result.msgContext = @[]

--- a/src/phmsgs.nim
+++ b/src/phmsgs.nim
@@ -236,12 +236,11 @@ proc popInfoContext*(conf: ConfigRef) =
   setLen(conf.m.msgContext, conf.m.msgContext.len - 1)
 
 proc getInfoContext*(conf: ConfigRef, index: int): TLineInfo =
-  let
-    i =
-      if index < 0:
-        conf.m.msgContext.len + index
-      else:
-        index
+  let i =
+    if index < 0:
+      conf.m.msgContext.len + index
+    else:
+      index
 
   if i >=% conf.m.msgContext.len:
     result = unknownLineInfo
@@ -376,12 +375,11 @@ proc msgWriteln*(conf: ConfigRef, s: string, flags: MsgFlags = {}) =
   ## This is used for 'nim dump' etc. where we don't have nimsuggest
   ## support.
   #if conf.cmd == cmdIdeTools and optCDebug notin gGlobalOptions: return
-  let
-    sep =
-      if msgNoUnitSep notin flags:
-        conf.unitSep
-      else:
-        ""
+  let sep =
+    if msgNoUnitSep notin flags:
+      conf.unitSep
+    else:
+      ""
 
   if not isNil(conf.writelnHook) and msgSkipHook notin flags:
     conf.writelnHook(s & sep)
@@ -472,11 +470,10 @@ proc msgKindToString*(kind: TMsgKind): string =
 proc getMessageStr(msg: TMsgKind, arg: string): string =
   msgKindToString(msg) % [arg]
 
-type
-  TErrorHandling* = enum
-    doNothing
-    doAbort
-    doRaise
+type TErrorHandling* = enum
+  doNothing
+  doAbort
+  doRaise
 
 proc log*(s: string) =
   var f: File
@@ -544,12 +541,11 @@ proc writeContext(conf: ConfigRef, lastinfo: TLineInfo) =
       if conf.structuredErrorHook != nil:
         conf.structuredErrorHook(conf, context.info, instantiationFrom, Severity.Hint)
       else:
-        let
-          message =
-            if context.detail == "":
-              instantiationFrom
-            else:
-              instantiationOfFrom.format(context.detail)
+        let message =
+          if context.detail == "":
+            instantiationFrom
+          else:
+            instantiationOfFrom.format(context.detail)
 
         styledMsgWriteln(
           styleBright, conf.toFileLineCol(context.info), " ", resetStyle, message
@@ -599,12 +595,11 @@ proc getSurroundingSrc(conf: ConfigRef, info: TLineInfo): string =
       result.add "\n" & indent & spaces(info.col) & '^'
 
 proc formatMsg*(conf: ConfigRef, info: TLineInfo, msg: TMsgKind, arg: string): string =
-  let
-    title =
-      case msg
-      of warnMin .. warnMax: WarningTitle
-      of hintMin .. hintMax: HintTitle
-      else: ErrorTitle
+  let title =
+    case msg
+    of warnMin .. warnMax: WarningTitle
+    of hintMin .. hintMax: HintTitle
+    else: ErrorTitle
 
   conf.toFileLineCol(info) & " " & title & getMessageStr(msg, arg)
 
@@ -630,13 +625,12 @@ proc liMessage*(
     # or inside a `tryConstExpr`.
     conf.m.errorOutputs = {eStdOut, eStdErr}
 
-  let
-    kind =
-      if msg in warnMin .. hintMax and msg != hintUserRaw:
-        $msg
-      else:
-        ""
-        # xxx not sure why hintUserRaw is special
+  let kind =
+    if msg in warnMin .. hintMax and msg != hintUserRaw:
+      $msg
+    else:
+      ""
+      # xxx not sure why hintUserRaw is special
 
   case msg
   of errMin .. errMax:
@@ -680,27 +674,24 @@ proc liMessage*(
 
     inc(conf.hintCounter)
 
-  let
-    s =
-      if isRaw:
-        arg
-      else:
-        getMessageStr(msg, arg)
+  let s =
+    if isRaw:
+      arg
+    else:
+      getMessageStr(msg, arg)
 
   if not ignoreMsg:
-    let
-      loc =
-        if info != unknownLineInfo:
-          conf.toFileLineCol(info) & " "
-        else:
-          ""
+    let loc =
+      if info != unknownLineInfo:
+        conf.toFileLineCol(info) & " "
+      else:
+        ""
     # we could also show `conf.cmdInput` here for `projectIsCmd`
-    var
-      kindmsg =
-        if kind.len > 0:
-          KindFormat % kind
-        else:
-          ""
+    var kindmsg =
+      if kind.len > 0:
+        KindFormat % kind
+      else:
+        ""
 
     if conf.structuredErrorHook != nil:
       conf.structuredErrorHook(conf, info, s & kindmsg, sev)
@@ -843,19 +834,17 @@ proc uniqueModuleName*(conf: ConfigRef, fid: FileIndex): string =
   ## The unique module name is guaranteed to only contain {'A'..'Z', 'a'..'z', '0'..'9', '_'}
   ## so that it is useful as a C identifier snippet.
   let path = AbsoluteFile toFullPath(conf, fid)
-  let
-    rel =
-      if path.string.startsWith(conf.libpath.string):
-        relativeTo(path, conf.libpath).string
-      else:
-        relativeTo(path, conf.projectPath).string
+  let rel =
+    if path.string.startsWith(conf.libpath.string):
+      relativeTo(path, conf.libpath).string
+    else:
+      relativeTo(path, conf.projectPath).string
 
-  let
-    trunc =
-      if rel.endsWith(".nim"):
-        rel.len - len(".nim")
-      else:
-        rel.len
+  let trunc =
+    if rel.endsWith(".nim"):
+      rel.len - len(".nim")
+    else:
+      rel.len
 
   result = newStringOfCap(trunc)
   for i in 0 ..< trunc:
@@ -873,12 +862,11 @@ proc uniqueModuleName*(conf: ConfigRef, fid: FileIndex): string =
       result.addInt ord(c)
 
 proc genSuccessX*(conf: ConfigRef) =
-  let
-    mem =
-      when declared(system.getMaxMem):
-        formatSize(getMaxMem()) & " peakmem"
-      else:
-        formatSize(getTotalMem()) & " totmem"
+  let mem =
+    when declared(system.getMaxMem):
+      formatSize(getMaxMem()) & " peakmem"
+    else:
+      formatSize(getTotalMem()) & " totmem"
 
   let loc = $conf.linesCompiled
 
@@ -919,12 +907,11 @@ proc genSuccessX*(conf: ConfigRef) =
       build.add "; options:" & flags
 
   let sec = formatFloat(epochTime() - conf.lastCmdTime, ffDecimal, 3)
-  let
-    project =
-      if conf.filenameOption == foAbs:
-        $conf.projectFull
-      else:
-        $conf.projectName # xxx honor conf.filenameOption more accurately
+  let project =
+    if conf.filenameOption == foAbs:
+      $conf.projectFull
+    else:
+      $conf.projectName # xxx honor conf.filenameOption more accurately
 
   var output: string
   if optCompileOnly in conf.globalOptions and conf.cmd != cmdJsonscript:

--- a/src/phoptions.nim
+++ b/src/phoptions.nim
@@ -603,10 +603,9 @@ template newPackageCache*(): untyped =
 proc newProfileData(): ProfileData =
   ProfileData(data: newTable[TLineInfo, ProfileInfo]())
 
-const
-  foreignPackageNotesDefault* = {
-    hintProcessing, warnUnknownMagic, hintQuitCalled, hintExecuting, hintUser, warnUser
-  }
+const foreignPackageNotesDefault* = {
+  hintProcessing, warnUnknownMagic, hintQuitCalled, hintExecuting, hintUser, warnUser
+}
 
 proc isDefined*(conf: ConfigRef, symbol: string): bool
 
@@ -889,12 +888,11 @@ proc setFromProjectName*(conf: ConfigRef, projectName: string) =
     conf.projectFull = AbsoluteFile projectName
 
   let p = splitFile(conf.projectFull)
-  let
-    dir =
-      if p.dir.isEmpty:
-        AbsoluteDir getCurrentDir()
-      else:
-        p.dir
+  let dir =
+    if p.dir.isEmpty:
+      AbsoluteDir getCurrentDir()
+    else:
+      p.dir
 
   conf.projectPath = AbsoluteDir canonicalizePath(conf, AbsoluteFile dir)
   conf.projectName = p.name
@@ -1031,12 +1029,11 @@ template patchModule(conf: ConfigRef) {.dirty.} =
       if ov.len > 0:
         result = AbsoluteFile(ov)
 
-const
-  stdlibDirs* = [
-    "pure", "core", "arch", "pure/collections", "pure/concurrency", "pure/unidecode",
-    "impure", "wrappers", "wrappers/linenoise", "windows", "posix", "js",
-    "deprecated/pure"
-  ]
+const stdlibDirs* = [
+  "pure", "core", "arch", "pure/collections", "pure/concurrency", "pure/unidecode",
+  "impure", "wrappers", "wrappers/linenoise", "windows", "posix", "js",
+  "deprecated/pure"
+]
 
 const
   pkgPrefix = "pkg/"

--- a/src/phparser.nim
+++ b/src/phparser.nim
@@ -667,15 +667,14 @@ proc semiStmtList(p: var Parser, result: PNode) =
   inc p.inSemiStmtList
   withInd(p):
     # Be lenient with the first stmt/expr
-    let
-      a =
-        case p.tok.tokType
-        of tkIf:
-          parseIfOrWhenExpr(p, nkIfStmt)
-        of tkWhen:
-          parseIfOrWhenExpr(p, nkWhenStmt)
-        else:
-          complexOrSimpleStmt(p)
+    let a =
+      case p.tok.tokType
+      of tkIf:
+        parseIfOrWhenExpr(p, nkIfStmt)
+      of tkWhen:
+        parseIfOrWhenExpr(p, nkWhenStmt)
+      else:
+        complexOrSimpleStmt(p)
     result.add a
 
     while p.tok.tokType != tkEof:
@@ -1239,12 +1238,11 @@ proc parseParamList(p: var Parser, retColon = true): PNode =
       splitLookahead(p, result[^1], clPostfix)
     optPar(p)
     eat(p, tkParRi)
-  let
-    hasRet =
-      if retColon:
-        p.tok.tokType == tkColon
-      else:
-        p.tok.tokType == tkOpr and p.tok.ident.s == "->"
+  let hasRet =
+    if retColon:
+      p.tok.tokType == tkColon
+    else:
+      p.tok.tokType == tkOpr and p.tok.ident.s == "->"
   if hasRet and p.tok.indent < 0:
     getTok(p)
     optInd(p, result)
@@ -1495,19 +1493,18 @@ proc primary(p: var Parser, mode: PrimaryMode): PNode =
     getTok(p)
     splitLookahead(p, a, clPostfix)
     optInd(p, a)
-    const
-      identOrLiteralKinds =
-        tkBuiltInMagics + {
-          tkSymbol,
-          tkAccent,
-          tkNil,
-          tkIntLit .. tkCustomLit,
-          tkCast,
-          tkOut,
-          tkParLe,
-          tkBracketLe,
-          tkCurlyLe
-        }
+    const identOrLiteralKinds =
+      tkBuiltInMagics + {
+        tkSymbol,
+        tkAccent,
+        tkNil,
+        tkIntLit .. tkCustomLit,
+        tkCast,
+        tkOut,
+        tkParLe,
+        tkBracketLe,
+        tkCurlyLe
+      }
     if isSigil and p.tok.tokType in identOrLiteralKinds:
       let baseInd = p.lex.currLineIndent
       result.add(identOrLiteral(p, mode))
@@ -2224,12 +2221,11 @@ proc parseEnum(p: var Parser): PNode =
   splitLookahead(p, result, clMid)
   # progress guaranteed
   while true:
-    let
-      symInd =
-        if p.tok.indent == -1:
-          p.currInd
-        else:
-          p.tok.indent
+    let symInd =
+      if p.tok.indent == -1:
+        p.currInd
+      else:
+        p.tok.indent
     var a = parseSymbol(p)
     if a.kind == nkEmpty:
       return
@@ -2395,15 +2391,14 @@ proc parseObject(p: var Parser): PNode =
   setEndInfo()
 
 proc parseTypeClassParam(p: var Parser): PNode =
-  let
-    modifier =
-      case p.tok.tokType
-      of tkOut, tkVar: nkVarTy
-      of tkPtr: nkPtrTy
-      of tkRef: nkRefTy
-      of tkStatic: nkStaticTy
-      of tkType: nkTypeOfExpr
-      else: nkEmpty
+  let modifier =
+    case p.tok.tokType
+    of tkOut, tkVar: nkVarTy
+    of tkPtr: nkPtrTy
+    of tkRef: nkRefTy
+    of tkStatic: nkStaticTy
+    of tkType: nkTypeOfExpr
+    else: nkEmpty
 
   if modifier != nkEmpty:
     result = newNodeP(modifier, p)
@@ -2718,13 +2713,11 @@ proc complexOrSimpleStmt(p: var Parser): PNode =
 proc parseStmt(p: var Parser, allowEmpty: bool): PNode =
   #| stmt = (IND{>} complexOrSimpleStmt^+(IND{=} / ';') DED)
   #|      / simpleStmt ^+ ';'
-  let
-    nextInd =
-      if p.tok.indent < p.currInd and p.skipped.len > 0 and
-          p.skipped[0].indent > p.currInd:
-        p.skipped[0].indent
-      else:
-        p.tok.indent
+  let nextInd =
+    if p.tok.indent < p.currInd and p.skipped.len > 0 and p.skipped[0].indent > p.currInd:
+      p.skipped[0].indent
+    else:
+      p.tok.indent
   if nextInd > p.currInd:
     result = newNodeP(nkStmtList, p, withPrefix = false)
     withInd(p, nextInd):

--- a/src/phrenderer.nim
+++ b/src/phrenderer.nim
@@ -373,19 +373,17 @@ proc infixHasParens(n: PNode, i: int): bool =
   let nNext = n[i].skipHiddenNodes
   if nNext.kind == nkInfix:
     if nNext[0].kind in {nkSym, nkIdent} and n[0].kind in {nkSym, nkIdent}:
-      let
-        nextId =
-          if nNext[0].kind == nkSym:
-            nNext[0].sym.name
-          else:
-            nNext[0].ident
+      let nextId =
+        if nNext[0].kind == nkSym:
+          nNext[0].sym.name
+        else:
+          nNext[0].ident
 
-      let
-        nnId =
-          if n[0].kind == nkSym:
-            n[0].sym.name
-          else:
-            n[0].ident
+      let nnId =
+        if n[0].kind == nkSym:
+          n[0].sym.name
+        else:
+          n[0].ident
 
       if i == 1:
         if getPrecedence(nextId) < getPrecedence(nnId):
@@ -427,12 +425,11 @@ proc litAux(g: TOutput, n: PNode, x: BiggestInt, size: int): string =
   if nfBase2 in n.flags:
     result = "0b" & toBin(x, size * 8)
   elif nfBase8 in n.flags:
-    var
-      y =
-        if size < sizeof(BiggestInt):
-          x and ((1.BiggestInt shl (size * 8)) - 1)
-        else:
-          x
+    var y =
+      if size < sizeof(BiggestInt):
+        x and ((1.BiggestInt shl (size * 8)) - 1)
+      else:
+        x
 
     result = "0o" & toOct(y, size * 3)
   elif nfBase16 in n.flags:
@@ -593,12 +590,11 @@ template withSrcLen(g: TSrcGen, body: untyped): LineLen =
   var sl {.inject.} = TSrcLen.init(g)
   let pre = sl.lineLen
   body
-  let
-    post =
-      if sl.nl:
-        MaxLineLen + 1
-      else:
-        sl.lineLen - pre
+  let post =
+    if sl.nl:
+      MaxLineLen + 1
+    else:
+      sl.lineLen - pre
   (post, sl.nl)
 
 template withSrcLen(g: TSrcLen, body: untyped): LineLen =
@@ -639,10 +635,9 @@ proc llist(
     subFlags: SubFlags = {},
     extra = 0,
 ): LineLen =
-  let
-    res =
-      withSrcLen(g):
-        glist(sl, n, brOpen, start, theEnd, separator, indentNL, flags, subFlags, extra)
+  let res =
+    withSrcLen(g):
+      glist(sl, n, brOpen, start, theEnd, separator, indentNL, flags, subFlags, extra)
   res + extra
 
 proc lstmts(g: var TOutput, n: PNode, flags: SubFlags = {}, doIndent = true): LineLen =
@@ -736,44 +731,43 @@ proc gcomma(
     if indented:
       g.dedent(indentNL)
 
-  let
-    (start, count) =
-      if lfFirstSticky in flags:
-        let count = n.len + theEnd - start + 1
-        if count == 0:
-          return
+  let (start, count) =
+    if lfFirstSticky in flags:
+      let count = n.len + theEnd - start + 1
+      if count == 0:
+        return
 
-        # The first item must be rendered without newlines, so we start with that
-        gsub(g, n[start], flags = subFlags + {sfSkipPostfix})
+      # The first item must be rendered without newlines, so we start with that
+      gsub(g, n[start], flags = subFlags + {sfSkipPostfix})
 
-        if count > 1:
-          let sep = separator(n[start])
-          putWithSpace(g, sep, $sep)
+      if count > 1:
+        let sep = separator(n[start])
+        putWithSpace(g, sep, $sep)
 
-        # Postfixes after separator!
-        gpostfixes(g, n[start], lfFirstCommentSticky in flags)
+      # Postfixes after separator!
+      gpostfixes(g, n[start], lfFirstCommentSticky in flags)
 
-        # If we can't fit everything on the current line, start over at a fresh one
-        if lfFirstAlone in flags and count > 1 and
-            overflows(
+      # If we can't fit everything on the current line, start over at a fresh one
+      if lfFirstAlone in flags and count > 1 and
+          overflows(
+            g,
+            lcomma(
               g,
-              lcomma(
-                g,
-                n,
-                start + 1,
-                theEnd,
-                separator,
-                indentNL = 0,
-                flags - {lfFirstSticky, lfFirstAlone},
-                subFlags,
-              ),
-            ) or n[start].postfix.len > 0:
-          indented = true
-          g.indentNL(indentNL)
+              n,
+              start + 1,
+              theEnd,
+              separator,
+              indentNL = 0,
+              flags - {lfFirstSticky, lfFirstAlone},
+              subFlags,
+            ),
+          ) or n[start].postfix.len > 0:
+        indented = true
+        g.indentNL(indentNL)
 
-        (start + 1, count - 1)
-      else:
-        (start, n.len + theEnd - start + 1)
+      (start + 1, count - 1)
+    else:
+      (start, n.len + theEnd - start + 1)
 
   if count == 0:
     return
@@ -785,27 +779,24 @@ proc gcomma(
   # If a full, comma-separate list fits on one line, go for it. If not, we put
   # each element on its own line unless it's a list of trivial things (so as to
   # avoid wasting significant vertical space on lists of numbers and the like)
-  let
-    onePerLine =
-      if not overflows(
+  let onePerLine =
+    if not overflows(
+      g,
+      lcomma(
         g,
-        lcomma(
-          g,
-          n,
-          start,
-          theEnd,
-          separator,
-          indentNL,
-          flags - {lfFirstSticky, lfFirstAlone},
-          subFlags,
-        ),
-      ):
-        false
-      else:
-        count > 1 and
-          anyIt(
-            n.sons[start .. n.len + theEnd], not isSimple(it, n.kind == nkIdentDefs)
-          )
+        n,
+        start,
+        theEnd,
+        separator,
+        indentNL,
+        flags - {lfFirstSticky, lfFirstAlone},
+        subFlags,
+      ),
+    ):
+      false
+    else:
+      count > 1 and
+        anyIt(n.sons[start .. n.len + theEnd], not isSimple(it, n.kind == nkIdentDefs))
 
   for i in start .. n.len + theEnd:
     let c = i < n.len + theEnd
@@ -900,9 +891,7 @@ proc gsection(g: var TOutput, n: PNode, kind: TokType, k: string) =
   # empty var sections are possible
   putWithSpace(g, kind, k)
 
-  let
-    complex =
-      n.len > 1 or n.mid.len > 0 or n[0].prefix.len > 0 or overflows(g, lsub(g, n[0]))
+  let complex = n.len > 1 or n.mid.len > 0 or n[0].prefix.len > 0
   if complex:
     gmids(g, n, true)
 
@@ -1198,12 +1187,11 @@ proc gproc(g: var TOutput, n: PNode) =
     gpattern(g, n[patternPos])
 
   # If there is no body, we don't need to indent the parameters as much
-  let
-    flags =
-      if n[bodyPos].kind != nkEmpty:
-        {sfLongIndent}
-      else:
-        {}
+  let flags =
+    if n[bodyPos].kind != nkEmpty:
+      {sfLongIndent}
+    else:
+      {}
 
   gsub(g, n[genericParamsPos], flags)
   gsub(g, n[paramsPos], flags, extra = lsub(g, n[pragmasPos], flags)[0])
@@ -1292,12 +1280,11 @@ proc gident(g: var TOutput, n: PNode) =
   put(g, t, s)
 
 proc doParamsAux(g: var TOutput, params: PNode) =
-  let
-    retLen =
-      if params.len > 0 and params[0].kind != nkEmpty:
-        lsub(g, params[0]) + len(" -> ")
-      else:
-        (0, false)
+  let retLen =
+    if params.len > 0 and params[0].kind != nkEmpty:
+      lsub(g, params[0]) + len(" -> ")
+    else:
+      (0, false)
 
   if params.len > 0:
     # We must always output () or we get a significantly different AST (!)
@@ -1321,16 +1308,15 @@ proc gsubOptNL(
   if hasIndent(n) and n.kind in subOptSkipNL:
     gsub(g, n, flags = flags)
   else:
-    let
-      nl =
-        overflows(
-          g,
-          if strict:
-            lsub(g, n)
-          else:
-            nlsub(g, n)
-          ,
-        )
+    let nl =
+      overflows(
+        g,
+        if strict:
+          lsub(g, n)
+        else:
+          nlsub(g, n)
+        ,
+      )
     withIndent(g, indentNL):
       if nl:
         optNL(g)
@@ -1365,11 +1351,10 @@ proc infixArgument(g: var TOutput, n: PNode, i: int, flags: SubFlags) =
   if needsParenthesis:
     put(g, tkParRi, ")")
 
-const
-  postExprBlocks = {
-    nkStmtList, nkStmtListExpr, nkOfBranch, nkElifBranch, nkElse, nkExceptBranch,
-    nkFinally, nkDo
-  }
+const postExprBlocks = {
+  nkStmtList, nkStmtListExpr, nkOfBranch, nkElifBranch, nkElse, nkExceptBranch,
+  nkFinally, nkDo
+}
 
 proc postStatements(
     g: var TOutput, n: PNode, start: int, skipDo: bool, skipColon = false
@@ -1574,12 +1559,11 @@ proc gsub(g: var TOutput, n: PNode, flags: SubFlags, extra: int) =
   of nkPar, nkClosure:
     glist(g, n, tkParLe, subflags = {sfNoIndent})
   of nkTupleConstr:
-    let
-      flags =
-        if n.len == 1 and n[0].kind != nkExprColonExpr:
-          {lfSepAtEnd}
-        else:
-          {lfLongSepAtEnd}
+    let flags =
+      if n.len == 1 and n[0].kind != nkExprColonExpr:
+        {lfSepAtEnd}
+      else:
+        {lfLongSepAtEnd}
 
     glist(g, n, tkParLe, flags = flags)
   of nkCurly:
@@ -1739,16 +1723,15 @@ proc gsub(g: var TOutput, n: PNode, flags: SubFlags, extra: int) =
   of nkPrefix:
     gsub(g, n[0])
     if n.len > 1:
-      let
-        opr =
-          if n[0].kind == nkIdent:
-            n[0].ident
-          elif n[0].kind == nkSym:
-            n[0].sym.name
-          elif n[0].kind in {nkOpenSymChoice, nkClosedSymChoice}:
-            n[0][0].sym.name
-          else:
-            nil
+      let opr =
+        if n[0].kind == nkIdent:
+          n[0].ident
+        elif n[0].kind == nkSym:
+          n[0].sym.name
+        elif n[0].kind in {nkOpenSymChoice, nkClosedSymChoice}:
+          n[0][0].sym.name
+        else:
+          nil
 
       let nNext = skipHiddenNodes(n[1])
       if nNext.kind == nkPrefix or (opr != nil and phrenderer.isKeyword(opr)):
@@ -2154,15 +2137,14 @@ proc gsub(g: var TOutput, n: PNode, flags: SubFlags, extra: int) =
     # Need to add empty parens here, or nkProcTy parsing becomes non-equal -
     # see hasSignature - it would be nicer to remove them when unncessary
     if n.len >= 1:
-      let
-        retExtra =
-          extra +
-          (
-            if n.len > 0 and n[0].kind != nkEmpty:
-              lsub(g, n[0]) + len(": ")
-            else:
-              (0, false)
-          ).len
+      let retExtra =
+        extra +
+        (
+          if n.len > 0 and n[0].kind != nkEmpty:
+            lsub(g, n[0]) + len(": ")
+          else:
+            (0, false)
+        ).len
       # Properties of the proc formal params formatting:
       # * long indent when body follows to separate args from body
       # * separator at end when using one-per-line for easy copy-pasting and

--- a/tests/after/comments.nim
+++ b/tests/after/comments.nim
@@ -214,12 +214,11 @@ block: # block colon line
   discard
   discard
 
-let
-  x =
-    proc(): int = # lambda eq line
-        # lambda first line
-        discard
-        discard
+let x =
+  proc(): int = # lambda eq line
+      # lambda first line
+      discard
+      discard
 while false: # while colon line
   # while first line
   discard

--- a/tests/after/exprs.nim
+++ b/tests/after/exprs.nim
@@ -45,45 +45,40 @@ discard xxxx "arg":
 
 let shortInfix = a * b * c + d * e * f + (a + b) * g
 
-let
-  mediumInfix =
+let mediumInfix =
+  aaaaaaaaaaaaa + bbbbbbbbbbbbbbb + ccccccccccccccc + dddddddddddddddd +
+  eeeeeeeeeeeeeeeeeeeee + fffffffffffffff * ggggggggggggggg + hhhhhhhhhhhhhhh +
+  iiiiiiiiiiiiii + jjjjjjjjjjjjjjjjj + kkkkkkkkkk
+let parenInfix =
+  (
     aaaaaaaaaaaaa + bbbbbbbbbbbbbbb + ccccccccccccccc + dddddddddddddddd +
-    eeeeeeeeeeeeeeeeeeeee + fffffffffffffff * ggggggggggggggg + hhhhhhhhhhhhhhh +
-    iiiiiiiiiiiiii + jjjjjjjjjjjjjjjjj + kkkkkkkkkk
-let
-  parenInfix =
-    (
-      aaaaaaaaaaaaa + bbbbbbbbbbbbbbb + ccccccccccccccc + dddddddddddddddd +
-      eeeeeeeeeeeeeeeeeeeee + fffffffffffffff
-    ) * (
-      ggggggggggggggg + hhhhhhhhhhhhhhh + iiiiiiiiiiiiii + jjjjjjjjjjjjjjjjj +
-      kkkkkkkkkkkkk
-    )
-let
-  parenShortInfix =
-    (aaaaaaaaaaaaa + eeeeeeeeeeeeeeeeeeeee) * (
-      ggggggggggggggg + hhhhhhhhhhhhhhh + iiiiiiiiiiiiii + jjjjjjjjjjjjjjjjj +
-      kkkkkkkkkkkkkkkk
-    )
-
-let
-  longInfix = (
-    a30 * a21 * a12 * a03 - a20 * a31 * a12 * a03 - a30 * a11 * a22 * a03 +
-    a10 * a31 * a22 * a03 + a20 * a11 * a32 * a03 - a10 * a21 * a32 * a03 -
-    a30 * a21 * a02 * a13 + a20 * a31 * a02 * a13 + a30 * a01 * a22 * a13 -
-    a00 * a31 * a22 * a13 - a20 * a01 * a32 * a13 + a00 * a21 * a32 * a13 +
-    a30 * a11 * a02 * a23 - a10 * a31 * a02 * a23 - a30 * a01 * a12 * a23 +
-    a00 * a31 * a12 * a23 + a10 * a01 * a32 * a23 - a00 * a11 * a32 * a23 -
-    a20 * a11 * a02 * a33 + a10 * a21 * a02 * a33 + a20 * a01 * a12 * a33 -
-    a00 * a21 * a12 * a33 - a10 * a01 * a22 * a33 + a00 * a11 * a22 * a33
+    eeeeeeeeeeeeeeeeeeeee + fffffffffffffff
+  ) * (
+    ggggggggggggggg + hhhhhhhhhhhhhhh + iiiiiiiiiiiiii + jjjjjjjjjjjjjjjjj +
+    kkkkkkkkkkkkk
+  )
+let parenShortInfix =
+  (aaaaaaaaaaaaa + eeeeeeeeeeeeeeeeeeeee) * (
+    ggggggggggggggg + hhhhhhhhhhhhhhh + iiiiiiiiiiiiii + jjjjjjjjjjjjjjjjj +
+    kkkkkkkkkkkkkkkk
   )
 
-let
-  longArray = [
-    aaaaaaaaaaaaa, bbbbbbbbbbbbbbb, ccccccccccccccc, dddddddddddddddd,
-    eeeeeeeeeeeeeeeeeeeee, fffffffffffffff, ggggggggggggggg, hhhhhhhhhhhhhhh,
-    iiiiiiiiiiiiii, jjjjjjjjjjjjjjjjj, kkkkkkkkkk
-  ]
+let longInfix = (
+  a30 * a21 * a12 * a03 - a20 * a31 * a12 * a03 - a30 * a11 * a22 * a03 +
+  a10 * a31 * a22 * a03 + a20 * a11 * a32 * a03 - a10 * a21 * a32 * a03 -
+  a30 * a21 * a02 * a13 + a20 * a31 * a02 * a13 + a30 * a01 * a22 * a13 -
+  a00 * a31 * a22 * a13 - a20 * a01 * a32 * a13 + a00 * a21 * a32 * a13 +
+  a30 * a11 * a02 * a23 - a10 * a31 * a02 * a23 - a30 * a01 * a12 * a23 +
+  a00 * a31 * a12 * a23 + a10 * a01 * a32 * a23 - a00 * a11 * a32 * a23 -
+  a20 * a11 * a02 * a33 + a10 * a21 * a02 * a33 + a20 * a01 * a12 * a33 -
+  a00 * a21 * a12 * a33 - a10 * a01 * a22 * a33 + a00 * a11 * a22 * a33
+)
+
+let longArray = [
+  aaaaaaaaaaaaa, bbbbbbbbbbbbbbb, ccccccccccccccc, dddddddddddddddd,
+  eeeeeeeeeeeeeeeeeeeee, fffffffffffffff, ggggggggggggggg, hhhhhhhhhhhhhhh,
+  iiiiiiiiiiiiii, jjjjjjjjjjjjjjjjj, kkkkkkkkkk
+]
 
 if aaaaaaaaaaaaaaaaaaaa and bbbbbbbbbbbbbbbbbbbbbbb and ccccccccccccccccccccccccc and
     ddddddddddddddddd and fffffffffffffffff:
@@ -108,11 +103,10 @@ if true:
   if false:
     discard
 
-let
-  a =
-    case x
-    of 2: 4
-    else: 4
+let a =
+  case x
+  of 2: 4
+  else: 4
 
 case aaaaaaaaaa
 of aaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbb, ccccccccccccccccccccccc,

--- a/tests/after/procs.nim
+++ b/tests/after/procs.nim
@@ -129,30 +129,27 @@ type Bp = proc
 type Cp = proc(v: int)
 type Dp = proc() {.nimcall.}
 type Ep = proc {.nimcall.}
-type
-  Fp =
-    proc(
-      aaaaaaaaaaaaaaaaa: int,
-      bbbbbbbbbbbbbbb =
-        proc() =
-            discard
-      ,
-      cccccccccccccccccc = 30,
-    )
+type Fp =
+  proc(
+    aaaaaaaaaaaaaaaaa: int,
+    bbbbbbbbbbbbbbb =
+      proc() =
+          discard
+    ,
+    cccccccccccccccccc = 30,
+  )
 
 type Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = proc {.bbbbbbbbbbbbbbbbbbbbbbbb.}
-type
-  Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa =
-    proc(aaaaaaaa: Bbbbbbb, ccccccccc: Dddddddddddd, eeeeee: Ffffff)
+type Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa =
+  proc(aaaaaaaa: Bbbbbbb, ccccccccc: Dddddddddddd, eeeeee: Ffffff)
 
-type
-  Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa =
-    proc(
-      aaaaaaaa: Bbbbbbb,
-      ccccccccc: Dddddddddddd,
-      eeeeeeeeeeeee: Ffffffffffffffff,
-      gggggggggggggg: Hhhhhhhhhhhhhhhhhhhh,
-    )
+type Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa =
+  proc(
+    aaaaaaaa: Bbbbbbb,
+    ccccccccc: Dddddddddddd,
+    eeeeeeeeeeeee: Ffffffffffffffff,
+    gggggggggggggg: Hhhhhhhhhhhhhhhhhhhh,
+  )
 
 proc `.()`() =
   discard

--- a/tests/after/types.nim
+++ b/tests/after/types.nim
@@ -1,17 +1,15 @@
 type A = int
 
 type TypeClass = A | B
-type
-  Bbbbbbbbbbbbbbbbbbbbbbbbbbbbb =
-    Aaaaaaaaaaaaaa | Bbbbbbbbbbbbbbbbb | Cccccccccccccccccccccc | Dddddddddddddddddddddd |
-    Eeeeeeeeeeeeeeeeeeeeeeeeee
+type Bbbbbbbbbbbbbbbbbbbbbbbbbbbbb =
+  Aaaaaaaaaaaaaa | Bbbbbbbbbbbbbbbbb | Cccccccccccccccccccccc | Dddddddddddddddddddddd |
+  Eeeeeeeeeeeeeeeeeeeeeeeeee
 
-type
-  GenericAlias[
-    T:
-      Aaaaaaaaaaaaaaaaaaa | Bbbbbbbbbbbbbbbbbbbbbbbb | Cccccccccccccccccccc |
-      Dddddddddddddddd | Eeeeeeeeeeeeeeeeeee
-  ] = Bbbbbbbbbbbbbbbbbb[T]
+type GenericAlias[
+  T:
+    Aaaaaaaaaaaaaaaaaaa | Bbbbbbbbbbbbbbbbbbbbbbbb | Cccccccccccccccccccc |
+    Dddddddddddddddd | Eeeeeeeeeeeeeeeeeee
+] = Bbbbbbbbbbbbbbbbbb[T]
 
 type GenericRef = GenType[A, ref B]
 proc procTypeclass(
@@ -22,48 +20,43 @@ proc procTypeclass(
 
 type EmptyObject = object
 
-type
-  FieldObject = object
-    aaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbb, cccccccccccccccccccc, dddddddddddddddddddd,
-      eeeeeeeeeeeeeeeeeeee, fffffffffffffffffff, ggggggggggggggggggggggg: int
-    aaaaaaaaaaaaaaa*, bbbbbbbbbbbbbbbbb*, cccccccccccccccccccc*, dddddddddddddddddddd*,
-      eeeeeeeeeeeeeeeeeeee*, fffffffffffffffffff*, ggggggggggggggggggggggg*: int
+type FieldObject = object
+  aaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbb, cccccccccccccccccccc, dddddddddddddddddddd,
+    eeeeeeeeeeeeeeeeeeee, fffffffffffffffffff, ggggggggggggggggggggggg: int
+  aaaaaaaaaaaaaaa*, bbbbbbbbbbbbbbbbb*, cccccccccccccccccccc*, dddddddddddddddddddd*,
+    eeeeeeeeeeeeeeeeeeee*, fffffffffffffffffff*, ggggggggggggggggggggggg*: int
 
-type
-  CaseObject = object
-    case f: bool
-    of false:
-      vfalse: int
-    of true:
-      vtrue: int
+type CaseObject = object
+  case f: bool
+  of false:
+    vfalse: int
+  of true:
+    vtrue: int
 
-type
-  CaseObject = object
-    case f {.
-      aaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccc,
-      ddddddddddddddddddddd, eeeeeeeeeeeeeeeeeee
-    .}: bool
-    of false:
-      vfalse: int
-    of true:
-      vtrue: int
+type CaseObject = object
+  case f {.
+    aaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccc,
+    ddddddddddddddddddddd, eeeeeeeeeeeeeeeeeee
+  .}: bool
+  of false:
+    vfalse: int
+  of true:
+    vtrue: int
 
-type
-  PragmaObject {.
-    objectPragma, aaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbb, cccccccccccccccccccccc,
-    dddddddddddddddddddd
-  .} = object
-    vfalse {.fieldPragma.}: int
-    vpublic* {.fieldPragma.}: int
+type PragmaObject {.
+  objectPragma, aaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbb, cccccccccccccccccccccc,
+  dddddddddddddddddddd
+.} = object
+  vfalse {.fieldPragma.}: int
+  vpublic* {.fieldPragma.}: int
 
-    vfalse {.
-      fieldPragma, aaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbb,
-      cccccccccccccccccccccccccccc, dddddddddddddddddddddd
-    .}: int
-    vpublic* {.fieldPragma.}: int
+  vfalse {.
+    fieldPragma, aaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbb,
+    cccccccccccccccccccccccccccc, dddddddddddddddddddddd
+  .}: int
+  vpublic* {.fieldPragma.}: int
 
-type
-  RefObject = ref object of RootObj
-    reffield: int
+type RefObject = ref object of RootObj
+  reffield: int
 
 type RefAlone = ref object of RootObj


### PR DESCRIPTION
The section "short form" was restored to its 0.2 format to allow the before-`=` part of the section to stay on the same line as the section keyword.

This reduces the overall indent of the (long) RHS which gives it better chances to be formatted nicely.