### PR TITLE
Adapt nph to Nim 2.2.x and recent nimbus-build-system

### DIFF
--- a/src/astyaml.nim
+++ b/src/astyaml.nim
@@ -104,7 +104,7 @@ proc symToYamlAux(
     res.addf("\n$1storage: $2", [istr, makeYamlString($n.loc.storage)])
     if card(n.loc.flags) > 0:
       res.addf("\n$1flags: $2", [istr, makeYamlString($n.loc.flags)])
-    res.addf("\n$1r: $2", [istr, n.loc.r])
+    res.addf("\n$1snippet: $2", [istr, n.loc.snippet])
     res.addf("\n$1lode:\n$1    ", [istr])
     res.treeToYamlAux(conf, n.loc.lode, marker, indent + 1, maxRecDepth - 1)
 
@@ -134,9 +134,9 @@ proc typeToYamlAux(
     res.addf("\n$1align: $2", [istr, $(n.align)])
     if n.len > 0:
       res.addf("\n$1sons:")
-      for s in n.sons:
+      for i in 0 ..< n.len:
         res.addf("\n$1  - ", [istr])
-        res.typeToYamlAux(conf, s, marker, indent + 1, maxRecDepth - 1)
+        res.typeToYamlAux(conf, n[i], marker, indent + 1, maxRecDepth - 1)
 
 proc treeToYamlAux(
     res: var string,

--- a/src/nph.nim
+++ b/src/nph.nim
@@ -13,7 +13,7 @@ import "$nim"/compiler/idents
 import std/[parseopt, strutils, os, sequtils]
 
 static:
-  doAssert NimMajor == 2 and NimMinor == 0, "nph needs a specific version of Nim"
+  doAssert NimMajor == 2 and NimMinor == 2, "nph needs a specific version of Nim"
 
 const
   Version = gorge("git describe --long --dirty --always --tags")


### PR DESCRIPTION
## Description

When bumping vendor dependencies in [nwaku](https://github.com/waku-org/nwaku), we've noticed that the `nph` stopped building.

This nwaku bump process aims to use the following `nimbus-build-system` commit: https://github.com/status-im/nimbus-build-system/commit/0be0663e1af76e869837226a4ef3e586fcc737d3

## More context

nwaku PR to upgrade vendor dependencies: https://github.com/waku-org/nwaku/pull/3410