### PR TITLE
Make `[]` operator simple (fixes #101)

### DIFF
--- a/src/phrenderer.nim
+++ b/src/phrenderer.nim
@@ -176,6 +176,8 @@ proc isSimple(n: PNode, allowExported = false, allowInfix = false): bool =
       n.allIt(isSimple(it))
     of nkProcTy:
       true
+    of nkBracketExpr:
+      n.len == 1
     else:
       false
 

--- a/tests/after/procs.nim
+++ b/tests/after/procs.nim
@@ -110,6 +110,10 @@ functionCall(
   aaaaaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaaa,
   aaaaaaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaa,
 )
+functionCall(
+  aaaaaaaaaaaaaaaaaaaaaa, derefisalsosimple[], aaaaaaaaaaaaaaaaaaa,
+  aaaaaaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaa,
+)
 
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(
   aaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaaaaa

--- a/tests/after/procs.nim.nph.yaml
+++ b/tests/after/procs.nim.nph.yaml
@@ -757,6 +757,22 @@ sons:
   - kind: "nkCall"
     sons:
       - kind: "nkIdent"
+        ident: "functionCall"
+      - kind: "nkIdent"
+        ident: "aaaaaaaaaaaaaaaaaaaaaa"
+      - kind: "nkBracketExpr"
+        sons:
+          - kind: "nkIdent"
+            ident: "derefisalsosimple"
+      - kind: "nkIdent"
+        ident: "aaaaaaaaaaaaaaaaaaa"
+      - kind: "nkIdent"
+        ident: "aaaaaaaaaaaaaaaaaaaaaaa"
+      - kind: "nkIdent"
+        ident: "aaaaaaaaaaaaa"
+  - kind: "nkCall"
+    sons:
+      - kind: "nkIdent"
         ident: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
       - kind: "nkIdent"
         ident: "aaaaaaaaaaaaaaa"

--- a/tests/before/procs.nim
+++ b/tests/before/procs.nim
@@ -35,6 +35,7 @@ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 
 command aaaaaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaa, bbbbbbbbbbbbbbbb
 functionCall(aaaaaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaa)
+functionCall(aaaaaaaaaaaaaaaaaaaaaa, derefisalsosimple[], aaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaa)
 
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(aaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaaa,aaaaaaaaaaaaaaaaa,aaaaaaaaaaaaaaaaaaaaa)
 

--- a/tests/before/procs.nim.nph.yaml
+++ b/tests/before/procs.nim.nph.yaml
@@ -757,6 +757,22 @@ sons:
   - kind: "nkCall"
     sons:
       - kind: "nkIdent"
+        ident: "functionCall"
+      - kind: "nkIdent"
+        ident: "aaaaaaaaaaaaaaaaaaaaaa"
+      - kind: "nkBracketExpr"
+        sons:
+          - kind: "nkIdent"
+            ident: "derefisalsosimple"
+      - kind: "nkIdent"
+        ident: "aaaaaaaaaaaaaaaaaaa"
+      - kind: "nkIdent"
+        ident: "aaaaaaaaaaaaaaaaaaaaaaa"
+      - kind: "nkIdent"
+        ident: "aaaaaaaaaaaaa"
+  - kind: "nkCall"
+    sons:
+      - kind: "nkIdent"
         ident: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
       - kind: "nkIdent"
         ident: "aaaaaaaaaaaaaaa"


### PR DESCRIPTION
This matters above all in function calls where a deref can cause one-per-line formatting to kick in