### PR TITLE
Treat `.` as part of a simple expression

### DIFF
--- a/docs/src/style.md
+++ b/docs/src/style.md
@@ -135,6 +135,12 @@ functionCall(
 )
 ```
 
+```admonish info "What is simple?"
+* literals (`2`, `"string"` etc)
+* simple identifiers (`myvar` etc)
+* dot expressions of the the above (`myObject.field`)
+```
+
 ### Parameter lists
 
 Parameter lists, such as function parameters and generics, are rendered using

--- a/src/phast.nim
+++ b/src/phast.nim
@@ -1630,10 +1630,7 @@ proc newTreeIT*(
   result.sons = @children
 
 template previouslyInferred*(t: PType): PType =
-  if t.sons.len > 1:
-    t.lastSon
-  else:
-    nil
+  if t.sons.len > 1: t.lastSon else: nil
 
 when false:
   import tables, strutils
@@ -2271,10 +2268,7 @@ proc skipGenericOwner*(s: PSym): PSym =
   ## symbol. This proc skips such owners and goes straight to the owner
   ## of the generic itself (the module or the enclosing proc).
   result =
-    if s.kind in skProcKinds and sfFromGeneric in s.flags:
-      s.owner.owner
-    else:
-      s.owner
+    if s.kind in skProcKinds and sfFromGeneric in s.flags: s.owner.owner else: s.owner
 
 proc originatingModule*(s: PSym): PSym =
   result = s.owner
@@ -2346,10 +2340,7 @@ proc toObject*(typ: PType): PType =
   ## cases should be a ``tyObject``).
   ## Otherwise ``typ`` is simply returned as-is.
   let t = typ.skipTypes({tyAlias, tyGenericInst})
-  if t.kind == tyRef:
-    t.lastSon
-  else:
-    typ
+  if t.kind == tyRef: t.lastSon else: typ
 
 proc toObjectFromRefPtrGeneric*(typ: PType): PType =
   #[

--- a/src/phlexer.nim
+++ b/src/phlexer.nim
@@ -268,10 +268,7 @@ proc `$`*(tok: Token): string =
   of tkParLe .. tkColon, tkEof, tkAccent:
     $tok.tokType
   else:
-    if tok.ident != nil:
-      tok.ident.s
-    else:
-      ""
+    if tok.ident != nil: tok.ident.s else: ""
 
 proc prettyTok*(tok: Token): string =
   if isKeyword(tok.tokType):
@@ -986,10 +983,8 @@ proc getString(L: var Lexer, tok: var Token, mode: StringMode) =
         L.lineNumber = line
 
         lexMessagePos(
-          L,
-          errGenerated,
-          L.lineStart,
-          "closing \"\"\" expected, but end of file reached",
+          L, errGenerated, L.lineStart,
+          "closing \"\"\" expected, but end of file reached"
         )
 
         L.lineNumber = line2

--- a/src/phmsgs.nim
+++ b/src/phmsgs.nim
@@ -375,11 +375,7 @@ proc msgWriteln*(conf: ConfigRef, s: string, flags: MsgFlags = {}) =
   ## This is used for 'nim dump' etc. where we don't have nimsuggest
   ## support.
   #if conf.cmd == cmdIdeTools and optCDebug notin gGlobalOptions: return
-  let sep =
-    if msgNoUnitSep notin flags:
-      conf.unitSep
-    else:
-      ""
+  let sep = if msgNoUnitSep notin flags: conf.unitSep else: ""
 
   if not isNil(conf.writelnHook) and msgSkipHook notin flags:
     conf.writelnHook(s & sep)

--- a/src/phparser.nim
+++ b/src/phparser.nim
@@ -964,8 +964,7 @@ proc primarySuffix(p: var Parser, r: PNode, baseIndent: int, mode: PrimaryMode):
         result = commandExpr(p, result, mode)
         break
       result = namedParams(p, result, nkCurlyExpr, tkCurlyRi)
-    of
-        tkSymbol,
+    of tkSymbol,
         tkAccent,
         tkIntLit .. tkCustomLit,
         tkNil,
@@ -1337,8 +1336,7 @@ proc parseProcExpr(p: var Parser, isExpr: bool, kind: TNodeKind): PNode =
 
 proc isExprStart(p: Parser): bool =
   case p.tok.tokType
-  of
-      tkSymbol,
+  of tkSymbol,
       tkAccent,
       tkOpr,
       tkNot,
@@ -2221,11 +2219,7 @@ proc parseEnum(p: var Parser): PNode =
   splitLookahead(p, result, clMid)
   # progress guaranteed
   while true:
-    let symInd =
-      if p.tok.indent == -1:
-        p.currInd
-      else:
-        p.tok.indent
+    let symInd = if p.tok.indent == -1: p.currInd else: p.tok.indent
     var a = parseSymbol(p)
     if a.kind == nkEmpty:
       return
@@ -2446,7 +2440,7 @@ proc parseTypeClass(p: var Parser): PNode =
       parMessage(
         p,
         "routine expected, but found '$1' (empty new-styled concepts are not allowed)",
-        p.tok,
+        p.tok
       )
     result.add(p.emptyNode)
   else:

--- a/tests/after/exprs.nim
+++ b/tests/after/exprs.nim
@@ -96,7 +96,15 @@ elif aaaaaaaaa and (
 ):
   discard
 
-let prefix = if someprettylongconditionhereabcabcabcabc: "[Valid]   " else: "[Invalid] "
+let prefix = if ifstmtthatfitsonasinglelinewithlongcond: "[Valid]   " else: "[Invalid] "
+
+let prefix2 =
+  if someprettylongconditionhereexpressiondoestfit: "[Valid]   " else: "[Invalid] "
+let prefix3 =
+  if someprettylongconditionhereexpressiondoestfitatallabcabcabcabc:
+    "[Valid]   "
+  else:
+    "[Invalid] "
 
 # short if in short if
 if true:
@@ -117,6 +125,9 @@ of aaaa:
 of aaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbb, ccccccccccccccccccccccc,
     dddddddddddddddddddddd, aaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbb,
     ccccccccccccccccccccccc, dddddddddddddddddddddd:
+  discard
+of aaaaaaaaaaaaaaaaaaaaaaaaaa .. bbbbbbbbbbbbbbbbbbbbbbbb,
+    dddddddddddddddddddddddddd .. ccccccccccccccccccccccc:
   discard
 else:
   discard

--- a/tests/after/exprs.nim.nph.yaml
+++ b/tests/after/exprs.nim.nph.yaml
@@ -1362,7 +1362,53 @@ sons:
               - kind: "nkElifExpr"
                 sons:
                   - kind: "nkIdent"
-                    ident: "someprettylongconditionhereabcabcabcabc"
+                    ident: "ifstmtthatfitsonasinglelinewithlongcond"
+                  - kind: "nkStmtList"
+                    sons:
+                      - kind: "nkStrLit"
+                        strVal: "[Valid]   "
+              - kind: "nkElseExpr"
+                sons:
+                  - kind: "nkStmtList"
+                    sons:
+                      - kind: "nkStrLit"
+                        strVal: "[Invalid] "
+  - kind: "nkLetSection"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "prefix2"
+          - kind: "nkEmpty"
+          - kind: "nkIfExpr"
+            sons:
+              - kind: "nkElifExpr"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "someprettylongconditionhereexpressiondoestfit"
+                  - kind: "nkStmtList"
+                    sons:
+                      - kind: "nkStrLit"
+                        strVal: "[Valid]   "
+              - kind: "nkElseExpr"
+                sons:
+                  - kind: "nkStmtList"
+                    sons:
+                      - kind: "nkStrLit"
+                        strVal: "[Invalid] "
+  - kind: "nkLetSection"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "prefix3"
+          - kind: "nkEmpty"
+          - kind: "nkIfExpr"
+            sons:
+              - kind: "nkElifExpr"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "someprettylongconditionhereexpressiondoestfitatallabcabcabcabc"
                   - kind: "nkStmtList"
                     sons:
                       - kind: "nkStrLit"
@@ -1465,6 +1511,29 @@ sons:
             ident: "ccccccccccccccccccccccc"
           - kind: "nkIdent"
             ident: "dddddddddddddddddddddd"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+      - kind: "nkOfBranch"
+        sons:
+          - kind: "nkInfix"
+            sons:
+              - kind: "nkIdent"
+                ident: ".."
+              - kind: "nkIdent"
+                ident: "aaaaaaaaaaaaaaaaaaaaaaaaaa"
+              - kind: "nkIdent"
+                ident: "bbbbbbbbbbbbbbbbbbbbbbbb"
+          - kind: "nkInfix"
+            sons:
+              - kind: "nkIdent"
+                ident: ".."
+              - kind: "nkIdent"
+                ident: "dddddddddddddddddddddddddd"
+              - kind: "nkIdent"
+                ident: "ccccccccccccccccccccccc"
           - kind: "nkStmtList"
             sons:
               - kind: "nkDiscardStmt"

--- a/tests/before/exprs.nim
+++ b/tests/before/exprs.nim
@@ -66,10 +66,13 @@ elif aaaaaaaaa and (bbbbbbbbbb or cccccccccccc and (dddddddddddddddd or eeeeeeee
 
 let
   prefix =
-    if someprettylongconditionhereabcabcabcabc:
+    if ifstmtthatfitsonasinglelinewithlongcond:
       "[Valid]   "
     else:
       "[Invalid] "
+
+let prefix2 = if someprettylongconditionhereexpressiondoestfit: "[Valid]   " else: "[Invalid] "
+let prefix3 = if someprettylongconditionhereexpressiondoestfitatallabcabcabcabc: "[Valid]   " else: "[Invalid] "
 
 # short if in short if
 if true:
@@ -83,6 +86,8 @@ case aaaaaaaaaa
 of aaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbb, ccccccccccccccccccccccc, ddddddddddddddddddddddd: discard
 of aaaa: discard
 of aaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbb, ccccccccccccccccccccccc, dddddddddddddddddddddd, aaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbb, ccccccccccccccccccccccc, dddddddddddddddddddddd:
+  discard
+of aaaaaaaaaaaaaaaaaaaaaaaaaa..bbbbbbbbbbbbbbbbbbbbbbbb, dddddddddddddddddddddddddd..ccccccccccccccccccccccc:
   discard
 else:
   discard

--- a/tests/before/exprs.nim.nph.yaml
+++ b/tests/before/exprs.nim.nph.yaml
@@ -1362,7 +1362,53 @@ sons:
               - kind: "nkElifExpr"
                 sons:
                   - kind: "nkIdent"
-                    ident: "someprettylongconditionhereabcabcabcabc"
+                    ident: "ifstmtthatfitsonasinglelinewithlongcond"
+                  - kind: "nkStmtList"
+                    sons:
+                      - kind: "nkStrLit"
+                        strVal: "[Valid]   "
+              - kind: "nkElseExpr"
+                sons:
+                  - kind: "nkStmtList"
+                    sons:
+                      - kind: "nkStrLit"
+                        strVal: "[Invalid] "
+  - kind: "nkLetSection"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "prefix2"
+          - kind: "nkEmpty"
+          - kind: "nkIfExpr"
+            sons:
+              - kind: "nkElifExpr"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "someprettylongconditionhereexpressiondoestfit"
+                  - kind: "nkStmtList"
+                    sons:
+                      - kind: "nkStrLit"
+                        strVal: "[Valid]   "
+              - kind: "nkElseExpr"
+                sons:
+                  - kind: "nkStmtList"
+                    sons:
+                      - kind: "nkStrLit"
+                        strVal: "[Invalid] "
+  - kind: "nkLetSection"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "prefix3"
+          - kind: "nkEmpty"
+          - kind: "nkIfExpr"
+            sons:
+              - kind: "nkElifExpr"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "someprettylongconditionhereexpressiondoestfitatallabcabcabcabc"
                   - kind: "nkStmtList"
                     sons:
                       - kind: "nkStrLit"
@@ -1465,6 +1511,29 @@ sons:
             ident: "ccccccccccccccccccccccc"
           - kind: "nkIdent"
             ident: "dddddddddddddddddddddd"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+      - kind: "nkOfBranch"
+        sons:
+          - kind: "nkInfix"
+            sons:
+              - kind: "nkIdent"
+                ident: ".."
+              - kind: "nkIdent"
+                ident: "aaaaaaaaaaaaaaaaaaaaaaaaaa"
+              - kind: "nkIdent"
+                ident: "bbbbbbbbbbbbbbbbbbbbbbbb"
+          - kind: "nkInfix"
+            sons:
+              - kind: "nkIdent"
+                ident: ".."
+              - kind: "nkIdent"
+                ident: "dddddddddddddddddddddddddd"
+              - kind: "nkIdent"
+                ident: "ccccccccccccccccccccccc"
           - kind: "nkStmtList"
             sons:
               - kind: "nkDiscardStmt"


### PR DESCRIPTION
Treating `.` as complex leads to complex formatting where it is not desired, such as module-prefixing and trivial field accesses - this plays well with omitting `()` in trivial calls as well.

* ensure long if-expressions are line-broken correctly
* render first condition of `of` on the same line