### PR TITLE
Allow function calls to partially fill RHS (fixes #52)

### DIFF
--- a/src/phast.nim
+++ b/src/phast.nim
@@ -672,9 +672,8 @@ type
   TSymKinds* = set[TSymKind]
 
 const
-  routineKinds* = {
-    skProc, skFunc, skMethod, skIterator, skConverter, skMacro, skTemplate
-  }
+  routineKinds* =
+    {skProc, skFunc, skMethod, skIterator, skConverter, skMacro, skTemplate}
   ExportableSymKinds* =
     {skVar, skLet, skConst, skType, skEnumField, skStub} + routineKinds
   tfUnion* = tfNoSideEffect
@@ -683,9 +682,8 @@ const
   tfReturnsNew* = tfInheritable
   skError* = skUnknown
 
-var eqTypeFlags* = {
-  tfIterator, tfNotNil, tfVarIsPtr, tfGcSafe, tfNoSideEffect, tfIsOutParam, tfSendable
-}
+var eqTypeFlags* =
+  {tfIterator, tfNotNil, tfVarIsPtr, tfGcSafe, tfNoSideEffect, tfIsOutParam, tfSendable}
   ## type flags that are essential for type equality.
   ## This is now a variable because for emulation of version:1.0 we
   ## might exclude {tfGcSafe, tfNoSideEffect}.
@@ -1353,9 +1351,8 @@ const
   resultPos* = 7
   dispatcherPos* = 8
   nfAllFieldsSet* = nfBase2
-  nkCallKinds* = {
-    nkCall, nkInfix, nkPrefix, nkPostfix, nkCommand, nkCallStrLit, nkHiddenCallConv
-  }
+  nkCallKinds* =
+    {nkCall, nkInfix, nkPrefix, nkPostfix, nkCommand, nkCallStrLit, nkHiddenCallConv}
   nkIdentKinds* = {nkIdent, nkSym, nkAccQuoted, nkOpenSymChoice, nkClosedSymChoice}
   nkPragmaCallKinds* = {nkExprColonExpr, nkCall, nkCallStrLit}
   nkLiterals* = {nkCharLit .. nkTripleStrLit}
@@ -1368,9 +1365,8 @@ const
   nkSymChoices* = {nkClosedSymChoice, nkOpenSymChoice}
   nkStrKinds* = {nkStrLit .. nkTripleStrLit}
   skLocalVars* = {skVar, skLet, skForVar, skParam, skResult}
-  skProcKinds* = {
-    skProc, skFunc, skTemplate, skMacro, skIterator, skMethod, skConverter
-  }
+  skProcKinds* =
+    {skProc, skFunc, skTemplate, skMacro, skIterator, skMethod, skConverter}
   defaultSize = -1
   defaultAlignment = -1
   defaultOffset* = -1
@@ -1849,9 +1845,8 @@ proc newProcNode*(
   result = newNodeI(kind, info)
   result.sons = @[name, pattern, genericParams, params, pragmas, exceptions, body]
 
-const AttachedOpToStr*: array[TTypeAttachedOp, string] = [
-  "=wasMoved", "=destroy", "=copy", "=dup", "=sink", "=trace", "=deepcopy"
-]
+const AttachedOpToStr*: array[TTypeAttachedOp, string] =
+  ["=wasMoved", "=destroy", "=copy", "=dup", "=sink", "=trace", "=deepcopy"]
 
 proc `$`*(s: PSym): string =
   if s != nil:
@@ -2444,9 +2439,8 @@ proc addParam*(procType: PType, param: PSym) =
 
   rawAddSon(procType, param.typ)
 
-const magicsThatCanRaise = {
-  mNone, mSlurp, mStaticExec, mParseExprToAst, mParseStmtToAst, mEcho
-}
+const magicsThatCanRaise =
+  {mNone, mSlurp, mStaticExec, mParseExprToAst, mParseStmtToAst, mEcho}
 
 proc canRaiseConservative*(fn: PNode): bool =
   if fn.kind == nkSym and fn.sym.magic notin magicsThatCanRaise:

--- a/src/phoptions.nim
+++ b/src/phoptions.nim
@@ -197,12 +197,10 @@ type
       # old unused: cmdInterpret, cmdDef: def feature (find definition for IDEs)
 
 const
-  cmdBackends* = {
-    cmdCompileToC, cmdCompileToCpp, cmdCompileToOC, cmdCompileToJS, cmdCrun
-  }
-  cmdDocLike* = {
-    cmdDoc0, cmdDoc, cmdDoc2tex, cmdJsondoc0, cmdJsondoc, cmdCtags, cmdBuildindex
-  }
+  cmdBackends* =
+    {cmdCompileToC, cmdCompileToCpp, cmdCompileToOC, cmdCompileToJS, cmdCrun}
+  cmdDocLike* =
+    {cmdDoc0, cmdDoc, cmdDoc2tex, cmdJsondoc0, cmdJsondoc, cmdCtags, cmdBuildindex}
 
 type
   NimVer* = tuple[major: int, minor: int, patch: int]
@@ -602,9 +600,8 @@ template newPackageCache*(): untyped =
 proc newProfileData(): ProfileData =
   ProfileData(data: newTable[TLineInfo, ProfileInfo]())
 
-const foreignPackageNotesDefault* = {
-  hintProcessing, warnUnknownMagic, hintQuitCalled, hintExecuting, hintUser, warnUser
-}
+const foreignPackageNotesDefault* =
+  {hintProcessing, warnUnknownMagic, hintQuitCalled, hintExecuting, hintUser, warnUser}
 
 proc isDefined*(conf: ConfigRef, symbol: string): bool
 

--- a/tests/after/exprs.nim
+++ b/tests/after/exprs.nim
@@ -145,8 +145,7 @@ aaaaaaa.bbbbbbbbb
 .longdotcall().ccccccccc.dddddddddd.eeeeeeeee
 .sdcsd(a0000000, b000000, c000000).fffffff.ggggggg.hhhhhhhh.csdcsdcs.sdcsdcsd.csdcsdcsdcsd.csdcsdcs.dcsdcsdcsdcs.sdc
 
-mynums =
-  myNums
+mynums = myNums
   .replace1("one", "o1ne")
   .replace2("two", "t2wo")
   .replace3("three", "t3hree")
@@ -170,3 +169,18 @@ discard
       (cccccccccccccccccccccc and ddddddddddddddddddd)
     )
   )
+
+# Dot expressions
+let test2 = someSimpleResult.fff(v).valueOr:
+  3
+
+let test2 = someSimpleResult(
+  aaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbb, ccccccccccccccccccccc, ddddddddddddd
+).valueOr:
+  3
+
+var aaaaaaaaaaaaaaaaaaaaaaaa =
+  bbbbbbbbbbbbbbbbbbbb.cccccccccccccccccccc[].ddddddddddddddddddddd
+
+aaaaaaaaaaaaaaaaaaaaaaaa =
+  bbbbbbbbbbbbbbbbbbbb.cccccccccccccccccccc[].ddddddddddddddddddddd

--- a/tests/after/exprs.nim.nph.yaml
+++ b/tests/after/exprs.nim.nph.yaml
@@ -1885,3 +1885,96 @@ sons:
                                     ident: "cccccccccccccccccccccc"
                                   - kind: "nkIdent"
                                     ident: "ddddddddddddddddddd"
+  - kind: "nkCommentStmt"
+    "comment": "# Dot expressions"
+  - kind: "nkLetSection"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "test2"
+          - kind: "nkEmpty"
+          - kind: "nkCall"
+            sons:
+              - kind: "nkDotExpr"
+                sons:
+                  - kind: "nkCall"
+                    sons:
+                      - kind: "nkDotExpr"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "someSimpleResult"
+                          - kind: "nkIdent"
+                            ident: "fff"
+                      - kind: "nkIdent"
+                        ident: "v"
+                  - kind: "nkIdent"
+                    ident: "valueOr"
+              - kind: "nkStmtList"
+                sons:
+                  - kind: "nkIntLit"
+                    intVal: 3
+  - kind: "nkLetSection"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "test2"
+          - kind: "nkEmpty"
+          - kind: "nkCall"
+            sons:
+              - kind: "nkDotExpr"
+                sons:
+                  - kind: "nkCall"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "someSimpleResult"
+                      - kind: "nkIdent"
+                        ident: "aaaaaaaaaaaaaaaaaaa"
+                      - kind: "nkIdent"
+                        ident: "bbbbbbbbbbbbb"
+                      - kind: "nkIdent"
+                        ident: "ccccccccccccccccccccc"
+                      - kind: "nkIdent"
+                        ident: "ddddddddddddd"
+                  - kind: "nkIdent"
+                    ident: "valueOr"
+              - kind: "nkStmtList"
+                sons:
+                  - kind: "nkIntLit"
+                    intVal: 3
+  - kind: "nkVarSection"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "aaaaaaaaaaaaaaaaaaaaaaaa"
+          - kind: "nkEmpty"
+          - kind: "nkDotExpr"
+            sons:
+              - kind: "nkBracketExpr"
+                sons:
+                  - kind: "nkDotExpr"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "bbbbbbbbbbbbbbbbbbbb"
+                      - kind: "nkIdent"
+                        ident: "cccccccccccccccccccc"
+              - kind: "nkIdent"
+                ident: "ddddddddddddddddddddd"
+  - kind: "nkAsgn"
+    sons:
+      - kind: "nkIdent"
+        ident: "aaaaaaaaaaaaaaaaaaaaaaaa"
+      - kind: "nkDotExpr"
+        sons:
+          - kind: "nkBracketExpr"
+            sons:
+              - kind: "nkDotExpr"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "bbbbbbbbbbbbbbbbbbbb"
+                  - kind: "nkIdent"
+                    ident: "cccccccccccccccccccc"
+          - kind: "nkIdent"
+            ident: "ddddddddddddddddddddd"

--- a/tests/after/postexprs.nim
+++ b/tests/after/postexprs.nim
@@ -92,10 +92,7 @@ of a:
 else:
   discard
 
-discard
-  (
-    aaa.bbb
-    .exec do(res: int64):
-      size = res
-  )
-  .ccc()
+discard (
+  aaa.bbb.exec do(res: int64):
+    size = res
+).ccc()

--- a/tests/before/exprs.nim
+++ b/tests/before/exprs.nim
@@ -114,3 +114,12 @@ let xxxxxxxxx = block:
 let yyyyyyyyyy = aaaaaaaaaaaaaaaaaaaaaaaaa.ffffffffffffff(aaaaaaaaa, bbbbbbbbbbbbbbbbbb, cccccccccccccccccccc)
 
 discard aaaaaaaaa and (aaaaaaaaaaaaaaaaaaaaaaaa and (aaaaaaaaaaaaaaaaaaaaa and bbbbbbbbbbbbbbbbbbbbbbb and (cccccccccccccccccccccc and ddddddddddddddddddd)))
+
+# Dot expressions
+let test2 = someSimpleResult.fff(v).valueOr: 3
+
+let test2 = someSimpleResult(aaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbb, ccccccccccccccccccccc, ddddddddddddd).valueOr: 3
+
+var aaaaaaaaaaaaaaaaaaaaaaaa = bbbbbbbbbbbbbbbbbbbb.cccccccccccccccccccc[].ddddddddddddddddddddd
+
+aaaaaaaaaaaaaaaaaaaaaaaa = bbbbbbbbbbbbbbbbbbbb.cccccccccccccccccccc[].ddddddddddddddddddddd

--- a/tests/before/exprs.nim.nph.yaml
+++ b/tests/before/exprs.nim.nph.yaml
@@ -1885,3 +1885,96 @@ sons:
                                     ident: "cccccccccccccccccccccc"
                                   - kind: "nkIdent"
                                     ident: "ddddddddddddddddddd"
+  - kind: "nkCommentStmt"
+    "comment": "# Dot expressions"
+  - kind: "nkLetSection"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "test2"
+          - kind: "nkEmpty"
+          - kind: "nkCall"
+            sons:
+              - kind: "nkDotExpr"
+                sons:
+                  - kind: "nkCall"
+                    sons:
+                      - kind: "nkDotExpr"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "someSimpleResult"
+                          - kind: "nkIdent"
+                            ident: "fff"
+                      - kind: "nkIdent"
+                        ident: "v"
+                  - kind: "nkIdent"
+                    ident: "valueOr"
+              - kind: "nkStmtList"
+                sons:
+                  - kind: "nkIntLit"
+                    intVal: 3
+  - kind: "nkLetSection"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "test2"
+          - kind: "nkEmpty"
+          - kind: "nkCall"
+            sons:
+              - kind: "nkDotExpr"
+                sons:
+                  - kind: "nkCall"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "someSimpleResult"
+                      - kind: "nkIdent"
+                        ident: "aaaaaaaaaaaaaaaaaaa"
+                      - kind: "nkIdent"
+                        ident: "bbbbbbbbbbbbb"
+                      - kind: "nkIdent"
+                        ident: "ccccccccccccccccccccc"
+                      - kind: "nkIdent"
+                        ident: "ddddddddddddd"
+                  - kind: "nkIdent"
+                    ident: "valueOr"
+              - kind: "nkStmtList"
+                sons:
+                  - kind: "nkIntLit"
+                    intVal: 3
+  - kind: "nkVarSection"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "aaaaaaaaaaaaaaaaaaaaaaaa"
+          - kind: "nkEmpty"
+          - kind: "nkDotExpr"
+            sons:
+              - kind: "nkBracketExpr"
+                sons:
+                  - kind: "nkDotExpr"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "bbbbbbbbbbbbbbbbbbbb"
+                      - kind: "nkIdent"
+                        ident: "cccccccccccccccccccc"
+              - kind: "nkIdent"
+                ident: "ddddddddddddddddddddd"
+  - kind: "nkAsgn"
+    sons:
+      - kind: "nkIdent"
+        ident: "aaaaaaaaaaaaaaaaaaaaaaaa"
+      - kind: "nkDotExpr"
+        sons:
+          - kind: "nkBracketExpr"
+            sons:
+              - kind: "nkDotExpr"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "bbbbbbbbbbbbbbbbbbbb"
+                  - kind: "nkIdent"
+                    ident: "cccccccccccccccccccc"
+          - kind: "nkIdent"
+            ident: "ddddddddddddddddddddd"


### PR DESCRIPTION
* post-expr-calls (`a.valueOr: ...`) don't count towards dot stacking
* prefer new line for lists etc if full line fits on RHS
* simple lhs of dot expressions can partially fill a line