### PR TITLE
Prefer infix operator at end of line

### DIFF
--- a/src/astcmp.nim
+++ b/src/astcmp.nim
@@ -52,9 +52,8 @@ proc parseString2(
   closeParser(p)
 
 proc similarKinds(ak, bk: TNodeKind): bool =
-  ak == bk or (ak in {nkElseExpr, nkElse} and bk in {nkElseExpr, nkElse}) or (
-    ak in {nkElifExpr, nkElifBranch} and bk in {nkElifExpr, nkElifBranch}
-  )
+  ak == bk or (ak in {nkElseExpr, nkElse} and bk in {nkElseExpr, nkElse}) or
+    (ak in {nkElifExpr, nkElifBranch} and bk in {nkElifExpr, nkElifBranch})
 
 proc equivalent*(a, b: PNode): Outcome =
   if not similarKinds(a.kind, b.kind):

--- a/src/phast.nim
+++ b/src/phast.nim
@@ -1122,8 +1122,8 @@ type
     # proc and type instantiations are cached in the generic symbol
     case kind*: TSymKind
     of routineKinds:
-    #procInstCache*: seq[PInstantiation]
-    #procInstCache*: seq[PInstantiation]
+      #procInstCache*: seq[PInstantiation]
+      #procInstCache*: seq[PInstantiation]
       gcUnsafetyReason*: PSym # for better error messages regarding gcsafe
       transformedBody*: PNode # cached body after transf pass
     of skLet, skVar, skField, skForVar:

--- a/src/phlexer.nim
+++ b/src/phlexer.nim
@@ -588,9 +588,8 @@ proc getNumber(L: var Lexer, result: var Token) =
     else:
       lexMessageLitNum(L, "invalid number suffix: '$1'", errPos)
   # Is there still a literalish char awaiting? Then it's an error!
-  if L.buf[postPos] in literalishChars or (
-    L.buf[postPos] == '.' and L.buf[postPos + 1] in {'0' .. '9'}
-  ):
+  if L.buf[postPos] in literalishChars or
+      (L.buf[postPos] == '.' and L.buf[postPos + 1] in {'0' .. '9'}):
     lexMessageLitNum(L, "invalid number: '$1'", startpos)
 
   if result.tokType != tkCustomLit:
@@ -1172,9 +1171,8 @@ proc getSymbol(L: var Lexer, tok: var Token) =
 
   h = !$h
   tok.ident = L.cache.getIdent(cast[cstring](addr(L.buf[L.bufpos])), pos - L.bufpos, h)
-  if (tok.ident.id < ord(tokKeywordLow) - ord(tkSymbol)) or (
-    tok.ident.id > ord(tokKeywordHigh) - ord(tkSymbol)
-  ):
+  if (tok.ident.id < ord(tokKeywordLow) - ord(tkSymbol)) or
+      (tok.ident.id > ord(tokKeywordHigh) - ord(tkSymbol)):
     tok.tokType = tkSymbol
   else:
     tok.tokType = TokType(tok.ident.id + ord(tkSymbol))
@@ -1604,9 +1602,8 @@ proc rawGetTok*(L: var Lexer, tok: var Token) =
             "invalid token: no whitespace between number and identifier"
           )
     of '-':
-      if L.buf[L.bufpos + 1] in {'0' .. '9'} and (
-        L.bufpos - 1 == 0 or L.buf[L.bufpos - 1] in UnaryMinusWhitelist
-      ):
+      if L.buf[L.bufpos + 1] in {'0' .. '9'} and
+          (L.bufpos - 1 == 0 or L.buf[L.bufpos - 1] in UnaryMinusWhitelist):
         # x)-23 # binary minus
         # ,-23  # unary minus
         # \n-78 # unary minus? Yes.

--- a/src/phlineinfos.nim
+++ b/src/phlineinfos.nim
@@ -294,14 +294,12 @@ type
 
 proc computeNotesVerbosity(): array[0 .. 3, TNoteKinds] =
   result[3] =
-    {low(TNoteKind) .. high(TNoteKind)} - {
-      warnObservableStores, warnResultUsed, warnAnyEnumConv, warnBareExcept
-    }
+    {low(TNoteKind) .. high(TNoteKind)} -
+    {warnObservableStores, warnResultUsed, warnAnyEnumConv, warnBareExcept}
 
   result[2] =
-    result[3] - {
-      hintStackTrace, hintExtendedContext, hintDeclaredLoc, hintProcessingStmt
-    }
+    result[3] -
+    {hintStackTrace, hintExtendedContext, hintDeclaredLoc, hintProcessingStmt}
 
   result[1] =
     result[2] - {

--- a/src/phmsgs.nim
+++ b/src/phmsgs.nim
@@ -483,7 +483,7 @@ proc quit(conf: ConfigRef, msg: TMsgKind) {.gcsafe.} =
           """
 No stack traceback available
 To create a stacktrace, rerun compilation with './koch temp $1 <file>', see $2 for details""" %
-          [conf.command, "intern.html#debugging-the-compiler".createDocLink],
+            [conf.command, "intern.html#debugging-the-compiler".createDocLink],
           conf.unitSep,
         )
 
@@ -498,9 +498,8 @@ proc handleError(
 
     quit(conf, msg)
 
-  if msg >= errMin and msg <= errMax or (
-    msg in warnMin .. hintMax and msg in conf.warningAsErrors and not ignoreMsg
-  ):
+  if msg >= errMin and msg <= errMax or
+      (msg in warnMin .. hintMax and msg in conf.warningAsErrors and not ignoreMsg):
     inc(conf.errorCounter)
 
     conf.exitcode = 1'i8

--- a/src/phoptions.nim
+++ b/src/phoptions.nim
@@ -771,9 +771,8 @@ proc isDefined*(conf: ConfigRef, symbol: string): bool =
       result = CPU[conf.target.targetCPU].bit == 64
     of "nimrawsetjmp":
       result =
-        conf.target.targetOS in {
-          osSolaris, osNetbsd, osFreebsd, osOpenbsd, osDragonfly, osMacosx
-        }
+        conf.target.targetOS in
+        {osSolaris, osNetbsd, osFreebsd, osOpenbsd, osDragonfly, osMacosx}
     else:
       discard
 

--- a/src/phparser.nim
+++ b/src/phparser.nim
@@ -2340,7 +2340,7 @@ proc parseObjectPart(p: var Parser): PNode =
   #| objectPart = IND{>} objectPart^+IND{=} DED
   #|            / objectWhen / objectCase / 'nil' / 'discard' / declColonEquals
   if realInd(p):
-    result = newNodeP(nkRecList, p)
+    result = newNodeP(nkRecList, p, withPrefix = false)
     withInd(p):
       while sameInd(p):
         case p.tok.tokType

--- a/tests/after/exprs.nim
+++ b/tests/after/exprs.nim
@@ -84,15 +84,13 @@ if aaaaaaaaaaaaaaaaaaaa and bbbbbbbbbbbbbbbbbbbbbbb and cccccccccccccccccccccccc
     ddddddddddddddddd and fffffffffffffffff:
   discard
 
-if (aaaaaaaaaaaaaaaa and bbbbbbbbbbbbbbbbbbbbbbbbbbbb) or (
-  ccccccccccccccccccccccccccc and ddddddddddddddddddddd
-):
+if (aaaaaaaaaaaaaaaa and bbbbbbbbbbbbbbbbbbbbbbbbbbbb) or
+    (ccccccccccccccccccccccccccc and ddddddddddddddddddddd):
   discard
 elif aaaaaaaaa and (
   bbbbbbbbbb or
-  cccccccccccc and (
-    dddddddddddddddd or eeeeeeeeeeeeeee or fffffffffffffff or gggggggggggggg
-  )
+  cccccccccccc and
+  (dddddddddddddddd or eeeeeeeeeeeeeee or fffffffffffffff or gggggggggggggg)
 ):
   discard
 
@@ -164,3 +162,11 @@ let xxxxxxxxx = block:
 let yyyyyyyyyy = aaaaaaaaaaaaaaaaaaaaaaaaa.ffffffffffffff(
   aaaaaaaaa, bbbbbbbbbbbbbbbbbb, cccccccccccccccccccc
 )
+
+discard
+  aaaaaaaaa and (
+    aaaaaaaaaaaaaaaaaaaaaaaa and (
+      aaaaaaaaaaaaaaaaaaaaa and bbbbbbbbbbbbbbbbbbbbbbb and
+      (cccccccccccccccccccccc and ddddddddddddddddddd)
+    )
+  )

--- a/tests/after/exprs.nim.nph.yaml
+++ b/tests/after/exprs.nim.nph.yaml
@@ -1845,3 +1845,43 @@ sons:
                 ident: "bbbbbbbbbbbbbbbbbb"
               - kind: "nkIdent"
                 ident: "cccccccccccccccccccc"
+  - kind: "nkDiscardStmt"
+    sons:
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: "and"
+          - kind: "nkIdent"
+            ident: "aaaaaaaaa"
+          - kind: "nkPar"
+            sons:
+              - kind: "nkInfix"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "and"
+                  - kind: "nkIdent"
+                    ident: "aaaaaaaaaaaaaaaaaaaaaaaa"
+                  - kind: "nkPar"
+                    sons:
+                      - kind: "nkInfix"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "and"
+                          - kind: "nkInfix"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: "and"
+                              - kind: "nkIdent"
+                                ident: "aaaaaaaaaaaaaaaaaaaaa"
+                              - kind: "nkIdent"
+                                ident: "bbbbbbbbbbbbbbbbbbbbbbb"
+                          - kind: "nkPar"
+                            sons:
+                              - kind: "nkInfix"
+                                sons:
+                                  - kind: "nkIdent"
+                                    ident: "and"
+                                  - kind: "nkIdent"
+                                    ident: "cccccccccccccccccccccc"
+                                  - kind: "nkIdent"
+                                    ident: "ddddddddddddddddddd"

--- a/tests/before/exprs.nim
+++ b/tests/before/exprs.nim
@@ -112,3 +112,5 @@ let xxxxxxxxx = block:
   v
 
 let yyyyyyyyyy = aaaaaaaaaaaaaaaaaaaaaaaaa.ffffffffffffff(aaaaaaaaa, bbbbbbbbbbbbbbbbbb, cccccccccccccccccccc)
+
+discard aaaaaaaaa and (aaaaaaaaaaaaaaaaaaaaaaaa and (aaaaaaaaaaaaaaaaaaaaa and bbbbbbbbbbbbbbbbbbbbbbb and (cccccccccccccccccccccc and ddddddddddddddddddd)))

--- a/tests/before/exprs.nim.nph.yaml
+++ b/tests/before/exprs.nim.nph.yaml
@@ -1845,3 +1845,43 @@ sons:
                 ident: "bbbbbbbbbbbbbbbbbb"
               - kind: "nkIdent"
                 ident: "cccccccccccccccccccc"
+  - kind: "nkDiscardStmt"
+    sons:
+      - kind: "nkInfix"
+        sons:
+          - kind: "nkIdent"
+            ident: "and"
+          - kind: "nkIdent"
+            ident: "aaaaaaaaa"
+          - kind: "nkPar"
+            sons:
+              - kind: "nkInfix"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "and"
+                  - kind: "nkIdent"
+                    ident: "aaaaaaaaaaaaaaaaaaaaaaaa"
+                  - kind: "nkPar"
+                    sons:
+                      - kind: "nkInfix"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "and"
+                          - kind: "nkInfix"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: "and"
+                              - kind: "nkIdent"
+                                ident: "aaaaaaaaaaaaaaaaaaaaa"
+                              - kind: "nkIdent"
+                                ident: "bbbbbbbbbbbbbbbbbbbbbbb"
+                          - kind: "nkPar"
+                            sons:
+                              - kind: "nkInfix"
+                                sons:
+                                  - kind: "nkIdent"
+                                    ident: "and"
+                                  - kind: "nkIdent"
+                                    ident: "cccccccccccccccccccccc"
+                                  - kind: "nkIdent"
+                                    ident: "ddddddddddddddddddd"


### PR DESCRIPTION
If the second argument of an infix doesn't fit on the current line but fits on a new line, prefer a newline before the argument over partially formatting it on the same line as the operator.

This gives a preference to having the operator alone on the end of the line and nicely lines up parenthesized expressions in general.