### PR TITLE
tighten rhs expression whitespace and indent

### DIFF
--- a/docs/src/style.md
+++ b/docs/src/style.md
@@ -192,3 +192,42 @@ spaces around these infixes and sometimes not, leading to irregularity.
 Since there's no consensus in existing code at the time of writing, the rule is
 irregular and causes implementation complexity, `nph` formats `..` and `..<`
 with spaces.
+
+## Expressions
+
+Expressions appear in many places, such as after certain keywords (`return`,
+`yield`), as part of control flows (`if`, `while`), in assignments etc.
+
+Whenever possible, `nph` will try to keep the full expression on a single line:
+
+```nim
+let myvariable = somelongexpression(abc)
+```
+
+If this is not possible, the second preference is to move the whole expression
+to a new line, assuming it fits:
+
+```nim
+let myvariable =
+   someevenlongerexpression(abc, def)
+```
+
+If the expression still doesn't fit, we'll split it up on multiple lines:
+
+```nim
+let myvariable = someevenlongerexpression(
+  aaa, bbb, ccc, ddd
+)
+```
+
+Certain expressions linked by related keywords that don't fit on a single line
+will also be moved to a new line - for example, a multi-line `if`/`else` nested
+in a `return` will be lined up like so:
+
+```nim
+return
+  if condition:
+    complex(call)
+  else:
+    alsocomplex(call)
+```

--- a/src/phast.nim
+++ b/src/phast.nim
@@ -1407,22 +1407,20 @@ const PackageModuleId* = -3'i32
 proc idGeneratorFromModule*(m: PSym): IdGenerator =
   assert m.kind == skModule
 
-  result =
-    IdGenerator(
-      module: m.itemId.module,
-      symId: m.itemId.item,
-      typeId: 0,
-      disambTable: initCountTable[PIdent](),
-    )
+  result = IdGenerator(
+    module: m.itemId.module,
+    symId: m.itemId.item,
+    typeId: 0,
+    disambTable: initCountTable[PIdent](),
+  )
 
 proc idGeneratorForPackage*(nextIdWillBe: int32): IdGenerator =
-  result =
-    IdGenerator(
-      module: PackageModuleId,
-      symId: nextIdWillBe - 1'i32,
-      typeId: 0,
-      disambTable: initCountTable[PIdent](),
-    )
+  result = IdGenerator(
+    module: PackageModuleId,
+    symId: nextIdWillBe - 1'i32,
+    typeId: 0,
+    disambTable: initCountTable[PIdent](),
+  )
 
 proc nextSymId*(x: IdGenerator): ItemId {.inline.} =
   assert(not x.sealed)
@@ -1655,18 +1653,17 @@ proc newSym*(
 
   let id = nextSymId idgen
 
-  result =
-    PSym(
-      name: name,
-      kind: symKind,
-      flags: {},
-      info: info,
-      itemId: id,
-      options: options,
-      owner: owner,
-      offset: defaultOffset,
-      disamb: getOrDefault(idgen.disambTable, name).int32,
-    )
+  result = PSym(
+    name: name,
+    kind: symKind,
+    flags: {},
+    info: info,
+    itemId: id,
+    options: options,
+    owner: owner,
+    offset: defaultOffset,
+    disamb: getOrDefault(idgen.disambTable, name).int32,
+  )
 
   idgen.disambTable.inc name
   when false:
@@ -1685,8 +1682,8 @@ proc astdef*(s: PSym): PNode =
     s.ast
 
 proc isMetaType*(t: PType): bool =
-  return t.kind in tyMetaTypes or (t.kind == tyStatic and t.n == nil) or
-      tfHasMeta in t.flags
+  return
+    t.kind in tyMetaTypes or (t.kind == tyStatic and t.n == nil) or tfHasMeta in t.flags
 
 proc isUnresolvedStatic*(t: PType): bool =
   return t.kind == tyStatic and t.n == nil
@@ -1863,15 +1860,14 @@ proc `$`*(s: PSym): string =
     result = "<nil>"
 
 proc newType*(kind: TTypeKind, id: ItemId, owner: PSym): PType =
-  result =
-    PType(
-      kind: kind,
-      owner: owner,
-      size: defaultSize,
-      align: defaultAlignment,
-      itemId: id,
-      uniqueId: id,
-    )
+  result = PType(
+    kind: kind,
+    owner: owner,
+    size: defaultSize,
+    align: defaultAlignment,
+    itemId: id,
+    uniqueId: id,
+  )
 
   when false:
     if result.itemId.module == 55 and result.itemId.item == 2:
@@ -2065,16 +2061,15 @@ proc delSon*(father: PNode, idx: int) =
 template transitionNodeKindCommon(k: TNodeKind) =
   let obj {.inject.} = n[]
 
-  n[] =
-    TNode(
-      kind: k,
-      typ: obj.typ,
-      info: obj.info,
-      flags: obj.flags,
-      prefix: obj.prefix,
-      mid: obj.mid,
-      postfix: obj.postfix,
-    )
+  n[] = TNode(
+    kind: k,
+    typ: obj.typ,
+    info: obj.info,
+    flags: obj.flags,
+    prefix: obj.prefix,
+    mid: obj.mid,
+    postfix: obj.postfix,
+  )
   # n.comment = obj.comment # shouldn't be needed, the address doesnt' change
   when defined(useNodeIds):
     n.id = obj.id
@@ -2100,24 +2095,23 @@ proc transitionNoneToSym*(n: PNode) =
 template transitionSymKindCommon*(k: TSymKind) =
   let obj {.inject.} = s[]
 
-  s[] =
-    TSym(
-      kind: k,
-      itemId: obj.itemId,
-      magic: obj.magic,
-      typ: obj.typ,
-      name: obj.name,
-      info: obj.info,
-      owner: obj.owner,
-      flags: obj.flags,
-      ast: obj.ast,
-      options: obj.options,
-      position: obj.position,
-      offset: obj.offset,
-      loc: obj.loc,
-      annex: obj.annex,
-      constraint: obj.constraint,
-    )
+  s[] = TSym(
+    kind: k,
+    itemId: obj.itemId,
+    magic: obj.magic,
+    typ: obj.typ,
+    name: obj.name,
+    info: obj.info,
+    owner: obj.owner,
+    flags: obj.flags,
+    ast: obj.ast,
+    options: obj.options,
+    position: obj.position,
+    offset: obj.offset,
+    loc: obj.loc,
+    annex: obj.annex,
+    constraint: obj.constraint,
+  )
 
   when hasFFI:
     s.cname = obj.cname

--- a/src/phoptions.nim
+++ b/src/phoptions.nim
@@ -475,10 +475,9 @@ type
     suggestMaxResults*: int
     lastLineInfo*: TLineInfo
     writelnHook*: proc(output: string) {.closure, gcsafe.}
-    structuredErrorHook*:
-      proc(config: ConfigRef, info: TLineInfo, msg: string, severity: Severity) {.
-        closure, gcsafe
-      .}
+    structuredErrorHook*: proc(
+      config: ConfigRef, info: TLineInfo, msg: string, severity: Severity
+    ) {.closure, gcsafe.}
     cppCustomNamespace*: string
     nimMainPrefix*: string
     vmProfileData*: ProfileData
@@ -628,58 +627,57 @@ proc initConfigRefCommon(conf: ConfigRef) =
   conf.mainPackageNotes = NotesVerbosity[1]
 
 proc newConfigRef*(): ConfigRef =
-  result =
-    ConfigRef(
-      cCompiler: ccGcc,
-      macrosToExpand: newStringTable(modeStyleInsensitive),
-      arcToExpand: newStringTable(modeStyleInsensitive),
-      m: initMsgConfig(),
-      cppDefines: initHashSet[string](),
-      headerFile: "",
-      features: {},
-      legacyFeatures: {},
-      configVars: newStringTable(modeStyleInsensitive),
-      symbols: newStringTable(modeStyleInsensitive),
-      packageCache: newPackageCache(),
-      searchPaths: @[],
-      lazyPaths: @[],
-      outFile: RelativeFile"",
-      outDir: AbsoluteDir"",
-      prefixDir: AbsoluteDir"",
-      libpath: AbsoluteDir"",
-      nimcacheDir: AbsoluteDir"",
-      dllOverrides: newStringTable(modeCaseInsensitive),
-      moduleOverrides: newStringTable(modeStyleInsensitive),
-      cfileSpecificOptions: newStringTable(modeCaseSensitive),
-      projectName: "", # holds a name like 'nim'
-      projectPath: AbsoluteDir"", # holds a path like /home/alice/projects/nim/compiler/
-      projectFull: AbsoluteFile"", # projectPath/projectName
-      projectIsStdin: false, # whether we're compiling from stdin
-      projectMainIdx: FileIndex(0'i32), # the canonical path id of the main module
-      command: "", # the main command (e.g. cc, check, scan, etc)
-      commandArgs: @[], # any arguments after the main command
-      commandLine: "",
-      keepComments: true, # whether the parser needs to keep comments
-      implicitImports: @[], # modules that are to be implicitly imported
-      implicitIncludes: @[], # modules that are to be implicitly included
-      docSeeSrcUrl: "",
-      cIncludes: @[], # directories to search for included files
-      cLibs: @[], # directories to search for lib files
-      cLinkedLibs: @[], # libraries to link
-      backend: backendInvalid,
-      externalToLink: @[],
-      linkOptionsCmd: "",
-      compileOptionsCmd: @[],
-      linkOptions: "",
-      compileOptions: "",
-      ccompilerpath: "",
-      toCompile: @[],
-      arguments: "",
-      suggestMaxResults: 10_000,
-      maxLoopIterationsVM: 10_000_000,
-      vmProfileData: newProfileData(),
-      spellSuggestMax: spellSuggestSecretSauce,
-    )
+  result = ConfigRef(
+    cCompiler: ccGcc,
+    macrosToExpand: newStringTable(modeStyleInsensitive),
+    arcToExpand: newStringTable(modeStyleInsensitive),
+    m: initMsgConfig(),
+    cppDefines: initHashSet[string](),
+    headerFile: "",
+    features: {},
+    legacyFeatures: {},
+    configVars: newStringTable(modeStyleInsensitive),
+    symbols: newStringTable(modeStyleInsensitive),
+    packageCache: newPackageCache(),
+    searchPaths: @[],
+    lazyPaths: @[],
+    outFile: RelativeFile"",
+    outDir: AbsoluteDir"",
+    prefixDir: AbsoluteDir"",
+    libpath: AbsoluteDir"",
+    nimcacheDir: AbsoluteDir"",
+    dllOverrides: newStringTable(modeCaseInsensitive),
+    moduleOverrides: newStringTable(modeStyleInsensitive),
+    cfileSpecificOptions: newStringTable(modeCaseSensitive),
+    projectName: "", # holds a name like 'nim'
+    projectPath: AbsoluteDir"", # holds a path like /home/alice/projects/nim/compiler/
+    projectFull: AbsoluteFile"", # projectPath/projectName
+    projectIsStdin: false, # whether we're compiling from stdin
+    projectMainIdx: FileIndex(0'i32), # the canonical path id of the main module
+    command: "", # the main command (e.g. cc, check, scan, etc)
+    commandArgs: @[], # any arguments after the main command
+    commandLine: "",
+    keepComments: true, # whether the parser needs to keep comments
+    implicitImports: @[], # modules that are to be implicitly imported
+    implicitIncludes: @[], # modules that are to be implicitly included
+    docSeeSrcUrl: "",
+    cIncludes: @[], # directories to search for included files
+    cLibs: @[], # directories to search for lib files
+    cLinkedLibs: @[], # libraries to link
+    backend: backendInvalid,
+    externalToLink: @[],
+    linkOptionsCmd: "",
+    compileOptionsCmd: @[],
+    linkOptions: "",
+    compileOptions: "",
+    ccompilerpath: "",
+    toCompile: @[],
+    arguments: "",
+    suggestMaxResults: 10_000,
+    maxLoopIterationsVM: 10_000_000,
+    vmProfileData: newProfileData(),
+    spellSuggestMax: spellSuggestSecretSauce,
+  )
 
   initConfigRefCommon(result)
   setTargetFromSystem(result.target)
@@ -947,27 +945,26 @@ proc getNimcacheDir*(conf: ConfigRef): AbsoluteDir =
 proc pathSubs*(conf: ConfigRef, p, config: string): string =
   let home = removeTrailingDirSep(os.getHomeDir())
 
-  result =
-    unixToNativePath(
-      p % [
-        "nim",
-        getPrefixDir(conf).string,
-        "lib",
-        conf.libpath.string,
-        "home",
-        home,
-        "config",
-        config,
-        "projectname",
-        conf.projectName,
-        "projectpath",
-        conf.projectPath.string,
-        "projectdir",
-        conf.projectPath.string,
-        "nimcache",
-        getNimcacheDir(conf).string
-      ]
-    ).expandTilde
+  result = unixToNativePath(
+    p % [
+      "nim",
+      getPrefixDir(conf).string,
+      "lib",
+      conf.libpath.string,
+      "home",
+      home,
+      "config",
+      config,
+      "projectname",
+      conf.projectName,
+      "projectpath",
+      conf.projectPath.string,
+      "projectdir",
+      conf.projectPath.string,
+      "nimcache",
+      getNimcacheDir(conf).string
+    ]
+  ).expandTilde
 
 iterator nimbleSubs*(conf: ConfigRef, p: string): string =
   let pl = p.toLowerAscii

--- a/tests/after/comments.nim
+++ b/tests/after/comments.nim
@@ -214,11 +214,10 @@ block: # block colon line
   discard
   discard
 
-let x =
-  proc(): int = # lambda eq line
-    # lambda first line
-    discard
-    discard
+let x = proc(): int = # lambda eq line
+  # lambda first line
+  discard
+  discard
 while false: # while colon line
   # while first line
   discard
@@ -228,13 +227,13 @@ static: # static colon line
   discard
 
 discard Object( # object eol
-    # object first line
-    field: 0, # field line
-    field2:
-      # field colon line
-      # Field colon next line
-      42,
-  )
+  # object first line
+  field: 0, # field line
+  field2:
+    # field colon line
+    # Field colon next line
+    42,
+)
 
 a = b
 ## Doc comment after assignment

--- a/tests/after/comments.nim.nph.yaml
+++ b/tests/after/comments.nim.nph.yaml
@@ -866,10 +866,10 @@ sons:
           - kind: "nkIdent"
             ident: "Object"
           - kind: "nkExprColonExpr"
+            prefix:
+              - "# object first line"
             sons:
               - kind: "nkIdent"
-                prefix:
-                  - "# object first line"
                 ident: "field"
               - kind: "nkIntLit"
                 intVal: 0

--- a/tests/after/exprs.nim
+++ b/tests/after/exprs.nim
@@ -34,7 +34,7 @@ let
 
 # command syntax with colon
 discard xxxx "arg":
-    yyy
+  yyy
 
 (
   try:
@@ -156,3 +156,11 @@ mynums =
   .replace5("five", "f5ive")
   .replace6("six", "s6ix")
   .replace7("seven", "s7even")
+
+let xxxxxxxxx = block:
+  f()
+  v
+
+let yyyyyyyyyy = aaaaaaaaaaaaaaaaaaaaaaaaa.ffffffffffffff(
+  aaaaaaaaa, bbbbbbbbbbbbbbbbbb, cccccccccccccccccccc
+)

--- a/tests/after/exprs.nim.nph.yaml
+++ b/tests/after/exprs.nim.nph.yaml
@@ -1806,3 +1806,42 @@ sons:
             strVal: "seven"
           - kind: "nkStrLit"
             strVal: "s7even"
+  - kind: "nkLetSection"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "xxxxxxxxx"
+          - kind: "nkEmpty"
+          - kind: "nkBlockStmt"
+            sons:
+              - kind: "nkEmpty"
+              - kind: "nkStmtList"
+                sons:
+                  - kind: "nkCall"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "f"
+                  - kind: "nkIdent"
+                    ident: "v"
+  - kind: "nkLetSection"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "yyyyyyyyyy"
+          - kind: "nkEmpty"
+          - kind: "nkCall"
+            sons:
+              - kind: "nkDotExpr"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "aaaaaaaaaaaaaaaaaaaaaaaaa"
+                  - kind: "nkIdent"
+                    ident: "ffffffffffffff"
+              - kind: "nkIdent"
+                ident: "aaaaaaaaa"
+              - kind: "nkIdent"
+                ident: "bbbbbbbbbbbbbbbbbb"
+              - kind: "nkIdent"
+                ident: "cccccccccccccccccccc"

--- a/tests/after/postexprs.nim
+++ b/tests/after/postexprs.nim
@@ -38,46 +38,40 @@ call.dotExpr:
 call.dotExpr:
   discard 14
 
-asgn =
-  command do():
-    discard 15
-asgn =
-  command:
-    discard 16
-asgn =
-  command:
-    discard 17
+asgn = command do():
+  discard 15
+asgn = command:
+  discard 16
+asgn = command:
+  discard 17
 
-asgn =
-  command do():
-    discard 18
-asgn =
-  command:
-    discard 19
-asgn =
-  command:
-    discard 20
+asgn = command do():
+  discard 18
+asgn = command:
+  discard 19
+asgn = command:
+  discard 20
 
 if false:
   return command do():
-      discard 21
+    discard 21
 
 if false:
   return command:
-      discard 22
+    discard 22
 
 if false:
   return command:
-      discard 23
+    discard 23
 
 discard command do():
-    discard 24
+  discard 24
 
 discard command:
-    discard 25
+  discard 25
 
 discard command:
-    discard 26
+  discard 26
 
 call(
   command do():

--- a/tests/after/procs.nim
+++ b/tests/after/procs.nim
@@ -35,11 +35,10 @@ proc a6(
   discard
 
 proc a7(
-    T:
-      typedesc[
-        Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa | Bbbbbbbbbbbbbbbbbbbbbbbbbbbbb |
-          Cccccccccccccccccccccccccc | Dddddddddddd
-      ],
+    T: typedesc[
+      Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa | Bbbbbbbbbbbbbbbbbbbbbbbbbbbbb |
+        Cccccccccccccccccccccccccc | Dddddddddddd
+    ],
     aaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbb, cccccccccccccccccccccc, ddddddddddddddddddddddd;
 ) =
   discard
@@ -129,27 +128,24 @@ type Bp = proc
 type Cp = proc(v: int)
 type Dp = proc() {.nimcall.}
 type Ep = proc {.nimcall.}
-type Fp =
-  proc(
-    aaaaaaaaaaaaaaaaa: int,
-    bbbbbbbbbbbbbbb =
-      proc() =
-        discard
-    ,
-    cccccccccccccccccc = 30,
-  )
+type Fp = proc(
+  aaaaaaaaaaaaaaaaa: int,
+  bbbbbbbbbbbbbbb = proc() =
+    discard
+  ,
+  cccccccccccccccccc = 30,
+)
 
 type Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = proc {.bbbbbbbbbbbbbbbbbbbbbbbb.}
 type Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa =
   proc(aaaaaaaa: Bbbbbbb, ccccccccc: Dddddddddddd, eeeeee: Ffffff)
 
-type Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa =
-  proc(
-    aaaaaaaa: Bbbbbbb,
-    ccccccccc: Dddddddddddd,
-    eeeeeeeeeeeee: Ffffffffffffffff,
-    gggggggggggggg: Hhhhhhhhhhhhhhhhhhhh,
-  )
+type Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = proc(
+  aaaaaaaa: Bbbbbbb,
+  ccccccccc: Dddddddddddd,
+  eeeeeeeeeeeee: Ffffffffffffffff,
+  gggggggggggggg: Hhhhhhhhhhhhhhhhhhhh,
+)
 
 proc `.()`() =
   discard

--- a/tests/before/comments.nim.nph.yaml
+++ b/tests/before/comments.nim.nph.yaml
@@ -680,10 +680,10 @@ sons:
       - kind: "nkStmtList"
         sons:
           - kind: "nkCall"
+            prefix:
+              - "# try first dedent line"
             sons:
               - kind: "nkIdent"
-                prefix:
-                  - "# try first dedent line"
                 ident: "f"
       - kind: "nkExceptBranch"
         prefix:
@@ -865,10 +865,10 @@ sons:
           - kind: "nkIdent"
             ident: "Object"
           - kind: "nkExprColonExpr"
+            prefix:
+              - "# object first line"
             sons:
               - kind: "nkIdent"
-                prefix:
-                  - "# object first line"
                 ident: "field"
               - kind: "nkIntLit"
                 intVal: 0

--- a/tests/before/exprs.nim
+++ b/tests/before/exprs.nim
@@ -106,3 +106,9 @@ discard -1.. -2
 aaaaaaa.bbbbbbbbb.longdotcall().ccccccccc.dddddddddd.eeeeeeeee.sdcsd(a0000000, b000000, c000000).fffffff.ggggggg.hhhhhhhh.csdcsdcs.sdcsdcsd.csdcsdcsdcsd.csdcsdcs.dcsdcsdcsdcs.sdc
 
 mynums = myNums.replace1("one", "o1ne").replace2("two", "t2wo").replace3("three", "t3hree").replace5("four", "f4our").replace5("five", "f5ive").replace6("six", "s6ix").replace7("seven", "s7even")
+
+let xxxxxxxxx = block:
+  f()
+  v
+
+let yyyyyyyyyy = aaaaaaaaaaaaaaaaaaaaaaaaa.ffffffffffffff(aaaaaaaaa, bbbbbbbbbbbbbbbbbb, cccccccccccccccccccc)

--- a/tests/before/exprs.nim.nph.yaml
+++ b/tests/before/exprs.nim.nph.yaml
@@ -1806,3 +1806,42 @@ sons:
             strVal: "seven"
           - kind: "nkStrLit"
             strVal: "s7even"
+  - kind: "nkLetSection"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "xxxxxxxxx"
+          - kind: "nkEmpty"
+          - kind: "nkBlockStmt"
+            sons:
+              - kind: "nkEmpty"
+              - kind: "nkStmtList"
+                sons:
+                  - kind: "nkCall"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "f"
+                  - kind: "nkIdent"
+                    ident: "v"
+  - kind: "nkLetSection"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "yyyyyyyyyy"
+          - kind: "nkEmpty"
+          - kind: "nkCall"
+            sons:
+              - kind: "nkDotExpr"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "aaaaaaaaaaaaaaaaaaaaaaaaa"
+                  - kind: "nkIdent"
+                    ident: "ffffffffffffff"
+              - kind: "nkIdent"
+                ident: "aaaaaaaaa"
+              - kind: "nkIdent"
+                ident: "bbbbbbbbbbbbbbbbbb"
+              - kind: "nkIdent"
+                ident: "cccccccccccccccccccc"


### PR DESCRIPTION
When rendering the right-hand expression of a keyword like `return` or an assignment, sometimes we would add a newline and indent.

This PR avoids such extra indent/newlines by allowing partial expressions such as function calls to continue on the same line like so:

```nim
let myvariable = functioncall(
  arg0, arg1, ...
)
```

This saves significant amounts of space as we avoid the extra indent that previously would apply to the arguments in this case.