### PR TITLE
feat: add --diff and --color flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,28 +10,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target:
-          - os: linux
-            name: linux_x64
-          - os: macosx
-            name: macosx_x64
-          - os: windows
-            name: windows_x64
         include:
-          - target:
-              os: linux
-            builder: ubuntu-22.04
-          - target:
-              os: macosx
-            builder: macos-13
-          - target:
-              os: windows
-            builder: windows-2019
+          - name: linux_x64
+            builder: ubuntu-latest
+          - name: macosx_x64
+            builder: macos-latest
+          - name: windows_x64
+            builder: windows-latest
     defaults:
       run:
         shell: bash
 
-    name: CI '${{ matrix.target.name }}'
+    name: CI '${{ matrix.name }}'
     runs-on: ${{ matrix.builder }}
     steps:
       - name: Set git to use LF
@@ -41,9 +31,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Download and setup Nim DLLs (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          curl -L -o dlls.zip https://nim-lang.org/download/dlls.zip
+          unzip dlls.zip -d nim-dlls
+          echo "$GITHUB_WORKSPACE/nim-dlls" >> $GITHUB_PATH
+          echo "SSL_CERT_FILE=$GITHUB_WORKSPACE/nim-dlls/cacert.pem" >> $GITHUB_ENV
+
       - uses: nim-lang/setup-nimble-action@v1
         with:
-          nimble-version: '0.16.4'
+          nimble-version: '0.20.1'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build nph

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+# Unreleased
+
+New features:
+
+* `--diff` flag to show unified diff of formatting changes without modifying
+  files
+* `--color` / `--no-color` flags for colored diff output (requires `--diff`)
+* `.nph.toml` config file support for project-level configuration
+* `--exclude` flag to replace default exclusion patterns
+* `--extend-exclude` flag to add patterns to default exclusions
+* `--include` flag to customize which files to format
+* `--config` flag to specify a custom config file
+* Default exclusion patterns for common directories (build, dist, .git,
+  nimcache, etc.)
+* Files passed explicitly on CLI bypass all exclude filters (matching Black's
+  behavior)
+* CLI options override config file settings
+* pre-commit integration support with `nph` hook
+
 # 0.6.1
 
 No formatting changes!

--- a/README.md
+++ b/README.md
@@ -32,9 +32,6 @@ nph --check somefile.nim || echo "Not formatted!"
 # Show a diff of what would change without modifying files
 nph --diff somefile.nim
 
-# Show a colored diff (requires --diff)
-nph --diff --color somefile.nim
-
 # You can format stuff as part of a pipe using `-` as input:
 echo "echo 1" | nph -
 ```
@@ -93,5 +90,3 @@ Editor integrations are described [in the manual](https://arnetheduck.github.io/
 ## Continuous integration
 
 Check out the [companion Github Action](https://github.com/arnetheduck/nph-action) for a convenient CI option!
-
-

--- a/README.md
+++ b/README.md
@@ -29,11 +29,45 @@ nph src/
 # Use --check to verify that a file is formatted as `nph` would - useful in CI
 nph --check somefile.nim || echo "Not formatted!"
 
+# Show a diff of what would change without modifying files
+nph --diff somefile.nim
+
+# Show a colored diff (requires --diff)
+nph --diff --color somefile.nim
+
 # You can format stuff as part of a pipe using `-` as input:
 echo "echo 1" | nph -
 ```
 
-More information about features and style available from the [documentation](https://arnetheduck.github.io/nph/)
+## Configuration
+
+You can configure `nph` using a `.nph.toml` file in your project root:
+
+```toml
+# Completely replace default exclusions
+exclude = [
+  "build",
+  "dist",
+]
+
+# Add to default exclusions (more common)
+extend-exclude = [
+  "tests/fixtures",
+  "vendor",
+]
+
+# Customize which files to include (default: \.nim(s|ble)?$)
+include = [
+  "\.nim$",
+  "\.nims$",
+]
+```
+
+CLI options override config file settings. See the
+[documentation](https://arnetheduck.github.io/nph/usage.html) for more details.
+
+More information about features and style available from the
+[documentation](https://arnetheduck.github.io/nph/)
 
 ## Installation
 

--- a/config.nims
+++ b/config.nims
@@ -3,4 +3,4 @@ when withDir(thisDir(), system.fileExists("nimble.paths")):
   include "nimble.paths"
 # end Nimble config
 
-  --stylecheck:error
+--stylecheck:error

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -16,9 +16,6 @@ nph --check somefile.nim || echo "Not formatted!"
 # Show a diff of what would change without modifying files
 nph --diff somefile.nim
 
-# Show a colored diff (requires --diff)
-nph --diff --color somefile.nim
-
 # You can format stuff as part of a pipe using `-` as input:
 echo "echo 1" | nph -
 ```

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -13,8 +13,150 @@ nph src/
 # Use --check to verify that a file is formatted correctly as `nph` would - useful in CI
 nph --check somefile.nim || echo "Not formatted!"
 
+# Show a diff of what would change without modifying files
+nph --diff somefile.nim
+
+# Show a colored diff (requires --diff)
+nph --diff --color somefile.nim
+
 # You can format stuff as part of a pipe using `-` as input:
 echo "echo 1" | nph -
+```
+
+## Configuration file
+
+You can configure `nph` using a `.nph.toml` file in your project root. CLI
+options override config file settings.
+
+```toml
+# Completely replace default exclusions with your own patterns
+exclude = [
+  "build",
+  "dist",
+]
+
+# Add to default exclusions (recommended - doesn't lose the defaults)
+extend-exclude = [
+  "tests/fixtures",
+  "vendor",
+]
+
+# Customize which files to include (default: \.nim(s|ble)?$)
+include = [
+  "\.nim$",
+  "\.nims$",
+]
+```
+
+### Default exclusions
+
+By default, `nph` excludes common directories that typically don't contain
+source code:
+
+- `.git`, `.hg`, `.svn` - version control
+- `.nimble`, `nimcache` - Nim build artifacts
+- `.vscode`, `.idea` - editor directories
+- `__pycache__`, `.mypy_cache`, `.pytest_cache` - Python artifacts
+- `.nox`, `.tox`, `.venv`, `venv`, `.eggs` - Python environments
+- `node_modules` - JavaScript dependencies
+- `_build`, `buck-out`, `build`, `dist` - common build directories
+
+Use `extend-exclude` to add to these defaults, or `exclude` to replace them
+entirely.
+
+## CLI options
+
+### Filtering options
+
+#### `--exclude:pattern`
+
+Completely replaces the default exclusion patterns with your own regex pattern.
+Can be specified multiple times.
+
+```sh
+# Only exclude the build directory
+nph --exclude:build src/
+```
+
+#### `--extend-exclude:pattern`
+
+Adds a regex pattern to the default exclusions. Can be specified multiple times.
+This is typically more useful than `--exclude` since you keep the sensible
+defaults.
+
+```sh
+# Exclude vendor directory in addition to defaults
+nph --extend-exclude:vendor src/
+```
+
+#### `--include:pattern`
+
+Only format files matching this regex pattern. Can be specified multiple times.
+Default is `\.nim(s|ble)?$`.
+
+```sh
+# Only format .nim files (not .nims or .nimble)
+nph --include:'\.nim$' src/
+```
+
+**Note**: Files passed explicitly on the command line bypass all filtering
+(matching Black's behavior):
+
+```sh
+# This WILL format vendor/foo.nim even if vendor is excluded
+nph vendor/foo.nim
+```
+
+### Diff and check options
+
+#### `--diff`
+
+Show a unified diff of formatting changes without modifying files. Useful for
+previewing changes or in CI to see what would be reformatted.
+
+```sh
+nph --diff src/myfile.nim
+```
+
+Exit code is 0 even if changes are found (informational mode). Combine with
+`--check` to make it fail on changes.
+
+#### `--check`
+
+Check if files are formatted correctly without modifying them. Exits with code 1
+if any file would be reformatted. Perfect for CI pipelines.
+
+```sh
+nph --check src/
+```
+
+Can be combined with `--diff` to both show changes and fail:
+
+```sh
+nph --check --diff src/
+```
+
+#### `--color` / `--no-color`
+
+Enable or disable colored diff output. Only works with `--diff`. Default is
+`--no-color`.
+
+```sh
+# Show colored diff
+nph --diff --color src/myfile.nim
+
+# Explicitly disable color
+nph --diff --no-color src/myfile.nim
+```
+
+### Other options
+
+#### `--config:file`
+
+Specify a config file to use. Default is `.nph.toml` if it exists.
+
+```sh
+nph --config:custom.toml src/
 ```
 
 ## Disabling formatting locally

--- a/nph.nimble
+++ b/nph.nimble
@@ -15,7 +15,8 @@ bin           = @["nph"]
 # Note that the parser used by the formatter and the parser used by the verifier
 # might disagree if syntax changes are included in a Nim patch version.
 # TODO: nph should learn how to check formatting with any nim version
-requires "nim >= 2.2.0 & < 2.3", "compiler >= 2.2.0 & < 2.3", "hldiff"
+requires "nim >= 2.2.0 & < 2.3", "compiler >= 2.2.0 & < 2.3"
+requires "hldiff >= 1.0.6 & < 2"
 
 proc build() =
   exec "nim c --debuginfo -o:nph src/nph"

--- a/nph.nimble
+++ b/nph.nimble
@@ -15,7 +15,7 @@ bin           = @["nph"]
 # Note that the parser used by the formatter and the parser used by the verifier
 # might disagree if syntax changes are included in a Nim patch version.
 # TODO: nph should learn how to check formatting with any nim version
-requires "nim >= 2.2.0 & < 2.3", "compiler >= 2.2.0 & < 2.3"
+requires "nim >= 2.2.0 & < 2.3", "compiler >= 2.2.0 & < 2.3", "hldiff"
 
 proc build() =
   exec "nim c --debuginfo -o:nph src/nph"

--- a/nph.nimble
+++ b/nph.nimble
@@ -16,8 +16,10 @@ bin           = @["nph"]
 # might disagree if syntax changes are included in a Nim patch version.
 # TODO: nph should learn how to check formatting with any nim version
 requires "nim >= 2.2.0 & < 2.3", "compiler >= 2.2.0 & < 2.3"
-requires "hldiff >= 1.0.6 & < 2"
-requires "toml_serialization", "regex"
+requires "hldiff >= 1.0.7 & < 2"
+requires "glob >= 0.11.3 & < 0.12.0"
+requires "toml_serialization >= 0.2.18 & < 0.3.0"
+requires "regex >= 0.26.3 & < 0.27.0"
 
 proc build() =
   exec "nim c --debuginfo -o:nph src/nph"

--- a/src/nph.nim
+++ b/src/nph.nim
@@ -10,7 +10,18 @@ import
 
 import "$nim"/compiler/idents
 
-import std/[parseopt, strutils, os, sequtils]
+import std/[parseopt, strutils, os, sequtils, terminal]
+import pkg/hldiffpkg/edits
+import pkg/adix/lptabz
+
+# Silence LPTabz warnings by redirecting to /dev/null
+when defined(posix):
+  lpWarn = open("/dev/null", fmWrite)
+elif defined(windows):
+  lpWarn = open("NUL", fmWrite)
+else:
+  # Fallback: just use stderr but set max warnings to 0
+  lpMaxWarn = 0
 
 static:
   doAssert NimMajor == 2 and NimMinor == 2, "nph needs a specific version of Nim"
@@ -24,15 +35,19 @@ Usage:
   nph [options] nimfiles...
 Options:
   --check               check the formatting instead of performing it
+  --diff                show diff of formatting changes without writing files
   --out:file            set the output file (default: overwrite the input file)
   --outDir:dir          set the output dir (default: overwrite the input files)
+  --color               show colored diff (only applies when --diff is given)
+  --no-color            disable colored diff (default)
   --version             show the version
   --help                show this help
 """
   ErrCheckFailed = 1
-  ErrParseInputFailed = 2
-  ErrParseOutputFailed = 3
-  ErrEqFailed = 4
+  ErrDiffChanges = 2 # --diff mode: changes found (but exit 0)
+  ErrParseInputFailed = 3
+  ErrParseOutputFailed = 4
+  ErrEqFailed = 5
 
 proc writeHelp() =
   stdout.write(Usage)
@@ -59,7 +74,65 @@ proc makeConfigRef(): ConfigRef =
   conf.errorMax = int.high
   conf
 
-proc prettyPrint(infile, outfile: string, debug, check, printTokens: bool): int =
+proc printDiff(input, output, infile: string, color: bool) =
+  ## Print unified diff between input and output
+  let
+    inputLines = input.split('\n')
+    outputLines = output.split('\n')
+    sm = sames(inputLines, outputLines)
+
+  var begun = false
+  for eds in grouped(sm, 3):
+    if not begun:
+      begun = true
+      if color:
+        stdout.styledWriteLine(styleBright, "--- " & infile)
+        stdout.styledWriteLine(styleBright, "+++ " & infile & " (formatted)")
+      else:
+        stdout.writeLine("--- " & infile)
+        stdout.writeLine("+++ " & infile & " (formatted)")
+
+    let marker =
+      "@@ -" & rangeUni(eds[0].s.a, eds[^1].s.b + 1) & " +" &
+      rangeUni(eds[0].t.a, eds[^1].t.b + 1) & " @@"
+
+    if color:
+      stdout.styledWriteLine(fgCyan, marker)
+    else:
+      stdout.writeLine(marker)
+
+    for ed in eds:
+      case ed.ek
+      of ekEql:
+        for ln in inputLines[ed.s]:
+          stdout.writeLine(" " & ln)
+      of ekDel:
+        for ln in inputLines[ed.s]:
+          if color:
+            stdout.styledWriteLine(fgRed, "-" & ln)
+          else:
+            stdout.writeLine("-" & ln)
+      of ekIns:
+        for ln in outputLines[ed.t]:
+          if color:
+            stdout.styledWriteLine(fgGreen, "+" & ln)
+          else:
+            stdout.writeLine("+" & ln)
+      of ekSub:
+        for ln in inputLines[ed.s]:
+          if color:
+            stdout.styledWriteLine(fgRed, "-" & ln)
+          else:
+            stdout.writeLine("-" & ln)
+        for ln in outputLines[ed.t]:
+          if color:
+            stdout.styledWriteLine(fgGreen, "+" & ln)
+          else:
+            stdout.writeLine("+" & ln)
+
+proc prettyPrint(
+    infile, outfile: string, debug, check, diff, printTokens, color: bool
+): int =
   let
     conf = makeConfigRef()
     input =
@@ -82,6 +155,15 @@ proc prettyPrint(infile, outfile: string, debug, check, printTokens: bool): int 
 
   if conf.errorCounter > 0:
     return ErrParseOutputFailed
+
+  # Handle --diff mode: print diff and exit early
+  if diff:
+    if input != output:
+      printDiff(input, output, infile, color)
+      # --diff alone is informational (exit 0), --diff --check fails (exit 1)
+      return if check: ErrCheckFailed else: ErrDiffChanges
+    else:
+      return QuitSuccess # No changes needed
 
   if infile != "-":
     if debug:
@@ -111,6 +193,9 @@ proc prettyPrint(infile, outfile: string, debug, check, printTokens: bool): int 
   case eq.kind
   of Same:
     if check:
+      # Print which file would be reformatted (like Black)
+      if input != output:
+        stderr.writeLine("would reformat " & infile)
       ErrCheckFailed # We failed the equivalence check above
     else:
       # Formatting changed the file
@@ -158,8 +243,11 @@ proc main() =
     outfiles = newSeq[string]()
     debug = false
     check = false
+    diff = false
     printTokens = false
     usesDir = false
+    cliColorSet = false
+    cliColor = false
 
   for kind, key, val in getopt():
     case kind
@@ -183,10 +271,18 @@ proc main() =
         printTokens = true
       of "check":
         check = true
+      of "diff":
+        diff = true
       of "output", "o", "out":
         outfile = val
       of "outDir", "outdir":
         outdir = val
+      of "color":
+        cliColorSet = true
+        cliColor = true
+      of "no-color", "nocolor":
+        cliColorSet = true
+        cliColor = false
       of "":
         infiles.add("-")
       else:
@@ -203,6 +299,13 @@ proc main() =
   if outfile.len != 0 and usesDir:
     quit "[Error] out cannot be used alongside directories", 3
 
+  if diff and (outfile.len != 0 or outdir.len != 0):
+    quit "[Error] diff cannot be used with out or outDir", 3
+
+  # Validate --color requires --diff
+  if cliColorSet and cliColor and not diff:
+    quit "[Error] --color can only be used with --diff", 3
+
   if outfile.len == 0 and outdir.len == 0:
     outfiles = infiles
   elif outfile.len != 0 and infiles.len > 1:
@@ -216,20 +319,54 @@ proc main() =
   elif outdir.len != 0:
     outfiles = infiles.mapIt($(joinPath(outdir, it)))
 
-  var res = QuitSuccess
+  var
+    res = QuitSuccess
+    filesReformatted = 0
+    filesUnchanged = 0
+    filesErrored = 0
+
   for (infile, outfile) in zip(infiles, outfiles):
     let (dir, _, _) = splitFile(outfile)
 
     createDir(dir)
-    let err = prettyPrint(infile, outfile, debug, check, printTokens)
-    case err
-    of ErrCheckFailed:
-      quit ErrCheckFailed
-    else:
-      # Keep going on source code errors but fail the program eventually
-      res = max(res, err)
+    let err = prettyPrint(infile, outfile, debug, check, diff, printTokens, cliColor)
 
-  quit res
+    # Track statistics for summary
+    case err
+    of QuitSuccess:
+      filesUnchanged.inc
+    of ErrCheckFailed, ErrDiffChanges:
+      filesReformatted.inc
+    else:
+      filesErrored.inc
+
+    # Keep going to show all diffs/errors instead of failing fast
+    res = max(res, err)
+
+  # Print summary for --check or --diff (like Black)
+  if (check or diff) and infiles.len > 0:
+    if filesReformatted > 0 or filesUnchanged > 0:
+      var parts: seq[string]
+      if filesReformatted > 0:
+        let s = if filesReformatted == 1: "file" else: "files"
+        parts.add $filesReformatted & " " & s & " would be reformatted"
+      if filesUnchanged > 0:
+        let s = if filesUnchanged == 1: "file" else: "files"
+        parts.add $filesUnchanged & " " & s & " would be left unchanged"
+
+      if check and filesReformatted > 0:
+        stderr.writeLine "\nOh no! 💥 💔 💥"
+      elif not check:
+        stderr.writeLine "\nAll done! ✨ 👑 ✨"
+
+      stderr.writeLine parts.join(", ") & "."
+
+  # --diff alone exits 0 even with changes (informational)
+  # --check or --diff --check exits 1 with changes (for CI)
+  if res == ErrDiffChanges and not check:
+    quit QuitSuccess
+  else:
+    quit res
 
 when isMainModule:
   main()

--- a/src/nph.nim
+++ b/src/nph.nim
@@ -333,12 +333,9 @@ proc main() =
 
     # Track statistics for summary
     case err
-    of QuitSuccess:
-      filesUnchanged.inc
-    of ErrCheckFailed, ErrDiffChanges:
-      filesReformatted.inc
-    else:
-      filesErrored.inc
+    of QuitSuccess: filesUnchanged.inc
+    of ErrCheckFailed, ErrDiffChanges: filesReformatted.inc
+    else: filesErrored.inc
 
     # Keep going to show all diffs/errors instead of failing fast
     res = max(res, err)

--- a/src/nph.nim
+++ b/src/nph.nim
@@ -14,15 +14,6 @@ import std/[parseopt, strutils, os, sequtils, terminal]
 import pkg/hldiffpkg/edits
 import pkg/adix/lptabz
 
-# Silence LPTabz warnings by redirecting to /dev/null
-when defined(posix):
-  lpWarn = open("/dev/null", fmWrite)
-elif defined(windows):
-  lpWarn = open("NUL", fmWrite)
-else:
-  # Fallback: just use stderr but set max warnings to 0
-  lpMaxWarn = 0
-
 static:
   doAssert NimMajor == 2 and NimMinor == 2, "nph needs a specific version of Nim"
 
@@ -38,8 +29,8 @@ Options:
   --diff                show diff of formatting changes without writing files
   --out:file            set the output file (default: overwrite the input file)
   --outDir:dir          set the output dir (default: overwrite the input files)
-  --color               show colored diff (only applies when --diff is given)
-  --no-color            disable colored diff (default)
+  --color               force colored diff output (only applies when --diff is given)
+  --no-color            disable colored diff output
   --version             show the version
   --help                show this help
 """
@@ -247,7 +238,8 @@ proc main() =
     printTokens = false
     usesDir = false
     cliColorSet = false
-    cliColor = false
+    # Default to color if stdout is a TTY and NO_COLOR is not set or empty
+    cliColor = getEnv("NO_COLOR") == "" and isatty(stdout)
 
   for kind, key, val in getopt():
     case kind


### PR DESCRIPTION
Adds --diff flag to preview formatting changes without modifying files, and --color flag for colored diff output.

Behavior:
- --diff: shows unified diff, exits 0
- --diff --check: shows diff and exits 1 if changes needed (for CI)
- --color: enables ANSI colored diff output (requires --diff)
- --no-color: disables colored output (default)

Disallows --diff with --out/--outDir (contradictory operations).

Uses hldiff pkg for unified diff generation. Silences LPTabz warnings from hldiff library.

Adds hldiff package requirement to nph.nimble.