### PR TITLE
add "prefer semicolons" option

### DIFF
--- a/src/astcmp.nim
+++ b/src/astcmp.nim
@@ -91,7 +91,7 @@ proc equivalent*(a, b: PNode): Outcome =
       return equivalent(a.sons[1], b.sons[0])
 
     return Outcome(kind: Different, a: a, b: b)
-  
+
   if a.kind == nkGenericParams and a.len != b.len:
     var
       ac = 0
@@ -110,12 +110,13 @@ proc equivalent*(a, b: PNode): Outcome =
           return Outcome(kind: Different, a: a, b: b)
         inc amc
         inc bmc
-        if equivalent(a[ac][^1], b[bc][^1]).kind == Different or equivalent(a[ac][^2], b[bc][^2]).kind == Different:
+        if equivalent(a[ac][^1], b[bc][^1]).kind == Different or
+            equivalent(a[ac][^2], b[bc][^2]).kind == Different:
           return Outcome(kind: Different, a: a, b: b)
       inc ac
       amc = 0
     return Outcome(kind: Same)
-  
+
   let eq =
     case a.kind
     of nkCharLit .. nkUInt64Lit:

--- a/src/nim.cfg
+++ b/src/nim.cfg
@@ -1,1 +1,3 @@
 -d:nph
+warningAsError[Uninit]:off
+warningAsError[ProveInit]:off

--- a/src/nph.nim
+++ b/src/nph.nim
@@ -15,8 +15,8 @@ import std/[parseopt, strutils, os, sequtils]
 when defined(nimPreviewSlimSystem):
   import std/[assertions, syncio]
 
-#static:
-#  doAssert NimMajor == 2 and NimMinor == 0, "nph needs a specific version of Nim"
+static:
+  doAssert NimMajor == 2 and NimMinor == 0, "nph needs a specific version of Nim"
 
 const
   Version = gorge("git describe --long --dirty --always --tags")


### PR DESCRIPTION
This just uses `;` more aggressively in generic param's and proc formals. Behind a switch since it isn't going to be everyone's preference. Also I forgot to uncomment some lines so I'll push again in a sec. The nim.cfg defaults can be removed if you want, but they help for compatibility with projects that have them on.