### PR TITLE
Fix extra `do` in `block` and other "colon" statements

### DIFF
--- a/src/phparser.nim
+++ b/src/phparser.nim
@@ -544,12 +544,11 @@ proc exprColonEqExprList(p: var Parser, kind: TNodeKind, endTok: TokType): PNode
   exprColonEqExprListAux(p, endTok, result)
 
 proc dotExpr(p: var Parser, a: PNode): PNode =
-  var info = p.parLineInfo
-
   getTok(p)
 
   result = wrap(newNodeP(nkDotExpr, p, withPrefix = false), a)
-  result.info = info
+  # the dot might be at the next line already
+  result.info = a.info
   splitLookahead(p, result, clMid)
   optInd(p, result)
   result.add(parseSymbol(p, smAfterDot))

--- a/src/phrenderer.nim
+++ b/src/phrenderer.nim
@@ -276,7 +276,6 @@ proc optNL(g: var TOutput, a, b: PNode) =
         b.prefix[0].line
       else:
         int b.info.line
-
   # Only skip newline for consecutive comment statements on the same line
   # This preserves patterns like: #[...]# # comment
   # For all other nodes, always add the newline (normal formatting)
@@ -1017,7 +1016,13 @@ proc gcolcoms(g: var TOutput, n, stmts: PNode, useSub = false) =
   else:
     withIndent(g):
       optNL(g)
-      gstmts(g, stmts, flags = {sfNoIndent}, doIndent = false)
+      # sfSkipDo is here because when we render a colcom with a newline, the
+      # parser will add a layer of nkStmtList wrapping which in turn renders
+      # the extra `do` redundant, since post statements in nkStmtList should
+      # not have `do`. As noted elsewhere, this logic has been experimentally
+      # expanded to cover more and more cases and should probably be revisited
+      # in a principled way instead.
+      gstmts(g, stmts, flags = {sfSkipDo, sfNoIndent}, doIndent = false)
 
 proc gcond(g: var TOutput, n: PNode, flags: SubFlags = {}) =
   gsub(g, n, flags + {sfParDo})

--- a/tests/after/comments.nim
+++ b/tests/after/comments.nim
@@ -450,7 +450,6 @@ dotexpr
 if true:
   echo dotexpr.dot # after dotexpr in command ind
   # between two dotepxrs ind
-
   dotexpr
   # between dotexpr and dotonnewline ind
   .dotonnewline

--- a/tests/after/exprs.nim
+++ b/tests/after/exprs.nim
@@ -153,6 +153,9 @@ mynums = myNums
   .replace5("five", "f5ive")
   .replace6("six", "s6ix")
   .replace7("seven", "s7even")
+aaaaaaaaaaaaaaaaaaaaa.bbbbbbbbbbbbbbbbbbbbbb
+.ccccccccccccccccccccccccccc().ccccccccccccccccccccccccc
+.ddddddddddddddddd() # no newline before previous dotexpr
 
 let xxxxxxxxx = block:
   f()

--- a/tests/after/exprs.nim.nph.yaml
+++ b/tests/after/exprs.nim.nph.yaml
@@ -1806,6 +1806,30 @@ sons:
             strVal: "seven"
           - kind: "nkStrLit"
             strVal: "s7even"
+  - kind: "nkCall"
+    sons:
+      - kind: "nkDotExpr"
+        sons:
+          - kind: "nkDotExpr"
+            sons:
+              - kind: "nkCall"
+                sons:
+                  - kind: "nkDotExpr"
+                    sons:
+                      - kind: "nkDotExpr"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "aaaaaaaaaaaaaaaaaaaaa"
+                          - kind: "nkIdent"
+                            ident: "bbbbbbbbbbbbbbbbbbbbbb"
+                      - kind: "nkIdent"
+                        ident: "ccccccccccccccccccccccccccc"
+              - kind: "nkIdent"
+                ident: "ccccccccccccccccccccccccc"
+          - kind: "nkIdent"
+            ident: "ddddddddddddddddd"
+    postfix:
+      - "# no newline before previous dotexpr"
   - kind: "nkLetSection"
     sons:
       - kind: "nkIdentDefs"

--- a/tests/after/postexprs.nim
+++ b/tests/after/postexprs.nim
@@ -116,3 +116,9 @@ if (
 
 not (compiles do:
   discard)
+
+let aaa = (
+  block:
+    bbb.postexpr:
+      vvvv
+).ytyyy()

--- a/tests/after/postexprs.nim.nph.yaml
+++ b/tests/after/postexprs.nim.nph.yaml
@@ -667,3 +667,35 @@ sons:
               - kind: "nkDiscardStmt"
                 sons:
                   - kind: "nkEmpty"
+  - kind: "nkLetSection"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "aaa"
+          - kind: "nkEmpty"
+          - kind: "nkCall"
+            sons:
+              - kind: "nkDotExpr"
+                sons:
+                  - kind: "nkStmtListExpr"
+                    sons:
+                      - kind: "nkBlockStmt"
+                        sons:
+                          - kind: "nkEmpty"
+                          - kind: "nkStmtList"
+                            sons:
+                              - kind: "nkCall"
+                                sons:
+                                  - kind: "nkDotExpr"
+                                    sons:
+                                      - kind: "nkIdent"
+                                        ident: "bbb"
+                                      - kind: "nkIdent"
+                                        ident: "postexpr"
+                                  - kind: "nkStmtList"
+                                    sons:
+                                      - kind: "nkIdent"
+                                        ident: "vvvv"
+                  - kind: "nkIdent"
+                    ident: "ytyyy"

--- a/tests/before/exprs.nim
+++ b/tests/before/exprs.nim
@@ -106,6 +106,9 @@ discard -1.. -2
 aaaaaaa.bbbbbbbbb.longdotcall().ccccccccc.dddddddddd.eeeeeeeee.sdcsd(a0000000, b000000, c000000).fffffff.ggggggg.hhhhhhhh.csdcsdcs.sdcsdcsd.csdcsdcsdcsd.csdcsdcs.dcsdcsdcsdcs.sdc
 
 mynums = myNums.replace1("one", "o1ne").replace2("two", "t2wo").replace3("three", "t3hree").replace5("four", "f4our").replace5("five", "f5ive").replace6("six", "s6ix").replace7("seven", "s7even")
+aaaaaaaaaaaaaaaaaaaaa.bbbbbbbbbbbbbbbbbbbbbb
+.ccccccccccccccccccccccccccc()
+.ccccccccccccccccccccccccc.ddddddddddddddddd() # multiline dotexpr
 
 let xxxxxxxxx = block:
   f()

--- a/tests/before/exprs.nim.nph.yaml
+++ b/tests/before/exprs.nim.nph.yaml
@@ -1806,6 +1806,30 @@ sons:
             strVal: "seven"
           - kind: "nkStrLit"
             strVal: "s7even"
+  - kind: "nkCall"
+    sons:
+      - kind: "nkDotExpr"
+        sons:
+          - kind: "nkDotExpr"
+            sons:
+              - kind: "nkCall"
+                sons:
+                  - kind: "nkDotExpr"
+                    sons:
+                      - kind: "nkDotExpr"
+                        sons:
+                          - kind: "nkIdent"
+                            ident: "aaaaaaaaaaaaaaaaaaaaa"
+                          - kind: "nkIdent"
+                            ident: "bbbbbbbbbbbbbbbbbbbbbb"
+                      - kind: "nkIdent"
+                        ident: "ccccccccccccccccccccccccccc"
+              - kind: "nkIdent"
+                ident: "ccccccccccccccccccccccccc"
+          - kind: "nkIdent"
+            ident: "ddddddddddddddddd"
+    postfix:
+      - "# no newline before previous dotexpr"
   - kind: "nkLetSection"
     sons:
       - kind: "nkIdentDefs"

--- a/tests/before/postexprs.nim
+++ b/tests/before/postexprs.nim
@@ -109,3 +109,6 @@ if (func1 do: x): true
 
 not (compiles do:
   discard)
+
+let aaa = (block: bbb.postexpr:
+      vvvv).ytyyy()

--- a/tests/before/postexprs.nim.nph.yaml
+++ b/tests/before/postexprs.nim.nph.yaml
@@ -667,3 +667,33 @@ sons:
               - kind: "nkDiscardStmt"
                 sons:
                   - kind: "nkEmpty"
+  - kind: "nkLetSection"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "aaa"
+          - kind: "nkEmpty"
+          - kind: "nkCall"
+            sons:
+              - kind: "nkDotExpr"
+                sons:
+                  - kind: "nkStmtListExpr"
+                    sons:
+                      - kind: "nkBlockStmt"
+                        sons:
+                          - kind: "nkEmpty"
+                          - kind: "nkCall"
+                            sons:
+                              - kind: "nkDotExpr"
+                                sons:
+                                  - kind: "nkIdent"
+                                    ident: "bbb"
+                                  - kind: "nkIdent"
+                                    ident: "postexpr"
+                              - kind: "nkStmtList"
+                                sons:
+                                  - kind: "nkIdent"
+                                    ident: "vvvv"
+                  - kind: "nkIdent"
+                    ident: "ytyyy"


### PR DESCRIPTION
When splitting a statement over multiple lines, a statement list will be inserted by the parser - at the same time, the presence of a statement list in a post-expression removes the `do` marker.

Thus, when formatting compound single-line statements, nph would insert `do` when formatting the first time, and then remove it when formatting the same code a second time since the formatted AST had an extra statement list.

To counter this effect and generate code without the extra `do` consistently, skip do if the _formatted_ output is expected to contain a statement list when parsed, instead of just looking at the pre-formatting AST. Messy.

Also fixes a case of bad line computation for dot expressions - the dot might be on a different line than the actual start of the expression.