### PR TITLE
fix comment after if/while/case (fixes #71)

### DIFF
--- a/src/phparser.nim
+++ b/src/phparser.nim
@@ -482,6 +482,7 @@ proc exprEqExpr(p: var Parser): PNode =
 proc exprList(p: var Parser, endTok: TokType, result: PNode) =
   #| exprList = expr ^+ comma
   getTok(p)
+  splitLookahead(p, result, clMid)
   optInd(p, result)
   # progress guaranteed
   var a = parseExpr(p)
@@ -498,6 +499,7 @@ proc exprList(p: var Parser, endTok: TokType, result: PNode) =
 proc optionalExprList(p: var Parser, endTok: TokType, result: PNode) =
   #| optionalExprList = expr ^* comma
   getTok(p)
+  splitLookahead(p, result, clMid)
   optInd(p, result)
   # progress guaranteed
   while (p.tok.tokType != endTok) and (p.tok.tokType != tkEof):
@@ -1894,9 +1896,10 @@ proc parseIfOrWhen(p: var Parser, kind: TNodeKind): PNode =
   #| ifStmt = 'if' condStmt
   #| whenStmt = 'when' condStmt
   result = newNodeP(kind, p)
+
   while true:
-    getTok(p) # skip `if`, `when`, `elif`
     var branch = newNodeP(nkElifBranch, p)
+    getTok(p) # skip `if`, `when`, `elif`
     splitLookahead(p, branch, clMid)
     optInd(p, branch)
     branch.add(parseExpr(p))
@@ -1920,8 +1923,8 @@ proc parseIfOrWhenExpr(p: var Parser, kind: TNodeKind): PNode =
   #| whenExpr = 'when' condExpr
   result = newNodeP(kind, p)
   while true:
-    getTok(p) # skip `if`, `when`, `elif`
     var branch = newNodeP(nkElifExpr, p)
+    getTok(p) # skip `if`, `when`, `elif`
     splitLookahead(p, branch, clMid)
     optInd(p, branch)
     branch.add(parseExpr(p))
@@ -1983,11 +1986,13 @@ proc parseCase(p: var Parser): PNode =
       inElif = true
       b = newNodeP(nkElifBranch, p)
       getTok(p)
+      splitLookahead(p, b, clMid)
       optInd(p, b)
       b.add(parseExpr(p))
     of tkElse:
       b = newNodeP(nkElse, p)
       getTok(p)
+      splitLookahead(p, b, clMid)
     else:
       break
     b.add(parseColComStmt(p, b, clMid))

--- a/tests/after/comments.nim
+++ b/tests/after/comments.nim
@@ -473,3 +473,29 @@ block:
   block:
     discard
   # dedented comment post discard
+
+block:
+  if 2 >= 1 and 2 >= 1 and 2 >= 1: # some conditions:
+    discard
+  elif 2 >= 1 and 2 >= 1 and 2 >= 1: # some elif conds
+    discard
+
+  if 2 >= 1 and 2 >= 1 and 2 >= 1:
+    # some conditions with a very long comment that wont fit on a line abacacsdcasdcasdsdcsdcsdc
+    discard
+
+  if 2 >= 1 and
+      # some conditions
+      2 >= 1 and 2 >= 1:
+    discard
+
+  while 2 >= 1 and 2 >= 1 and 2 >= 1: # some conditions:
+    discard
+
+  case
+  # comment
+  true
+  of true: # comment
+    discard
+  else: #comment
+    discard

--- a/tests/after/comments.nim.nph.yaml
+++ b/tests/after/comments.nim.nph.yaml
@@ -1796,3 +1796,245 @@ sons:
                       - kind: "nkEmpty"
           - kind: "nkCommentStmt"
             "comment": "# dedented comment post discard"
+  - kind: "nkBlockStmt"
+    sons:
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkIfStmt"
+            sons:
+              - kind: "nkElifBranch"
+                mid:
+                  - "# some conditions:"
+                sons:
+                  - kind: "nkInfix"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "and"
+                      - kind: "nkInfix"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "and"
+                          - kind: "nkInfix"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: ">="
+                              - kind: "nkIntLit"
+                                intVal: 2
+                              - kind: "nkIntLit"
+                                intVal: 1
+                          - kind: "nkInfix"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: ">="
+                              - kind: "nkIntLit"
+                                intVal: 2
+                              - kind: "nkIntLit"
+                                intVal: 1
+                      - kind: "nkInfix"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: ">="
+                          - kind: "nkIntLit"
+                            intVal: 2
+                          - kind: "nkIntLit"
+                            intVal: 1
+                  - kind: "nkStmtList"
+                    sons:
+                      - kind: "nkDiscardStmt"
+                        sons:
+                          - kind: "nkEmpty"
+              - kind: "nkElifBranch"
+                mid:
+                  - "# some elif conds"
+                sons:
+                  - kind: "nkInfix"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "and"
+                      - kind: "nkInfix"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "and"
+                          - kind: "nkInfix"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: ">="
+                              - kind: "nkIntLit"
+                                intVal: 2
+                              - kind: "nkIntLit"
+                                intVal: 1
+                          - kind: "nkInfix"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: ">="
+                              - kind: "nkIntLit"
+                                intVal: 2
+                              - kind: "nkIntLit"
+                                intVal: 1
+                      - kind: "nkInfix"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: ">="
+                          - kind: "nkIntLit"
+                            intVal: 2
+                          - kind: "nkIntLit"
+                            intVal: 1
+                  - kind: "nkStmtList"
+                    sons:
+                      - kind: "nkDiscardStmt"
+                        sons:
+                          - kind: "nkEmpty"
+          - kind: "nkIfStmt"
+            sons:
+              - kind: "nkElifBranch"
+                sons:
+                  - kind: "nkInfix"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "and"
+                      - kind: "nkInfix"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "and"
+                          - kind: "nkInfix"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: ">="
+                              - kind: "nkIntLit"
+                                intVal: 2
+                              - kind: "nkIntLit"
+                                intVal: 1
+                          - kind: "nkInfix"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: ">="
+                              - kind: "nkIntLit"
+                                intVal: 2
+                              - kind: "nkIntLit"
+                                intVal: 1
+                      - kind: "nkInfix"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: ">="
+                          - kind: "nkIntLit"
+                            intVal: 2
+                          - kind: "nkIntLit"
+                            intVal: 1
+                  - kind: "nkStmtList"
+                    sons:
+                      - kind: "nkCommentStmt"
+                        "comment": "# some conditions with a very long comment that wont fit on a line abacacsdcasdcasdsdcsdcsdc"
+                      - kind: "nkDiscardStmt"
+                        sons:
+                          - kind: "nkEmpty"
+          - kind: "nkIfStmt"
+            sons:
+              - kind: "nkElifBranch"
+                sons:
+                  - kind: "nkInfix"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "and"
+                      - kind: "nkInfix"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "and"
+                          - kind: "nkInfix"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: ">="
+                              - kind: "nkIntLit"
+                                intVal: 2
+                              - kind: "nkIntLit"
+                                intVal: 1
+                          - kind: "nkInfix"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: ">="
+                              - kind: "nkIntLit"
+                                prefix:
+                                  - "# some conditions"
+                                intVal: 2
+                              - kind: "nkIntLit"
+                                intVal: 1
+                      - kind: "nkInfix"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: ">="
+                          - kind: "nkIntLit"
+                            intVal: 2
+                          - kind: "nkIntLit"
+                            intVal: 1
+                  - kind: "nkStmtList"
+                    sons:
+                      - kind: "nkDiscardStmt"
+                        sons:
+                          - kind: "nkEmpty"
+          - kind: "nkWhileStmt"
+            mid:
+              - "# some conditions:"
+            sons:
+              - kind: "nkInfix"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "and"
+                  - kind: "nkInfix"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "and"
+                      - kind: "nkInfix"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: ">="
+                          - kind: "nkIntLit"
+                            intVal: 2
+                          - kind: "nkIntLit"
+                            intVal: 1
+                      - kind: "nkInfix"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: ">="
+                          - kind: "nkIntLit"
+                            intVal: 2
+                          - kind: "nkIntLit"
+                            intVal: 1
+                  - kind: "nkInfix"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: ">="
+                      - kind: "nkIntLit"
+                        intVal: 2
+                      - kind: "nkIntLit"
+                        intVal: 1
+              - kind: "nkStmtList"
+                sons:
+                  - kind: "nkDiscardStmt"
+                    sons:
+                      - kind: "nkEmpty"
+          - kind: "nkCaseStmt"
+            sons:
+              - kind: "nkIdent"
+                prefix:
+                  - "# comment"
+                ident: "true"
+              - kind: "nkOfBranch"
+                mid:
+                  - "# comment"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "true"
+                  - kind: "nkStmtList"
+                    sons:
+                      - kind: "nkDiscardStmt"
+                        sons:
+                          - kind: "nkEmpty"
+              - kind: "nkElse"
+                mid:
+                  - "#comment"
+                sons:
+                  - kind: "nkStmtList"
+                    sons:
+                      - kind: "nkDiscardStmt"
+                        sons:
+                          - kind: "nkEmpty"

--- a/tests/before/comments.nim
+++ b/tests/before/comments.nim
@@ -454,3 +454,42 @@ block:
   block:
     discard
   # dedented comment post discard
+
+block:
+  if  # some conditions:
+    2 >= 1 and
+    2 >= 1 and
+    2 >= 1:
+    discard
+  elif # some elif conds
+    2 >= 1 and
+    2 >= 1 and
+    2 >= 1:
+    discard
+
+  if  # some conditions with a very long comment that wont fit on a line abacacsdcasdcasdsdcsdcsdc
+    2 >= 1 and
+    2 >= 1 and
+    2 >= 1:
+    discard
+
+  if
+    2 >= 1 and
+    # some conditions
+    2 >= 1 and
+    2 >= 1:
+    discard
+
+  while  # some conditions:
+    2 >= 1 and
+    2 >= 1 and
+    2 >= 1:
+    discard
+
+  case # comment
+  true
+  of # comment
+    true:
+      discard
+  else #comment
+    : discard

--- a/tests/before/comments.nim.nph.yaml
+++ b/tests/before/comments.nim.nph.yaml
@@ -1792,3 +1792,245 @@ sons:
                       - kind: "nkEmpty"
           - kind: "nkCommentStmt"
             "comment": "# dedented comment post discard"
+  - kind: "nkBlockStmt"
+    sons:
+      - kind: "nkEmpty"
+      - kind: "nkStmtList"
+        sons:
+          - kind: "nkIfStmt"
+            sons:
+              - kind: "nkElifBranch"
+                mid:
+                  - "# some conditions:"
+                sons:
+                  - kind: "nkInfix"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "and"
+                      - kind: "nkInfix"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "and"
+                          - kind: "nkInfix"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: ">="
+                              - kind: "nkIntLit"
+                                intVal: 2
+                              - kind: "nkIntLit"
+                                intVal: 1
+                          - kind: "nkInfix"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: ">="
+                              - kind: "nkIntLit"
+                                intVal: 2
+                              - kind: "nkIntLit"
+                                intVal: 1
+                      - kind: "nkInfix"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: ">="
+                          - kind: "nkIntLit"
+                            intVal: 2
+                          - kind: "nkIntLit"
+                            intVal: 1
+                  - kind: "nkStmtList"
+                    sons:
+                      - kind: "nkDiscardStmt"
+                        sons:
+                          - kind: "nkEmpty"
+              - kind: "nkElifBranch"
+                mid:
+                  - "# some elif conds"
+                sons:
+                  - kind: "nkInfix"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "and"
+                      - kind: "nkInfix"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "and"
+                          - kind: "nkInfix"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: ">="
+                              - kind: "nkIntLit"
+                                intVal: 2
+                              - kind: "nkIntLit"
+                                intVal: 1
+                          - kind: "nkInfix"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: ">="
+                              - kind: "nkIntLit"
+                                intVal: 2
+                              - kind: "nkIntLit"
+                                intVal: 1
+                      - kind: "nkInfix"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: ">="
+                          - kind: "nkIntLit"
+                            intVal: 2
+                          - kind: "nkIntLit"
+                            intVal: 1
+                  - kind: "nkStmtList"
+                    sons:
+                      - kind: "nkDiscardStmt"
+                        sons:
+                          - kind: "nkEmpty"
+          - kind: "nkIfStmt"
+            sons:
+              - kind: "nkElifBranch"
+                mid:
+                  - "# some conditions with a very long comment that wont fit on a line abacacsdcasdcasdsdcsdcsdc"
+                sons:
+                  - kind: "nkInfix"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "and"
+                      - kind: "nkInfix"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "and"
+                          - kind: "nkInfix"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: ">="
+                              - kind: "nkIntLit"
+                                intVal: 2
+                              - kind: "nkIntLit"
+                                intVal: 1
+                          - kind: "nkInfix"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: ">="
+                              - kind: "nkIntLit"
+                                intVal: 2
+                              - kind: "nkIntLit"
+                                intVal: 1
+                      - kind: "nkInfix"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: ">="
+                          - kind: "nkIntLit"
+                            intVal: 2
+                          - kind: "nkIntLit"
+                            intVal: 1
+                  - kind: "nkStmtList"
+                    sons:
+                      - kind: "nkDiscardStmt"
+                        sons:
+                          - kind: "nkEmpty"
+          - kind: "nkIfStmt"
+            sons:
+              - kind: "nkElifBranch"
+                sons:
+                  - kind: "nkInfix"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "and"
+                      - kind: "nkInfix"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "and"
+                          - kind: "nkInfix"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: ">="
+                              - kind: "nkIntLit"
+                                intVal: 2
+                              - kind: "nkIntLit"
+                                intVal: 1
+                          - kind: "nkInfix"
+                            sons:
+                              - kind: "nkIdent"
+                                ident: ">="
+                              - kind: "nkIntLit"
+                                prefix:
+                                  - "# some conditions"
+                                intVal: 2
+                              - kind: "nkIntLit"
+                                intVal: 1
+                      - kind: "nkInfix"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: ">="
+                          - kind: "nkIntLit"
+                            intVal: 2
+                          - kind: "nkIntLit"
+                            intVal: 1
+                  - kind: "nkStmtList"
+                    sons:
+                      - kind: "nkDiscardStmt"
+                        sons:
+                          - kind: "nkEmpty"
+          - kind: "nkWhileStmt"
+            mid:
+              - "# some conditions:"
+            sons:
+              - kind: "nkInfix"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "and"
+                  - kind: "nkInfix"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "and"
+                      - kind: "nkInfix"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: ">="
+                          - kind: "nkIntLit"
+                            intVal: 2
+                          - kind: "nkIntLit"
+                            intVal: 1
+                      - kind: "nkInfix"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: ">="
+                          - kind: "nkIntLit"
+                            intVal: 2
+                          - kind: "nkIntLit"
+                            intVal: 1
+                  - kind: "nkInfix"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: ">="
+                      - kind: "nkIntLit"
+                        intVal: 2
+                      - kind: "nkIntLit"
+                        intVal: 1
+              - kind: "nkStmtList"
+                sons:
+                  - kind: "nkDiscardStmt"
+                    sons:
+                      - kind: "nkEmpty"
+          - kind: "nkCaseStmt"
+            sons:
+              - kind: "nkIdent"
+                prefix:
+                  - "# comment"
+                ident: "true"
+              - kind: "nkOfBranch"
+                mid:
+                  - "# comment"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "true"
+                  - kind: "nkStmtList"
+                    sons:
+                      - kind: "nkDiscardStmt"
+                        sons:
+                          - kind: "nkEmpty"
+              - kind: "nkElse"
+                mid:
+                  - "#comment"
+                sons:
+                  - kind: "nkStmtList"
+                    sons:
+                      - kind: "nkDiscardStmt"
+                        sons:
+                          - kind: "nkEmpty"


### PR DESCRIPTION
When a comment appears after keywords with conditionals, it's an open question how to format them: they could stay there but this causes trouble with indent of long/non-trivial conditions - instead of coming up with a clever solution, this PR simply moves the comment out of there.