### PR TITLE
fix: exclude patterns ignored when scanning directories 

### DIFF
--- a/src/nph.nim
+++ b/src/nph.nim
@@ -303,6 +303,7 @@ proc main() =
     outfile, outdir, configFile: string
     infiles = newSeq[string]()
     explicitFiles = newSeq[string]() # Files passed explicitly, not from dir walk
+    explicitDirs = newSeq[string]() # Directories passed explicitly on the command line
     outfiles = newSeq[string]()
     debug = false
     check = false
@@ -324,9 +325,7 @@ proc main() =
     of cmdArgument:
       if dirExists(key):
         usesDir = true
-        for file in walkDirRec(key):
-          if file.isNimFile:
-            infiles &= file
+        explicitDirs.add(key)
       else:
         let f = key.addFileExt(".nim")
         infiles.add(f)
@@ -421,14 +420,24 @@ proc main() =
     includePatterns: compilePatterns(finalIncludePatterns),
   )
 
-  # Filter input files based on include/exclude patterns
-  # BUT: explicitly passed files bypass filtering (like Black)
+  # Filter explicit files — they bypass exclusions (like Black)
   var filteredFiles = newSeq[string]()
   for file in infiles:
     if file in explicitFiles or matchesFilters(file, compiledPatterns):
       filteredFiles.add(file)
-
   infiles = filteredFiles
+
+  # Walk explicitly passed directories, applying exclusions to relative paths
+  # so that subdirs like "nimbledeps" are excluded but the dir itself is not.
+  for dir in explicitDirs:
+    for file in walkDirRec(dir):
+      if not file.isNimFile:
+        continue
+      let n = normalizePath(file)
+      let relPath = relativePath(n, normalizePath(dir))
+      if not shouldExclude(relPath, compiledPatterns.excludePatterns) and
+          shouldInclude(relPath, compiledPatterns.includePatterns):
+        infiles.add(file)
 
   if infiles.len == 0:
     quit "[Error] no input file.", 3

--- a/src/nph.nim
+++ b/src/nph.nim
@@ -327,7 +327,6 @@ proc main() =
         for file in walkDirRec(key):
           if file.isNimFile:
             infiles &= file
-            explicitFiles.add(file) # Track files from explicit directories
       else:
         let f = key.addFileExt(".nim")
         infiles.add(f)

--- a/src/nph.nim
+++ b/src/nph.nim
@@ -435,8 +435,7 @@ proc main() =
         continue
       let n = normalizePath(file)
       let relPath = relativePath(n, normalizePath(dir))
-      if not shouldExclude(relPath, compiledPatterns.excludePatterns) and
-          shouldInclude(relPath, compiledPatterns.includePatterns):
+      if matchesFilters(relPath, compiledPatterns):
         infiles.add(file)
 
   if infiles.len == 0:


### PR DESCRIPTION
When passing a directory to nph, files found by walkDirRec were added to explicitFiles, causing exclude patterns to be bypassed entirely. Files in nimbledeps/ (and other default exclusions) were formatted when they shouldn't .

The fix defers directory walking to after patterns are compiled, applying exclusions to paths relative to the passed directory.
                                                                      
To reproduce:                                                                                                            

```sh   
mkdir -p /tmp/test_nph_exclude/nimbledeps                                                                                
echo 'let x=1' > /tmp/test_nph_exclude/main.nim                                                                        
echo 'let x=1' > /tmp/test_nph_exclude/nimbledeps/foo.nim
```

`nph --check /tmp/test_nph_exclude` products: 

```
arnaud@fedora:/tmp/test_nph_exclude$ /home/arnaud/Work/logos/nph/nph --check .  
would reformat ./main.nim
would reformat ./nimbledeps/foo.nim

Oh no! 💥 💔 💥
2 files would be reformatted.
```

After the fix: 

```
arnaud@fedora:/tmp/test_nph_exclude$ /home/arnaud/Work/logos/nph/nph --check .  
would reformat ./main.nim

Oh no! 💥 💔 💥
1 file would be reformatted.
```