### PR TITLE
avoid spurious single-line commas

### DIFF
--- a/format-git-repo.sh
+++ b/format-git-repo.sh
@@ -9,15 +9,14 @@ git ls-files | grep ".nim$" | xargs -n1 nph
 
 ! git diff --exit-code > /dev/null || { echo "This repository is already formatted" ; exit 0 ; }
 
-git commit -am "Formatted with nph $(nph --version)"
+git commit -am "Formatted with nph $(nph --version)" --author "nph <nph@example.com>"
 
 echo "# Formatted with nph $(nph --version)" >> .git-blame-ignore-revs
 echo "$(git rev-parse HEAD)" >> .git-blame-ignore-revs
 
 git add .git-blame-ignore-revs
-git commit -m "Add $(git rev-parse HEAD) to .git-blame-ignore-revs"
+git commit -m "Add $(git rev-parse HEAD) to .git-blame-ignore-revs" --author "nph <nph@example.com>"
 
 echo "The repo has been updated with two commits recording the reformatting and blame information."
 echo "You can review the changes with 'git diff HEAD^^' before pushing to a public repository."
 echo "If you don't want blame information, remove the last commit with 'git reset --hard HEAD^'."
-

--- a/nph.nimble
+++ b/nph.nimble
@@ -94,10 +94,10 @@ proc commitProject(
 
   try:
     exec "git checkout -b nph"
-    exec "git commit -am \"Formatted with nph $(nph --version)\""
+    exec "git commit -am \"Formatted with nph $(nph --version)\" --author \"nph <nph@example.com>\""
   except:
     exec "git checkout nph"
-    exec "git commit -am \"Formatted with nph $(nph --version)\" --amend"
+    exec "git commit -am \"Formatted with nph $(nph --version)\" --amend --author \"nph <nph@example.com>\""
 
   cd "../.."
 

--- a/src/phmsgs.nim
+++ b/src/phmsgs.nim
@@ -139,8 +139,7 @@ proc fileInfoIdx*(
         if pseudoPath:
           RelativeFile filename
         else:
-          relativeTo(canon, conf.projectPath)
-        ,
+          relativeTo(canon, conf.projectPath),
       )
     )
 

--- a/src/phrenderer.nim
+++ b/src/phrenderer.nim
@@ -527,8 +527,7 @@ proc init(T: type TSrcLen, g: TSrcGen): T =
       if g.tokens.len > 0:
         @[g.tokens[^1]]
       else:
-        @[]
-    ,
+        @[],
     config: g.config,
   )
 
@@ -1130,8 +1129,7 @@ proc gtry(g: var TOutput, n: PNode) =
       if trivial:
         {sfOneLine}
       else:
-        {}
-    ,
+        {},
   )
 
 proc gfor(g: var TOutput, n: PNode) =
@@ -2219,8 +2217,7 @@ proc renderTree*(n: PNode, conf: ConfigRef = nil): string =
     if conf == nil:
       newPartialConfigRef()
     else:
-      conf
-    ,
+      conf,
   )
   # do not indent the initial statement list so that
   # writeFile("file.nim", repr n)

--- a/src/phrenderer.nim
+++ b/src/phrenderer.nim
@@ -836,7 +836,8 @@ proc gsonsNL(
 ) =
   for i in start .. n.len + theEnd:
     gsub(g, n[i], flags)
-    g.optNL()
+    if i != n.len + theEnd:
+      g.optNL()
 
 proc glist(
     g: var TOutput,
@@ -977,10 +978,6 @@ proc gstmts(g: var TOutput, n: PNode, flags: SubFlags = {}, doIndent = true) =
 
   dedent(g, ind)
 
-  if not trivial:
-    optNL(g)
-  # if not trivial:
-  #   optNL(g)
   if needsPar:
     if not trivial:
       optNL(g)
@@ -1095,7 +1092,7 @@ proc gif(g: var TOutput, n: PNode, flags: SubFlags) =
     if oneline:
       # We end up here when rendering things that were parsed as expressions but
       # don't match the "trivial" rule above
-      # TODO treat such constructs as trivail for better determinism?
+      # TODO treat such constructs as trivial for better determinism?
       gsons(g, n, 1)
     else:
       optNL(g)

--- a/tests/after/comments.nim
+++ b/tests/after/comments.nim
@@ -330,8 +330,7 @@ discard
   54 # discard value
 
 proc x() =
-  discard
-  # proc, impl and comment on one line
+  discard # proc, impl and comment on one line
 
 proc xxx() = # after proc before indented name
   discard

--- a/tests/after/comments.nim.nph.yaml
+++ b/tests/after/comments.nim.nph.yaml
@@ -1205,8 +1205,8 @@ sons:
           - kind: "nkDiscardStmt"
             sons:
               - kind: "nkEmpty"
-          - kind: "nkCommentStmt"
-            "comment": "# proc, impl and comment on one line"
+            postfix:
+              - "# proc, impl and comment on one line"
   - kind: "nkProcDef"
     mid:
       - "# after proc before indented name"

--- a/tests/after/postexprs.nim
+++ b/tests/after/postexprs.nim
@@ -94,5 +94,4 @@ else:
 
 discard (
   aaa.bbb.exec do(res: int64):
-    size = res
-).ccc()
+    size = res).ccc()

--- a/tests/after/procs.nim
+++ b/tests/after/procs.nim
@@ -131,8 +131,7 @@ type Ep = proc {.nimcall.}
 type Fp = proc(
   aaaaaaaaaaaaaaaaa: int,
   bbbbbbbbbbbbbbb = proc() =
-    discard
-  ,
+    discard,
   cccccccccccccccccc = 30,
 )
 

--- a/tests/after/style.nim
+++ b/tests/after/style.nim
@@ -39,8 +39,7 @@ functionCall(10000000, 2000000000, 3000000000, 40000000, 5000000000)
 proc f(
   myParameter = 0,
   callback: SomeCallback = proc() =
-    discard
-  ,
+    discard,
   nextParameter = 1,
 )
 


### PR DESCRIPTION
Somewhat defensively, nph was putting a comma on a new line after certain complex constructs, in particular when using a complex expression in a parameter list - it turns out that this comma can stay on the same line most of the time, as long as an `nkCommand` is not involved