### PR TITLE
Indent stacked dot calls

### DIFF
--- a/src/phrenderer.nim
+++ b/src/phrenderer.nim
@@ -1537,6 +1537,9 @@ proc gsub(g: var TOutput, n: PNode, flags: SubFlags, extra: int) =
 
       gsub(g, n[0], nameFlags)
 
+      # The way stacked calls work, the `.name` part will be indented when on a
+      # new line by the nkDotExpr handler - when that happens, we must also
+      # indent the list of parameters
       let ind = g.condIndent(stackDot, flagIndent(flags))
       glist(g, n, tkParLe, start = 1, flags = {lfLongSepAtEnd})
       g.dedent(ind)
@@ -1681,6 +1684,8 @@ proc gsub(g: var TOutput, n: PNode, flags: SubFlags, extra: int) =
         gmids(g, n)
       elif stackNL:
         optNL(g)
+
+      # Careful, this indent must be matched for the parameter list in nkCall!
       g.optIndent(wid)
       put(g, tkDot, ".")
       gsub(g, n[1], {sfNoIndent})

--- a/src/phrenderer.nim
+++ b/src/phrenderer.nim
@@ -1490,40 +1490,60 @@ proc gsub(g: var TOutput, n: PNode, flags: SubFlags, extra: int) =
   of nkNilLit:
     put(g, tkNil, atom(g, n)) # complex expressions
   of nkCall, nkConv, nkPattern, nkObjConstr:
-    if n.len > 1 and n.lastSon.kind in postExprBlocks:
-      let
-        doPars =
-          if n.lastSon.kind in {nkStmtList, nkDo} and sfParDo in flags:
-            # A expression that ends with a call with a `do` needs an extra set
-            # of parens to highlight where the `do` ends.
-            put(g, tkParLe, $tkParLe)
-            optNL(g)
-            true
-          else:
-            false
-        ind = condIndent(g, doPars)
+    if n.len >= 1:
+      let stackDot =
+        if n[0].kind == nkDotExpr:
+          let dot = n[0]
+          sfStackDot in flags or (
+            g.overflows(lsub(g, dot[0]) + lsub(g, dot[1]) + 1) and
+            isStackedCall(dot[0], true)
+          )
+        else:
+          false
 
-      gsub(g, n[0])
+      if n.len > 1 and n.lastSon.kind in postExprBlocks:
+        let
+          doPars =
+            if n.lastSon.kind in {nkStmtList, nkDo} and sfParDo in flags:
+              # A expression that ends with a call with a `do` needs an extra set
+              # of parens to highlight where the `do` ends.
+              put(g, tkParLe, $tkParLe)
+              optNL(g)
+              true
+            else:
+              false
+          ind = condIndent(g, doPars)
 
-      var i = 1
-      while i < n.len and n[i].kind notin postExprBlocks:
-        i.inc
+        gsub(g, n[0], flags * {sfNoIndent, sfLongIndent})
 
-      if i > 1:
-        glist(
-          g, n, tkParLe, start = 1, theEnd = i - 1 - n.len, flags = {lfLongSepAtEnd}
-        )
+        var i = 1
+        while i < n.len and n[i].kind notin postExprBlocks:
+          i.inc
 
-      postStatements(g, n, i, sfSkipDo in flags, skipMids = i > 1)
+        if i > 1:
+          glist(
+            g, n, tkParLe, start = 1, theEnd = i - 1 - n.len, flags = {lfLongSepAtEnd}
+          )
 
-      dedent(g, ind)
+        postStatements(g, n, i, sfSkipDo in flags, skipMids = i > 1)
 
-      if doPars:
-        optNL(g)
-        put(g, tkParRi, $tkParRi)
-    elif n.len >= 1:
-      gsub(g, n[0], flags = (flags * {sfStackDot}) + {sfStackDotInCall})
-      glist(g, n, tkParLe, start = 1, flags = {lfLongSepAtEnd})
+        dedent(g, ind)
+
+        if doPars:
+          optNL(g)
+          put(g, tkParRi, $tkParRi)
+      else:
+        let nameFlags =
+          (flags * {sfStackDot, sfNoIndent, sfLongIndent}) + {sfStackDotInCall}
+
+        gsub(g, n[0], nameFlags)
+
+        if n[0].kind == nkDotExpr:
+          let ind = g.condIndent(stackDot, flagIndent(flags))
+          glist(g, n, tkParLe, start = 1, flags = {lfLongSepAtEnd})
+          g.dedent(ind)
+        else:
+          glist(g, n, tkParLe, start = 1, flags = {lfLongSepAtEnd})
     else:
       put(g, tkParLe, "(")
       put(g, tkParRi, ")")
@@ -1647,12 +1667,13 @@ proc gsub(g: var TOutput, n: PNode, flags: SubFlags, extra: int) =
           )
         stackNL = stackDot and sfStackDotInCall in flags
         subFlags =
-          {sfParDo} + (
+          flags * {sfNoIndent, sfLongIndent} + {sfParDo} + (
             if stackDot:
               {sfStackDot}
             else:
               {}
           )
+        wid = flagIndent(flags)
 
       gsub(g, n[0], flags = subFlags)
 
@@ -1664,8 +1685,10 @@ proc gsub(g: var TOutput, n: PNode, flags: SubFlags, extra: int) =
         gmids(g, n)
       elif stackNL:
         optNL(g)
+      g.optIndent(wid)
       put(g, tkDot, ".")
-      gsub(g, n[1])
+      gsub(g, n[1], {sfNoIndent})
+      g.dedent(wid)
   of nkBind:
     putWithSpace(g, tkBind, "bind")
     gsub(g, n[0])

--- a/src/phrenderer.nim
+++ b/src/phrenderer.nim
@@ -1490,60 +1490,56 @@ proc gsub(g: var TOutput, n: PNode, flags: SubFlags, extra: int) =
   of nkNilLit:
     put(g, tkNil, atom(g, n)) # complex expressions
   of nkCall, nkConv, nkPattern, nkObjConstr:
-    if n.len >= 1:
-      let stackDot =
-        if n[0].kind == nkDotExpr:
-          let dot = n[0]
-          sfStackDot in flags or (
-            g.overflows(lsub(g, dot[0]) + lsub(g, dot[1]) + 1) and
-            isStackedCall(dot[0], true)
-          )
-        else:
-          false
+    if n.len > 1 and n.lastSon.kind in postExprBlocks:
+      let
+        doPars =
+          if n.lastSon.kind in {nkStmtList, nkDo} and sfParDo in flags:
+            # A expression that ends with a call with a `do` needs an extra set
+            # of parens to highlight where the `do` ends.
+            put(g, tkParLe, $tkParLe)
+            optNL(g)
+            true
+          else:
+            false
+        ind = condIndent(g, doPars)
 
-      if n.len > 1 and n.lastSon.kind in postExprBlocks:
-        let
-          doPars =
-            if n.lastSon.kind in {nkStmtList, nkDo} and sfParDo in flags:
-              # A expression that ends with a call with a `do` needs an extra set
-              # of parens to highlight where the `do` ends.
-              put(g, tkParLe, $tkParLe)
-              optNL(g)
-              true
-            else:
-              false
-          ind = condIndent(g, doPars)
+      gsub(g, n[0], flags * {sfNoIndent, sfLongIndent})
 
-        gsub(g, n[0], flags * {sfNoIndent, sfLongIndent})
+      var i = 1
+      while i < n.len and n[i].kind notin postExprBlocks:
+        i.inc
 
-        var i = 1
-        while i < n.len and n[i].kind notin postExprBlocks:
-          i.inc
+      if i > 1:
+        glist(
+          g, n, tkParLe, start = 1, theEnd = i - 1 - n.len, flags = {lfLongSepAtEnd}
+        )
 
-        if i > 1:
-          glist(
-            g, n, tkParLe, start = 1, theEnd = i - 1 - n.len, flags = {lfLongSepAtEnd}
-          )
+      postStatements(g, n, i, sfSkipDo in flags, skipMids = i > 1)
 
-        postStatements(g, n, i, sfSkipDo in flags, skipMids = i > 1)
+      dedent(g, ind)
 
-        dedent(g, ind)
-
-        if doPars:
-          optNL(g)
-          put(g, tkParRi, $tkParRi)
-      else:
-        let nameFlags =
+      if doPars:
+        optNL(g)
+        put(g, tkParRi, $tkParRi)
+    elif n.len >= 1:
+      let
+        nameFlags =
           (flags * {sfStackDot, sfNoIndent, sfLongIndent}) + {sfStackDotInCall}
+        stackDot =
+          if n[0].kind == nkDotExpr:
+            let dot = n[0]
+            sfStackDot in flags or (
+              g.overflows(lsub(g, dot[0]) + lsub(g, dot[1]) + 1) and
+              isStackedCall(dot[0], true)
+            )
+          else:
+            false
 
-        gsub(g, n[0], nameFlags)
+      gsub(g, n[0], nameFlags)
 
-        if n[0].kind == nkDotExpr:
-          let ind = g.condIndent(stackDot, flagIndent(flags))
-          glist(g, n, tkParLe, start = 1, flags = {lfLongSepAtEnd})
-          g.dedent(ind)
-        else:
-          glist(g, n, tkParLe, start = 1, flags = {lfLongSepAtEnd})
+      let ind = g.condIndent(stackDot, flagIndent(flags))
+      glist(g, n, tkParLe, start = 1, flags = {lfLongSepAtEnd})
+      g.dedent(ind)
     else:
       put(g, tkParLe, "(")
       put(g, tkParRi, ")")

--- a/tests/after/comments.nim
+++ b/tests/after/comments.nim
@@ -445,21 +445,21 @@ echo dotexpr.dot # after dotexpr in command
 
 dotexpr
 # between dotexpr and dotonnewline
-.dotonnewline
+  .dotonnewline
 
 if true:
   echo dotexpr.dot # after dotexpr in command ind
   # between two dotepxrs ind
   dotexpr
   # between dotexpr and dotonnewline ind
-  .dotonnewline
+    .dotonnewline
 
 block:
   f.x
   # comment between the dots
-  .z()
+    .z()
   # also after call
-  .d() # far eol of dotexpr
+    .d() # far eol of dotexpr
 
   # after dotexpr ind
 

--- a/tests/after/exprs.nim
+++ b/tests/after/exprs.nim
@@ -142,8 +142,8 @@ discard a .. -b
 discard -1 .. -2
 
 aaaaaaa.bbbbbbbbb
-.longdotcall().ccccccccc.dddddddddd.eeeeeeeee
-.sdcsd(a0000000, b000000, c000000).fffffff.ggggggg.hhhhhhhh.csdcsdcs.sdcsdcsd.csdcsdcsdcsd.csdcsdcs.dcsdcsdcsdcs.sdc
+  .longdotcall().ccccccccc.dddddddddd.eeeeeeeee
+  .sdcsd(a0000000, b000000, c000000).fffffff.ggggggg.hhhhhhhh.csdcsdcs.sdcsdcsd.csdcsdcsdcsd.csdcsdcs.dcsdcsdcsdcs.sdc
 
 mynums = myNums
   .replace1("one", "o1ne")
@@ -154,8 +154,8 @@ mynums = myNums
   .replace6("six", "s6ix")
   .replace7("seven", "s7even")
 aaaaaaaaaaaaaaaaaaaaa.bbbbbbbbbbbbbbbbbbbbbb
-.ccccccccccccccccccccccccccc().ccccccccccccccccccccccccc
-.ddddddddddddddddd() # no newline before previous dotexpr
+  .ccccccccccccccccccccccccccc().ccccccccccccccccccccccccc
+  .ddddddddddddddddd() # no newline before previous dotexpr
 
 let xxxxxxxxx = block:
   f()
@@ -244,3 +244,53 @@ let xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx =
 let xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx = """
 
 """
+
+csasacdsa
+  .casdcasdcsadc(
+    aaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbb, ccccccccccccccccccccccc
+  )
+  .cccccccccc(eeeeeeeeeeeeeeeeeeeeee, bbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccc)
+  .ddddddd()
+  .eeeeeeeee()
+
+if csasacdsa
+    .casdcasdcsadc(
+      aaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbb, ccccccccccccccccccccccc
+    )
+    .cccccccccc(eeeeeeeeeeeeeeeeeeeeee, bbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccc)
+    .ddddddd()
+    .eeeeeeeee():
+  discard
+
+if csasacdsa
+    .casdcasdcsadc(
+      aaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbb, ccccccccccccccccccccccc
+    )
+    .cccccccccc(eeeeeeeeeeeeeeeeeeeeee, bbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccc)
+    .ddddddd()
+    .eeeeeeeee() and
+    csasacdsa
+    .casdcasdcsadc(
+      aaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbb, ccccccccccccccccccccccc
+    )
+    .cccccccccc(eeeeeeeeeeeeeeeeeeeeee, bbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccc)
+    .ddddddd()
+    .eeeeeeeee():
+  discard
+
+let x = csasacdsa
+  .casdcasdcsadc(
+    aaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbb, ccccccccccccccccccccccc
+  )
+  .cccccccccc(eeeeeeeeeeeeeeeeeeeeee, bbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccc)
+  .ddddddd()
+  .eeeeeeeee()
+
+let x = csasacdsa
+  .casdcasdcsadc(
+    aaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbb, ccccccccccccccccccccccc
+  )
+  .cccccccccc(eeeeeeeeeeeeeeeeeeeeee, bbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccc)
+  .ddddddd()
+  .eeeeeeeee().valueOr:
+    discard

--- a/tests/after/exprs.nim.nph.yaml
+++ b/tests/after/exprs.nim.nph.yaml
@@ -2274,3 +2274,278 @@ sons:
           - kind: "nkEmpty"
           - kind: "nkTripleStrLit"
             strVal: "\u000A"
+  - kind: "nkCall"
+    sons:
+      - kind: "nkDotExpr"
+        sons:
+          - kind: "nkCall"
+            sons:
+              - kind: "nkDotExpr"
+                sons:
+                  - kind: "nkCall"
+                    sons:
+                      - kind: "nkDotExpr"
+                        sons:
+                          - kind: "nkCall"
+                            sons:
+                              - kind: "nkDotExpr"
+                                sons:
+                                  - kind: "nkIdent"
+                                    ident: "csasacdsa"
+                                  - kind: "nkIdent"
+                                    ident: "casdcasdcsadc"
+                              - kind: "nkIdent"
+                                ident: "aaaaaaaaaaaaaaaaaaaaaaaa"
+                              - kind: "nkIdent"
+                                ident: "bbbbbbbbbbbbbbbbbbbbbbbb"
+                              - kind: "nkIdent"
+                                ident: "ccccccccccccccccccccccc"
+                          - kind: "nkIdent"
+                            ident: "cccccccccc"
+                      - kind: "nkIdent"
+                        ident: "eeeeeeeeeeeeeeeeeeeeee"
+                      - kind: "nkIdent"
+                        ident: "bbbbbbbbbbbbbbbbbbbb"
+                      - kind: "nkIdent"
+                        ident: "cccccccccccccccccccc"
+                  - kind: "nkIdent"
+                    ident: "ddddddd"
+          - kind: "nkIdent"
+            ident: "eeeeeeeee"
+  - kind: "nkIfStmt"
+    sons:
+      - kind: "nkElifBranch"
+        sons:
+          - kind: "nkCall"
+            sons:
+              - kind: "nkDotExpr"
+                sons:
+                  - kind: "nkCall"
+                    sons:
+                      - kind: "nkDotExpr"
+                        sons:
+                          - kind: "nkCall"
+                            sons:
+                              - kind: "nkDotExpr"
+                                sons:
+                                  - kind: "nkCall"
+                                    sons:
+                                      - kind: "nkDotExpr"
+                                        sons:
+                                          - kind: "nkIdent"
+                                            ident: "csasacdsa"
+                                          - kind: "nkIdent"
+                                            ident: "casdcasdcsadc"
+                                      - kind: "nkIdent"
+                                        ident: "aaaaaaaaaaaaaaaaaaaaaaaa"
+                                      - kind: "nkIdent"
+                                        ident: "bbbbbbbbbbbbbbbbbbbbbbbb"
+                                      - kind: "nkIdent"
+                                        ident: "ccccccccccccccccccccccc"
+                                  - kind: "nkIdent"
+                                    ident: "cccccccccc"
+                              - kind: "nkIdent"
+                                ident: "eeeeeeeeeeeeeeeeeeeeee"
+                              - kind: "nkIdent"
+                                ident: "bbbbbbbbbbbbbbbbbbbb"
+                              - kind: "nkIdent"
+                                ident: "cccccccccccccccccccc"
+                          - kind: "nkIdent"
+                            ident: "ddddddd"
+                  - kind: "nkIdent"
+                    ident: "eeeeeeeee"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+  - kind: "nkIfStmt"
+    sons:
+      - kind: "nkElifBranch"
+        sons:
+          - kind: "nkInfix"
+            sons:
+              - kind: "nkIdent"
+                ident: "and"
+              - kind: "nkCall"
+                sons:
+                  - kind: "nkDotExpr"
+                    sons:
+                      - kind: "nkCall"
+                        sons:
+                          - kind: "nkDotExpr"
+                            sons:
+                              - kind: "nkCall"
+                                sons:
+                                  - kind: "nkDotExpr"
+                                    sons:
+                                      - kind: "nkCall"
+                                        sons:
+                                          - kind: "nkDotExpr"
+                                            sons:
+                                              - kind: "nkIdent"
+                                                ident: "csasacdsa"
+                                              - kind: "nkIdent"
+                                                ident: "casdcasdcsadc"
+                                          - kind: "nkIdent"
+                                            ident: "aaaaaaaaaaaaaaaaaaaaaaaa"
+                                          - kind: "nkIdent"
+                                            ident: "bbbbbbbbbbbbbbbbbbbbbbbb"
+                                          - kind: "nkIdent"
+                                            ident: "ccccccccccccccccccccccc"
+                                      - kind: "nkIdent"
+                                        ident: "cccccccccc"
+                                  - kind: "nkIdent"
+                                    ident: "eeeeeeeeeeeeeeeeeeeeee"
+                                  - kind: "nkIdent"
+                                    ident: "bbbbbbbbbbbbbbbbbbbb"
+                                  - kind: "nkIdent"
+                                    ident: "cccccccccccccccccccc"
+                              - kind: "nkIdent"
+                                ident: "ddddddd"
+                      - kind: "nkIdent"
+                        ident: "eeeeeeeee"
+              - kind: "nkCall"
+                sons:
+                  - kind: "nkDotExpr"
+                    sons:
+                      - kind: "nkCall"
+                        sons:
+                          - kind: "nkDotExpr"
+                            sons:
+                              - kind: "nkCall"
+                                sons:
+                                  - kind: "nkDotExpr"
+                                    sons:
+                                      - kind: "nkCall"
+                                        sons:
+                                          - kind: "nkDotExpr"
+                                            sons:
+                                              - kind: "nkIdent"
+                                                ident: "csasacdsa"
+                                              - kind: "nkIdent"
+                                                ident: "casdcasdcsadc"
+                                          - kind: "nkIdent"
+                                            ident: "aaaaaaaaaaaaaaaaaaaaaaaa"
+                                          - kind: "nkIdent"
+                                            ident: "bbbbbbbbbbbbbbbbbbbbbbbb"
+                                          - kind: "nkIdent"
+                                            ident: "ccccccccccccccccccccccc"
+                                      - kind: "nkIdent"
+                                        ident: "cccccccccc"
+                                  - kind: "nkIdent"
+                                    ident: "eeeeeeeeeeeeeeeeeeeeee"
+                                  - kind: "nkIdent"
+                                    ident: "bbbbbbbbbbbbbbbbbbbb"
+                                  - kind: "nkIdent"
+                                    ident: "cccccccccccccccccccc"
+                              - kind: "nkIdent"
+                                ident: "ddddddd"
+                      - kind: "nkIdent"
+                        ident: "eeeeeeeee"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+  - kind: "nkLetSection"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "x"
+          - kind: "nkEmpty"
+          - kind: "nkCall"
+            sons:
+              - kind: "nkDotExpr"
+                sons:
+                  - kind: "nkCall"
+                    sons:
+                      - kind: "nkDotExpr"
+                        sons:
+                          - kind: "nkCall"
+                            sons:
+                              - kind: "nkDotExpr"
+                                sons:
+                                  - kind: "nkCall"
+                                    sons:
+                                      - kind: "nkDotExpr"
+                                        sons:
+                                          - kind: "nkIdent"
+                                            ident: "csasacdsa"
+                                          - kind: "nkIdent"
+                                            ident: "casdcasdcsadc"
+                                      - kind: "nkIdent"
+                                        ident: "aaaaaaaaaaaaaaaaaaaaaaaa"
+                                      - kind: "nkIdent"
+                                        ident: "bbbbbbbbbbbbbbbbbbbbbbbb"
+                                      - kind: "nkIdent"
+                                        ident: "ccccccccccccccccccccccc"
+                                  - kind: "nkIdent"
+                                    ident: "cccccccccc"
+                              - kind: "nkIdent"
+                                ident: "eeeeeeeeeeeeeeeeeeeeee"
+                              - kind: "nkIdent"
+                                ident: "bbbbbbbbbbbbbbbbbbbb"
+                              - kind: "nkIdent"
+                                ident: "cccccccccccccccccccc"
+                          - kind: "nkIdent"
+                            ident: "ddddddd"
+                  - kind: "nkIdent"
+                    ident: "eeeeeeeee"
+  - kind: "nkLetSection"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "x"
+          - kind: "nkEmpty"
+          - kind: "nkCall"
+            sons:
+              - kind: "nkDotExpr"
+                sons:
+                  - kind: "nkCall"
+                    sons:
+                      - kind: "nkDotExpr"
+                        sons:
+                          - kind: "nkCall"
+                            sons:
+                              - kind: "nkDotExpr"
+                                sons:
+                                  - kind: "nkCall"
+                                    sons:
+                                      - kind: "nkDotExpr"
+                                        sons:
+                                          - kind: "nkCall"
+                                            sons:
+                                              - kind: "nkDotExpr"
+                                                sons:
+                                                  - kind: "nkIdent"
+                                                    ident: "csasacdsa"
+                                                  - kind: "nkIdent"
+                                                    ident: "casdcasdcsadc"
+                                              - kind: "nkIdent"
+                                                ident: "aaaaaaaaaaaaaaaaaaaaaaaa"
+                                              - kind: "nkIdent"
+                                                ident: "bbbbbbbbbbbbbbbbbbbbbbbb"
+                                              - kind: "nkIdent"
+                                                ident: "ccccccccccccccccccccccc"
+                                          - kind: "nkIdent"
+                                            ident: "cccccccccc"
+                                      - kind: "nkIdent"
+                                        ident: "eeeeeeeeeeeeeeeeeeeeee"
+                                      - kind: "nkIdent"
+                                        ident: "bbbbbbbbbbbbbbbbbbbb"
+                                      - kind: "nkIdent"
+                                        ident: "cccccccccccccccccccc"
+                                  - kind: "nkIdent"
+                                    ident: "ddddddd"
+                          - kind: "nkIdent"
+                            ident: "eeeeeeeee"
+                  - kind: "nkIdent"
+                    ident: "valueOr"
+              - kind: "nkStmtList"
+                sons:
+                  - kind: "nkDiscardStmt"
+                    sons:
+                      - kind: "nkEmpty"

--- a/tests/before/exprs.nim
+++ b/tests/before/exprs.nim
@@ -152,3 +152,37 @@ let xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx = """xxxxxxxxxxxxxxxxxxxxxxx
 let xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx = """
 
 """
+
+csasacdsa.casdcasdcsadc(
+  aaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbb, ccccccccccccccccccccccc
+).cccccccccc(eeeeeeeeeeeeeeeeeeeeee, bbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccc)
+.ddddddd().eeeeeeeee()
+
+if csasacdsa.casdcasdcsadc(
+  aaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbb, ccccccccccccccccccccccc
+).cccccccccc(eeeeeeeeeeeeeeeeeeeeee, bbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccc)
+.ddddddd().eeeeeeeee():
+  discard
+
+
+if csasacdsa.casdcasdcsadc(
+  aaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbb, ccccccccccccccccccccccc
+).cccccccccc(eeeeeeeeeeeeeeeeeeeeee, bbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccc)
+.ddddddd().eeeeeeeee() and csasacdsa.casdcasdcsadc(
+  aaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbb, ccccccccccccccccccccccc
+).cccccccccc(eeeeeeeeeeeeeeeeeeeeee, bbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccc)
+.ddddddd().eeeeeeeee():
+  discard
+
+
+let x = csasacdsa.casdcasdcsadc(
+  aaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbb, ccccccccccccccccccccccc
+)
+.cccccccccc(eeeeeeeeeeeeeeeeeeeeee, bbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccc)
+.ddddddd().eeeeeeeee()
+
+let x = csasacdsa.casdcasdcsadc(
+  aaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbb, ccccccccccccccccccccccc
+).cccccccccc(eeeeeeeeeeeeeeeeeeeeee, bbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccc)
+.ddddddd().eeeeeeeee().valueOr:
+  discard

--- a/tests/before/exprs.nim.nph.yaml
+++ b/tests/before/exprs.nim.nph.yaml
@@ -2274,3 +2274,278 @@ sons:
           - kind: "nkEmpty"
           - kind: "nkTripleStrLit"
             strVal: "\u000A"
+  - kind: "nkCall"
+    sons:
+      - kind: "nkDotExpr"
+        sons:
+          - kind: "nkCall"
+            sons:
+              - kind: "nkDotExpr"
+                sons:
+                  - kind: "nkCall"
+                    sons:
+                      - kind: "nkDotExpr"
+                        sons:
+                          - kind: "nkCall"
+                            sons:
+                              - kind: "nkDotExpr"
+                                sons:
+                                  - kind: "nkIdent"
+                                    ident: "csasacdsa"
+                                  - kind: "nkIdent"
+                                    ident: "casdcasdcsadc"
+                              - kind: "nkIdent"
+                                ident: "aaaaaaaaaaaaaaaaaaaaaaaa"
+                              - kind: "nkIdent"
+                                ident: "bbbbbbbbbbbbbbbbbbbbbbbb"
+                              - kind: "nkIdent"
+                                ident: "ccccccccccccccccccccccc"
+                          - kind: "nkIdent"
+                            ident: "cccccccccc"
+                      - kind: "nkIdent"
+                        ident: "eeeeeeeeeeeeeeeeeeeeee"
+                      - kind: "nkIdent"
+                        ident: "bbbbbbbbbbbbbbbbbbbb"
+                      - kind: "nkIdent"
+                        ident: "cccccccccccccccccccc"
+                  - kind: "nkIdent"
+                    ident: "ddddddd"
+          - kind: "nkIdent"
+            ident: "eeeeeeeee"
+  - kind: "nkIfStmt"
+    sons:
+      - kind: "nkElifBranch"
+        sons:
+          - kind: "nkCall"
+            sons:
+              - kind: "nkDotExpr"
+                sons:
+                  - kind: "nkCall"
+                    sons:
+                      - kind: "nkDotExpr"
+                        sons:
+                          - kind: "nkCall"
+                            sons:
+                              - kind: "nkDotExpr"
+                                sons:
+                                  - kind: "nkCall"
+                                    sons:
+                                      - kind: "nkDotExpr"
+                                        sons:
+                                          - kind: "nkIdent"
+                                            ident: "csasacdsa"
+                                          - kind: "nkIdent"
+                                            ident: "casdcasdcsadc"
+                                      - kind: "nkIdent"
+                                        ident: "aaaaaaaaaaaaaaaaaaaaaaaa"
+                                      - kind: "nkIdent"
+                                        ident: "bbbbbbbbbbbbbbbbbbbbbbbb"
+                                      - kind: "nkIdent"
+                                        ident: "ccccccccccccccccccccccc"
+                                  - kind: "nkIdent"
+                                    ident: "cccccccccc"
+                              - kind: "nkIdent"
+                                ident: "eeeeeeeeeeeeeeeeeeeeee"
+                              - kind: "nkIdent"
+                                ident: "bbbbbbbbbbbbbbbbbbbb"
+                              - kind: "nkIdent"
+                                ident: "cccccccccccccccccccc"
+                          - kind: "nkIdent"
+                            ident: "ddddddd"
+                  - kind: "nkIdent"
+                    ident: "eeeeeeeee"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+  - kind: "nkIfStmt"
+    sons:
+      - kind: "nkElifBranch"
+        sons:
+          - kind: "nkInfix"
+            sons:
+              - kind: "nkIdent"
+                ident: "and"
+              - kind: "nkCall"
+                sons:
+                  - kind: "nkDotExpr"
+                    sons:
+                      - kind: "nkCall"
+                        sons:
+                          - kind: "nkDotExpr"
+                            sons:
+                              - kind: "nkCall"
+                                sons:
+                                  - kind: "nkDotExpr"
+                                    sons:
+                                      - kind: "nkCall"
+                                        sons:
+                                          - kind: "nkDotExpr"
+                                            sons:
+                                              - kind: "nkIdent"
+                                                ident: "csasacdsa"
+                                              - kind: "nkIdent"
+                                                ident: "casdcasdcsadc"
+                                          - kind: "nkIdent"
+                                            ident: "aaaaaaaaaaaaaaaaaaaaaaaa"
+                                          - kind: "nkIdent"
+                                            ident: "bbbbbbbbbbbbbbbbbbbbbbbb"
+                                          - kind: "nkIdent"
+                                            ident: "ccccccccccccccccccccccc"
+                                      - kind: "nkIdent"
+                                        ident: "cccccccccc"
+                                  - kind: "nkIdent"
+                                    ident: "eeeeeeeeeeeeeeeeeeeeee"
+                                  - kind: "nkIdent"
+                                    ident: "bbbbbbbbbbbbbbbbbbbb"
+                                  - kind: "nkIdent"
+                                    ident: "cccccccccccccccccccc"
+                              - kind: "nkIdent"
+                                ident: "ddddddd"
+                      - kind: "nkIdent"
+                        ident: "eeeeeeeee"
+              - kind: "nkCall"
+                sons:
+                  - kind: "nkDotExpr"
+                    sons:
+                      - kind: "nkCall"
+                        sons:
+                          - kind: "nkDotExpr"
+                            sons:
+                              - kind: "nkCall"
+                                sons:
+                                  - kind: "nkDotExpr"
+                                    sons:
+                                      - kind: "nkCall"
+                                        sons:
+                                          - kind: "nkDotExpr"
+                                            sons:
+                                              - kind: "nkIdent"
+                                                ident: "csasacdsa"
+                                              - kind: "nkIdent"
+                                                ident: "casdcasdcsadc"
+                                          - kind: "nkIdent"
+                                            ident: "aaaaaaaaaaaaaaaaaaaaaaaa"
+                                          - kind: "nkIdent"
+                                            ident: "bbbbbbbbbbbbbbbbbbbbbbbb"
+                                          - kind: "nkIdent"
+                                            ident: "ccccccccccccccccccccccc"
+                                      - kind: "nkIdent"
+                                        ident: "cccccccccc"
+                                  - kind: "nkIdent"
+                                    ident: "eeeeeeeeeeeeeeeeeeeeee"
+                                  - kind: "nkIdent"
+                                    ident: "bbbbbbbbbbbbbbbbbbbb"
+                                  - kind: "nkIdent"
+                                    ident: "cccccccccccccccccccc"
+                              - kind: "nkIdent"
+                                ident: "ddddddd"
+                      - kind: "nkIdent"
+                        ident: "eeeeeeeee"
+          - kind: "nkStmtList"
+            sons:
+              - kind: "nkDiscardStmt"
+                sons:
+                  - kind: "nkEmpty"
+  - kind: "nkLetSection"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "x"
+          - kind: "nkEmpty"
+          - kind: "nkCall"
+            sons:
+              - kind: "nkDotExpr"
+                sons:
+                  - kind: "nkCall"
+                    sons:
+                      - kind: "nkDotExpr"
+                        sons:
+                          - kind: "nkCall"
+                            sons:
+                              - kind: "nkDotExpr"
+                                sons:
+                                  - kind: "nkCall"
+                                    sons:
+                                      - kind: "nkDotExpr"
+                                        sons:
+                                          - kind: "nkIdent"
+                                            ident: "csasacdsa"
+                                          - kind: "nkIdent"
+                                            ident: "casdcasdcsadc"
+                                      - kind: "nkIdent"
+                                        ident: "aaaaaaaaaaaaaaaaaaaaaaaa"
+                                      - kind: "nkIdent"
+                                        ident: "bbbbbbbbbbbbbbbbbbbbbbbb"
+                                      - kind: "nkIdent"
+                                        ident: "ccccccccccccccccccccccc"
+                                  - kind: "nkIdent"
+                                    ident: "cccccccccc"
+                              - kind: "nkIdent"
+                                ident: "eeeeeeeeeeeeeeeeeeeeee"
+                              - kind: "nkIdent"
+                                ident: "bbbbbbbbbbbbbbbbbbbb"
+                              - kind: "nkIdent"
+                                ident: "cccccccccccccccccccc"
+                          - kind: "nkIdent"
+                            ident: "ddddddd"
+                  - kind: "nkIdent"
+                    ident: "eeeeeeeee"
+  - kind: "nkLetSection"
+    sons:
+      - kind: "nkIdentDefs"
+        sons:
+          - kind: "nkIdent"
+            ident: "x"
+          - kind: "nkEmpty"
+          - kind: "nkCall"
+            sons:
+              - kind: "nkDotExpr"
+                sons:
+                  - kind: "nkCall"
+                    sons:
+                      - kind: "nkDotExpr"
+                        sons:
+                          - kind: "nkCall"
+                            sons:
+                              - kind: "nkDotExpr"
+                                sons:
+                                  - kind: "nkCall"
+                                    sons:
+                                      - kind: "nkDotExpr"
+                                        sons:
+                                          - kind: "nkCall"
+                                            sons:
+                                              - kind: "nkDotExpr"
+                                                sons:
+                                                  - kind: "nkIdent"
+                                                    ident: "csasacdsa"
+                                                  - kind: "nkIdent"
+                                                    ident: "casdcasdcsadc"
+                                              - kind: "nkIdent"
+                                                ident: "aaaaaaaaaaaaaaaaaaaaaaaa"
+                                              - kind: "nkIdent"
+                                                ident: "bbbbbbbbbbbbbbbbbbbbbbbb"
+                                              - kind: "nkIdent"
+                                                ident: "ccccccccccccccccccccccc"
+                                          - kind: "nkIdent"
+                                            ident: "cccccccccc"
+                                      - kind: "nkIdent"
+                                        ident: "eeeeeeeeeeeeeeeeeeeeee"
+                                      - kind: "nkIdent"
+                                        ident: "bbbbbbbbbbbbbbbbbbbb"
+                                      - kind: "nkIdent"
+                                        ident: "cccccccccccccccccccc"
+                                  - kind: "nkIdent"
+                                    ident: "ddddddd"
+                          - kind: "nkIdent"
+                            ident: "eeeeeeeee"
+                  - kind: "nkIdent"
+                    ident: "valueOr"
+              - kind: "nkStmtList"
+                sons:
+                  - kind: "nkDiscardStmt"
+                    sons:
+                      - kind: "nkEmpty"


### PR DESCRIPTION
https://github.com/arnetheduck/nph/pull/32 introduced call chaining, but when called outside of a `let`, the lack of indent makes it hard to tell where the dot expression ends and where the next expression starts

To make the expression boundaries more visible, apply an indent to the dotted calls, like so:

```nim
# old
aaaa
.f()
.g()

# new
aaaa
  .f()
  .g()
```