### PR TITLE
Keep prefix expressions on same line

### DIFF
--- a/src/phrenderer.nim
+++ b/src/phrenderer.nim
@@ -1339,7 +1339,7 @@ proc gsubOptNL(g: var TOutput, n: PNode, indentNL = IndentWidth, flags: SubFlags
     nkCurlyExpr, nkPragmaExpr, nkCommand, nkExprEqExpr, nkAsgn, nkFastAsgn, nkClosure,
     nkTupleConstr, nkCurly, nkArgList, nkTableConstr, nkBracket, nkBind, nkDo,
     nkIdentDefs, nkConstDef, nkVarTuple, nkExprColonExpr, nkTypeOfExpr, nkDistinctTy,
-    nkTypeDef, nkBlockStmt, nkBlockExpr, nkLambda, nkProcTy,
+    nkTypeDef, nkBlockStmt, nkBlockExpr, nkLambda, nkProcTy, nkPrefix,
   }
 
   let
@@ -1741,9 +1741,9 @@ proc gsub(g: var TOutput, n: PNode, flags: SubFlags, extra: int) =
       sublen = lsub(g, n[2])
       nsublen = nlsub(g, n[2])
       overflows = n.len == 3 and overflows(g, nsublen) and not infixHasParens(n, 2)
-      fitsNL = overflows(g, sublen) and fits(g, sublen + g.indent)
-      indent = sfNoIndent notin flags and (fitsNL or overflows and not hasIndent(n[2]))
       wid = flagIndent(flags)
+      fitsNL = overflows(g, sublen) and fits(g, sublen + g.indent + wid)
+      indent = sfNoIndent notin flags and (fitsNL or overflows and not hasIndent(n[2]))
       flags2 =
         if indent:
           # Only indent infix once otherwise for long strings of + / and / etc

--- a/tests/after/exprs.nim
+++ b/tests/after/exprs.nim
@@ -200,6 +200,39 @@ let bbbbbbccccb = [
   888888888888888,
 ]
 
+let bbbbbbccccb = @[
+  int64 533, 444444444444444444, 555555555555555555, 6666666666666666, 6777777777777777,
+  888888888888888,
+]
+
+let bbbbbbccccb = %*{
+  a: 533,
+  b: 444444444444444444,
+  c: 555555555555555555,
+  d: 6666666666666666,
+  e: 6777777777777777,
+  f: 888888888888888,
+}
+
+let xxxxxxxxxxxxxxxxxxxxxxxxxxxx =
+  ?aaaaaaaaaaaaaaaaaaaaaaa(bbbbbbbbbbbbb, cccccccccccc, ddddddddddd)
+
+let xxxxxxxxxxxxxxxxxxxxxxxxxxxx = ?aaaaaaaaaaaaaaaaaaaaaaa(
+  bbbbbbbbbbbbb, cccccccccccc, ddddddddddd, eeeeeeeeeeeeee, ffffffffffffff,
+  ggggggggggggggggggggg,
+)
+
+let xxxxxxxxxxxxxxxxxxxxxxxxxxxx = not aaaaaaaaaaaaaaaaaaaaaaa(
+  bbbbbbbbbbbbb, cccccccccccc, ddddddddddd, eeeeeeeeeeeeee, ffffffffffffff,
+  ggggggggggggggggggggg,
+)
+
+let bbbbbbccccb = block:
+  @[
+    533, 444444444444444444, 555555555555555555, 6666666666666666, 6777777777777777,
+    888888888888888,
+  ]
+
 let xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx =
   """xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 

--- a/tests/after/exprs.nim.nph.yaml
+++ b/tests/after/exprs.nim.nph.yaml
@@ -2054,6 +2054,189 @@ sons:
       - kind: "nkIdentDefs"
         sons:
           - kind: "nkIdent"
+            ident: "bbbbbbccccb"
+          - kind: "nkEmpty"
+          - kind: "nkPrefix"
+            sons:
+              - kind: "nkIdent"
+                ident: "@"
+              - kind: "nkBracket"
+                sons:
+                  - kind: "nkCommand"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "int64"
+                      - kind: "nkIntLit"
+                        intVal: 533
+                  - kind: "nkInt64Lit"
+                    intVal: 444444444444444444
+                  - kind: "nkInt64Lit"
+                    intVal: 555555555555555555
+                  - kind: "nkInt64Lit"
+                    intVal: 6666666666666666
+                  - kind: "nkInt64Lit"
+                    intVal: 6777777777777777
+                  - kind: "nkInt64Lit"
+                    intVal: 888888888888888
+  - kind: "nkLetSection"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "bbbbbbccccb"
+          - kind: "nkEmpty"
+          - kind: "nkPrefix"
+            sons:
+              - kind: "nkIdent"
+                ident: "%*"
+              - kind: "nkTableConstr"
+                sons:
+                  - kind: "nkExprColonExpr"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "a"
+                      - kind: "nkIntLit"
+                        intVal: 533
+                  - kind: "nkExprColonExpr"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "b"
+                      - kind: "nkInt64Lit"
+                        intVal: 444444444444444444
+                  - kind: "nkExprColonExpr"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "c"
+                      - kind: "nkInt64Lit"
+                        intVal: 555555555555555555
+                  - kind: "nkExprColonExpr"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "d"
+                      - kind: "nkInt64Lit"
+                        intVal: 6666666666666666
+                  - kind: "nkExprColonExpr"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "e"
+                      - kind: "nkInt64Lit"
+                        intVal: 6777777777777777
+                  - kind: "nkExprColonExpr"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "f"
+                      - kind: "nkInt64Lit"
+                        intVal: 888888888888888
+  - kind: "nkLetSection"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "xxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+          - kind: "nkEmpty"
+          - kind: "nkPrefix"
+            sons:
+              - kind: "nkIdent"
+                ident: "?"
+              - kind: "nkCall"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "aaaaaaaaaaaaaaaaaaaaaaa"
+                  - kind: "nkIdent"
+                    ident: "bbbbbbbbbbbbb"
+                  - kind: "nkIdent"
+                    ident: "cccccccccccc"
+                  - kind: "nkIdent"
+                    ident: "ddddddddddd"
+  - kind: "nkLetSection"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "xxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+          - kind: "nkEmpty"
+          - kind: "nkPrefix"
+            sons:
+              - kind: "nkIdent"
+                ident: "?"
+              - kind: "nkCall"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "aaaaaaaaaaaaaaaaaaaaaaa"
+                  - kind: "nkIdent"
+                    ident: "bbbbbbbbbbbbb"
+                  - kind: "nkIdent"
+                    ident: "cccccccccccc"
+                  - kind: "nkIdent"
+                    ident: "ddddddddddd"
+                  - kind: "nkIdent"
+                    ident: "eeeeeeeeeeeeee"
+                  - kind: "nkIdent"
+                    ident: "ffffffffffffff"
+                  - kind: "nkIdent"
+                    ident: "ggggggggggggggggggggg"
+  - kind: "nkLetSection"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "xxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+          - kind: "nkEmpty"
+          - kind: "nkPrefix"
+            sons:
+              - kind: "nkIdent"
+                ident: "not"
+              - kind: "nkCall"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "aaaaaaaaaaaaaaaaaaaaaaa"
+                  - kind: "nkIdent"
+                    ident: "bbbbbbbbbbbbb"
+                  - kind: "nkIdent"
+                    ident: "cccccccccccc"
+                  - kind: "nkIdent"
+                    ident: "ddddddddddd"
+                  - kind: "nkIdent"
+                    ident: "eeeeeeeeeeeeee"
+                  - kind: "nkIdent"
+                    ident: "ffffffffffffff"
+                  - kind: "nkIdent"
+                    ident: "ggggggggggggggggggggg"
+  - kind: "nkLetSection"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "bbbbbbccccb"
+          - kind: "nkEmpty"
+          - kind: "nkBlockStmt"
+            sons:
+              - kind: "nkEmpty"
+              - kind: "nkStmtList"
+                sons:
+                  - kind: "nkPrefix"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "@"
+                      - kind: "nkBracket"
+                        sons:
+                          - kind: "nkIntLit"
+                            intVal: 533
+                          - kind: "nkInt64Lit"
+                            intVal: 444444444444444444
+                          - kind: "nkInt64Lit"
+                            intVal: 555555555555555555
+                          - kind: "nkInt64Lit"
+                            intVal: 6666666666666666
+                          - kind: "nkInt64Lit"
+                            intVal: 6777777777777777
+                          - kind: "nkInt64Lit"
+                            intVal: 888888888888888
+  - kind: "nkLetSection"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
             ident: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
           - kind: "nkEmpty"
           - kind: "nkTripleStrLit"

--- a/tests/before/exprs.nim
+++ b/tests/before/exprs.nim
@@ -130,6 +130,18 @@ let bbbbbbb = ["aaaaaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbbbbbbbbbb", "ccccccccc
 
 let bbbbbbccccb = [int64 533, 444444444444444444, 555555555555555555, 6666666666666666, 6777777777777777, 888888888888888]
 
+let bbbbbbccccb = @[int64 533, 444444444444444444, 555555555555555555, 6666666666666666, 6777777777777777, 888888888888888]
+
+let bbbbbbccccb = %*{a: 533, b: 444444444444444444, c: 555555555555555555, d: 6666666666666666, e: 6777777777777777, f: 888888888888888}
+
+let xxxxxxxxxxxxxxxxxxxxxxxxxxxx = ?aaaaaaaaaaaaaaaaaaaaaaa(bbbbbbbbbbbbb, cccccccccccc, ddddddddddd)
+
+let xxxxxxxxxxxxxxxxxxxxxxxxxxxx = ?aaaaaaaaaaaaaaaaaaaaaaa(bbbbbbbbbbbbb, cccccccccccc, ddddddddddd, eeeeeeeeeeeeee, ffffffffffffff, ggggggggggggggggggggg)
+
+let xxxxxxxxxxxxxxxxxxxxxxxxxxxx = not aaaaaaaaaaaaaaaaaaaaaaa(bbbbbbbbbbbbb, cccccccccccc, ddddddddddd, eeeeeeeeeeeeee, ffffffffffffff, ggggggggggggggggggggg)
+
+let bbbbbbccccb = block: @[533, 444444444444444444, 555555555555555555, 6666666666666666, 6777777777777777, 888888888888888]
+
 let xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx = """xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 """

--- a/tests/before/exprs.nim.nph.yaml
+++ b/tests/before/exprs.nim.nph.yaml
@@ -2054,6 +2054,189 @@ sons:
       - kind: "nkIdentDefs"
         sons:
           - kind: "nkIdent"
+            ident: "bbbbbbccccb"
+          - kind: "nkEmpty"
+          - kind: "nkPrefix"
+            sons:
+              - kind: "nkIdent"
+                ident: "@"
+              - kind: "nkBracket"
+                sons:
+                  - kind: "nkCommand"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "int64"
+                      - kind: "nkIntLit"
+                        intVal: 533
+                  - kind: "nkInt64Lit"
+                    intVal: 444444444444444444
+                  - kind: "nkInt64Lit"
+                    intVal: 555555555555555555
+                  - kind: "nkInt64Lit"
+                    intVal: 6666666666666666
+                  - kind: "nkInt64Lit"
+                    intVal: 6777777777777777
+                  - kind: "nkInt64Lit"
+                    intVal: 888888888888888
+  - kind: "nkLetSection"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "bbbbbbccccb"
+          - kind: "nkEmpty"
+          - kind: "nkPrefix"
+            sons:
+              - kind: "nkIdent"
+                ident: "%*"
+              - kind: "nkTableConstr"
+                sons:
+                  - kind: "nkExprColonExpr"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "a"
+                      - kind: "nkIntLit"
+                        intVal: 533
+                  - kind: "nkExprColonExpr"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "b"
+                      - kind: "nkInt64Lit"
+                        intVal: 444444444444444444
+                  - kind: "nkExprColonExpr"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "c"
+                      - kind: "nkInt64Lit"
+                        intVal: 555555555555555555
+                  - kind: "nkExprColonExpr"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "d"
+                      - kind: "nkInt64Lit"
+                        intVal: 6666666666666666
+                  - kind: "nkExprColonExpr"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "e"
+                      - kind: "nkInt64Lit"
+                        intVal: 6777777777777777
+                  - kind: "nkExprColonExpr"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "f"
+                      - kind: "nkInt64Lit"
+                        intVal: 888888888888888
+  - kind: "nkLetSection"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "xxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+          - kind: "nkEmpty"
+          - kind: "nkPrefix"
+            sons:
+              - kind: "nkIdent"
+                ident: "?"
+              - kind: "nkCall"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "aaaaaaaaaaaaaaaaaaaaaaa"
+                  - kind: "nkIdent"
+                    ident: "bbbbbbbbbbbbb"
+                  - kind: "nkIdent"
+                    ident: "cccccccccccc"
+                  - kind: "nkIdent"
+                    ident: "ddddddddddd"
+  - kind: "nkLetSection"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "xxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+          - kind: "nkEmpty"
+          - kind: "nkPrefix"
+            sons:
+              - kind: "nkIdent"
+                ident: "?"
+              - kind: "nkCall"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "aaaaaaaaaaaaaaaaaaaaaaa"
+                  - kind: "nkIdent"
+                    ident: "bbbbbbbbbbbbb"
+                  - kind: "nkIdent"
+                    ident: "cccccccccccc"
+                  - kind: "nkIdent"
+                    ident: "ddddddddddd"
+                  - kind: "nkIdent"
+                    ident: "eeeeeeeeeeeeee"
+                  - kind: "nkIdent"
+                    ident: "ffffffffffffff"
+                  - kind: "nkIdent"
+                    ident: "ggggggggggggggggggggg"
+  - kind: "nkLetSection"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "xxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+          - kind: "nkEmpty"
+          - kind: "nkPrefix"
+            sons:
+              - kind: "nkIdent"
+                ident: "not"
+              - kind: "nkCall"
+                sons:
+                  - kind: "nkIdent"
+                    ident: "aaaaaaaaaaaaaaaaaaaaaaa"
+                  - kind: "nkIdent"
+                    ident: "bbbbbbbbbbbbb"
+                  - kind: "nkIdent"
+                    ident: "cccccccccccc"
+                  - kind: "nkIdent"
+                    ident: "ddddddddddd"
+                  - kind: "nkIdent"
+                    ident: "eeeeeeeeeeeeee"
+                  - kind: "nkIdent"
+                    ident: "ffffffffffffff"
+                  - kind: "nkIdent"
+                    ident: "ggggggggggggggggggggg"
+  - kind: "nkLetSection"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "bbbbbbccccb"
+          - kind: "nkEmpty"
+          - kind: "nkBlockStmt"
+            sons:
+              - kind: "nkEmpty"
+              - kind: "nkStmtList"
+                sons:
+                  - kind: "nkPrefix"
+                    sons:
+                      - kind: "nkIdent"
+                        ident: "@"
+                      - kind: "nkBracket"
+                        sons:
+                          - kind: "nkIntLit"
+                            intVal: 533
+                          - kind: "nkInt64Lit"
+                            intVal: 444444444444444444
+                          - kind: "nkInt64Lit"
+                            intVal: 555555555555555555
+                          - kind: "nkInt64Lit"
+                            intVal: 6666666666666666
+                          - kind: "nkInt64Lit"
+                            intVal: 6777777777777777
+                          - kind: "nkInt64Lit"
+                            intVal: 888888888888888
+  - kind: "nkLetSection"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
             ident: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
           - kind: "nkEmpty"
           - kind: "nkTripleStrLit"


### PR DESCRIPTION
When formatting arrays, tuples and similar "surrounded" lists, we allow the opening character to stay on the same line, ie:

```nim
const myarray = [
  ...
]
```

However, if we change the above to a seq or json mapping, the opening statement jumps to the next line due to the additional prefix call (`@` in this case):

```nim
const myseq =
  @[
    ...
  ]
```

The above formatting is unexpected in the context since the constructs both look like lists - prefix calls are meant to be unobtrusive and above all, adding an extra indent for the items gives up valuable horizontal space for a construct that already is indented - moving prefix calls to the same line gives a more natural look for this category of constructs:

```nim
const myseq = @[
  ...
]
const myjson = %{
  a: b,
  ...
}
```

The change also affects other kinds of prefixes, in particular `?` of nim-results fame and `not` - before:

```nim
let f = call(
  ...
)
let f2 =
  ?call(
    ...
  )
let f3 =
  not call(
    ...
  )
```

After:

```nim
let f = call(
  ...
)
let f2 = ?call(
  ...
)
let f3 = not call(
  ...
)
```